### PR TITLE
Add info-metric component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,3 +6,4 @@ $govuk-global-styles: true;
 // local components
 @import "components/chart";
 @import "components/glance-metric";
+@import "components/info-metric";

--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -1,0 +1,38 @@
+@import "../../../node_modules/govuk-frontend/helpers/colour";
+@import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
+
+.app-c-info-metric__heading {
+  @include govuk-responsive-margin(1, "bottom");
+}
+
+.app-c-info-metric__trend {
+  @include govuk-responsive-margin(2, "left");
+}
+
+.app-c-info-metric__trend-text {
+  @include govuk-visually-hidden;
+}
+
+.app-c-info-metric__trend-icon {
+  color: $grey-1;
+}
+
+.app-c-info-metric__period {
+  @include govuk-responsive-margin(2, "left");
+}
+
+.app-c-info-metric__about {
+  @include govuk-responsive-margin(2, "top");
+}
+
+.app-c-info-metric__about {
+
+  .govuk-details__summary-text {
+    @include govuk-font(16);
+  }
+
+  .govuk-details__text {
+    @include govuk-font(16);
+  }
+
+}

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -1,0 +1,49 @@
+<%
+  name ||= false
+  figure ||= false
+  period ||= false
+  about ||= false
+  trend_percentage ||= false
+  context ||= false
+
+%>
+<% if name && figure && context %>
+  <div class="app-c-info-metric govuk-body">
+    <h3 class="app-c-info-metric__heading"><%= name %></h3>
+    <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
+    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
+    <% if trend_percentage %>
+      <span class="app-c-info-metric__trend">
+        <% if trend_percentage > 0 %>+<% end %><%= trend_percentage %>%
+      </span>
+      <% if trend_percentage.to_f > 0 %>
+        <span class="app-c-info-metric__trend--up">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9650;</span>
+          <span class="app-c-info-metric__trend-text">Upward trend</span>
+        <span>
+      <% elsif trend_percentage.to_f < 0 %>
+        <span class="app-c-info-metric__trend--down">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9660;</span>
+          <span class="app-c-info-metric__trend-text">Downward trend</span>
+        <span>
+      <% else %>
+        <span class="app-c-info-metric__trend--no-change">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9679;</span>
+          <span class="app-c-info-metric__trend-text">No change</span>
+        <span>
+      <% end %>
+    <% end %>
+    <% if period %>
+      <span class="app-c-info-metric__period"><%= period %></span>
+    <% end %>
+    <% if about %>
+      <div class="app-c-info-metric__about govuk-body-s">
+        <%= render "govuk_publishing_components/components/details", {
+          title: "About this data"
+        } do %>
+          <%= about %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/components/docs/info-metric.yml
+++ b/app/views/components/docs/info-metric.yml
@@ -1,0 +1,35 @@
+name: "Info metric"
+description: "The glance metric component is a view of a single or aggregated metric for a content item. The minimum requirements for it to display are a name and figure but it also supports trend direction and explanatory text to describe the metric. "
+part_of_admin_layout: true
+body: |
+
+accessibility_criteria: |
+  - Icons used in the component must have text equivalents
+
+shared_accessibility_criteria:
+  - link
+
+examples:
+  default:
+    data:
+      name: "Unique pageviews"
+      figure: "167"
+      measurement_display_label: "m"
+      measurement_explicit_label: "million"
+      context: "This is in your top 10 items"
+      trend_percentage: 0.5
+      period: "Apr 2018 to Mar 2018"
+  no measurement labels:
+    data:
+      name: "Feedback comments"
+      figure: "35"
+      trend_percentage: 0.5
+      period: "Apr 2018 to Mar 2018"
+  with a link:
+    data:
+      name: "Feedback comments"
+      figure: "35"
+      trend_percentage: 0.5
+      period: "Apr 2018 to Mar 2018"
+      link_text: "See comments in Feedex"
+      link_url: "http://www.feedex.com"

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -94,6 +94,55 @@
   </div>
 </div>
 
+
+<h2>Info metric examples</h2>
+
+<% about_text = capture do %>
+  <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vestibulum quam vitae felis venenatis, at hendrerit ante accumsan. Cras commodo, leo ac auctor vehicula, elit dolor pulvinar sapien, ut congue arcu sapien sit amet nibh. Donec eu est nec nisi gravida gravida ut eget libero. In hac habitasse platea dictumst.</p>
+  <p>Aliquam sed arcu et purus porttitor consequat sed malesuada arcu. Phasellus tellus justo, finibus ac porttitor sed, pulvinar et sapiensi.</p>
+  <p>Data source: Google Analytics</p>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "components/info-metric", {
+      name: "Unique pageviews",
+      figure: number_with_delimiter(4354343, :delimiter => ','),
+      context: "Number of sessions during which the page was viewed at least once",
+      trend_percentage: 0,
+      period: "From previous 30 days",
+      about: about_text
+    } %>
+  </div>
+</div>
+
+<% words_about = capture do %>
+  <p>Content may be hard to read if it has a lot of words, consider whether it should be broken down or simplified.</p>
+<% end %>
+<% pdf_about = capture do %>
+  <p>Many PDF files are not accessible. Could the content be presented on a web page instead of in a downloadable format?</p>
+
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= render "components/info-metric", {
+      name: "Number of PDFs",
+      figure: "2",
+      context: "How many PDFs are attached to the page",
+      about: pdf_about
+    } %>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <%= render "components/info-metric", {
+      name: "Word count",
+      figure: "2,214",
+      context: "Number of words on the page",
+      about: words_about
+    } %>
+  </div>
+</div>
+
 <h2>Chart examples</h2>
 
 

--- a/spec/components/info_metric_spec.rb
+++ b/spec/components/info_metric_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe "Info Metric", type: :view do
+  let(:data) {
+    {
+      name: "Unique pageviews",
+      figure: "167,345",
+      context: "This is in your top 10 items",
+      trend_percentage: 0.5,
+      period: "Apr 2018 to Mar 2018",
+      about: "<p>This metric was extrapolated from measurement data.</p>"
+    }
+  }
+
+  it "does not render when no data is given" do
+    assert_empty render_component({})
+  end
+
+  it "does not render if name is not supplied" do
+    data[:name] = false
+    assert_empty render_component(data)
+  end
+
+  it "does not render if figure is not supplied" do
+    data[:figure] = false
+    assert_empty render_component(data)
+  end
+
+
+  it "renders correctly when given valid data" do
+    render_component(data)
+    assert_select ".app-c-info-metric"
+    assert_select ".app-c-info-metric__heading", text: "Unique pageviews"
+    assert_select ".app-c-info-metric__figure", text: "167,345"
+    assert_select ".app-c-info-metric__context", text: "This is in your top 10 items"
+    assert_select ".app-c-info-metric__trend", text: "+0.5%"
+    assert_select ".app-c-info-metric__period", text: "Apr 2018 to Mar 2018"
+    assert_select ".gem-c-details", 1
+    assert_select ".app-c-info-metric__about .govuk-details__text", text: "<p>This metric was extrapolated from measurement data.</p>"
+  end
+
+  it "displays the correct trend direction when trend is supplied" do
+    render_component(data)
+    assert_select ".app-c-info-metric__trend--up .app-c-info-metric__trend-text", text: "Upward trend"
+    data[:trend_percentage] = -2
+    render_component(data)
+    assert_select ".app-c-info-metric__trend--down .app-c-info-metric__trend-text", text: "Downward trend"
+    data[:trend_percentage] = 0
+    render_component(data)
+    assert_select ".app-c-info-metric__trend--no-change .app-c-info-metric__trend-text", text: "No change"
+  end
+
+  it "does not render the detail link when no about data is supplied" do
+    data[:about] = false
+    render_component(data)
+    assert_select ".gem-c-details", 0
+  end
+
+  def render_component(locals)
+    render partial: "components/info-metric", locals: locals
+  end
+end


### PR DESCRIPTION
This component displays a metric alongside supporting information
with optional trend info and about text

![screen shot 2018-08-23 at 13 53 03](https://user-images.githubusercontent.com/31649453/44526434-eaac2900-a6db-11e8-86f3-328dd22b0703.png)

https://trello.com/c/2ZuLZwCO/609-3-build-info-metric-component