### PR TITLE
Remove temporary spec

### DIFF
--- a/spec/temp_spec.rb
+++ b/spec/temp_spec.rb
@@ -1,5 +1,0 @@
-RSpec.describe 'the app' do
-  it 'should pass' do
-    expect(1).to eq(1)
-  end
-end


### PR DESCRIPTION
Temp spec was added to ensure that the application was working as
expected. This change will remove the spec as it is no longer needed.