### PR TITLE
Remove logstasher from production.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,8 +1,5 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new(Rails.root.join('log', 'production.json.log'))
-  # config.logstasher.suppress_app_log = true
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
We are having issues deploying the application in integration. They seem
to be related to permissions issues when logging

```
rake aborted!
Errno::EACCES: Permission denied @ rb_sysopen - /data/vhost/content-data-admin/releases/20180814135728/log/production.json.log
/data/vhost/content-data-admin/releases/20180814135728/config/environments/production.rb:4:in `new'
/data/vhost/content-data-admin/releases/20180814135728/config/environments/production.rb:4:in `block in <main>'
/data/vhost/content-data-admin/shared/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/railtie.rb:216:in `instance_eval'
/data/vhost/content-data-admin/shared/bundle/ruby/2.5.0/gems/railties-5.2.0/lib/rails/railtie.rb:216:in `configure'
/data/vhost/content-data-admin/releases/20180814135728/config/environments/production.rb:1:in `<main>'
/data/vhost/content-data-admin/shared/bundle/ruby/2.5.0/gems/bootsnap-1.3.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `require'
/data/vhost/content-data-admin/shared/bundle/ruby/2.5.0/gems/bootsnap-1.3.1/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:21:in `block in require_with_bootsnap_lfi'
/data/vhost/content-data-admin/shared/bundle/ruby/2.5.0/gems/bootsnap-1.3.1/lib/bootsnap/load_path_cache/loaded_features_index.rb:65:in `register'
```