### PR TITLE
Add component guide to app

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,20 @@ module ContentDataAdmin
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    # The "Slimmer" gem is loaded by the publishing components and will automatically
+    # attempt to intercept requests and provide a layout. We don't use that
+    # functionality here, so we have to tell slimmer to not do it.
+    config.middleware.delete Slimmer::App
+
+    # The "acceptance environment" we're in - not the same as Rails env.
+    # Can be production, staging, integration, or development
+    govuk_environments = {
+      "production" => "production",
+      "staging" => "staging",
+      "integration-blue-aws" => "integration",
+    }
+
+    config.govuk_environment = govuk_environments.fetch(ENV["ERRBIT_ENVIRONMENT_NAME"], "development")
   end
 end

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,7 @@
+# config/initializers/govuk_publishing_components.rb
+GovukPublishingComponents.configure do |c|
+  c.component_guide_title = "Content Data"
+  c.application_print_stylesheet = nil
+   c.application_stylesheet = "govuk_publishing_components/admin_styles"
+  c.application_javascript = nil
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   get "/healthcheck", to: proc { [200, {}, ["OK"]] }
+
+  mount GovukPublishingComponents::Engine, at: "/component-guide"
 end


### PR DESCRIPTION
This allows us to see the app's own components (when built) and those from the shared gem at /component-guide