### PR TITLE
Set rubyLintDiff to false

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,7 @@ library("govuk")
 
 node("postgresql-9.3") {
   govuk.buildProject(
+    rubyLintDiff: false,
     beforeTest: {
       govuk.setEnvar("TEST_COVERAGE", "true")
     }


### PR DESCRIPTION
To ensure all of the code is linted all the time.