### PR TITLE
Multi chart endpoint

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -7,13 +7,14 @@ class MetricsController < ApplicationController
       base_path: params[:base_path],
       from: params[:from],
       to: params[:to],
-      metric: params[:metric]
-    ).to_hash
+      metrics: params[:metrics]
+    )
+
     @timeseries = service.fetch_timeseries(
       base_path: params[:base_path],
       from: params[:from],
       to: params[:to],
-      metric: params[:metric]
-    ).to_hash
+      metrics: params[:metrics]
+    )
   end
 end

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -1,5 +1,5 @@
 module ChartsHelper
-  def series_chart
-    ChartPresenter.new(@timeseries)
+  def series_chart(metric)
+    ChartPresenter.new(json: @timeseries, metric: metric)
   end
 end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -1,12 +1,9 @@
 class ChartPresenter
-  attr_reader :json
+  attr_reader :json, :metric
 
-  def initialize(json)
-    @json = json.with_indifferent_access
-  end
-
-  def metric
-    json.keys.first
+  def initialize(json:, metric:)
+    @metric = metric
+    @json = json.to_h.with_indifferent_access
   end
 
   def from

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,34 +1,19 @@
-require 'gds_api/base'
-class MetricsService
-  attr_reader :base_path, :from, :to, :metric
+require 'gds_api/content_data_api'
 
-  def fetch(base_path:, from:, to:, metric:)
-    url = request_url(base_path, from, to, metric)
-    client.get_json(url)
+class MetricsService
+  def fetch(base_path:, from:, to:, metrics:)
+    url = api.request_url(base_path: base_path, from: from, to: to, metrics: metrics)
+    api.client.get_json(url).to_hash
   end
 
-  def fetch_timeseries(base_path:, from:, to:, metric:)
-    url = time_series_request_url(base_path, from, to, metric)
-    client.get_json(url).to_hash
+  def fetch_timeseries(base_path:, from:, to:, metrics:)
+    url = api.time_series_request_url(base_path: base_path, from: from, to: to, metrics: metrics)
+    api.client.get_json(url).to_hash
   end
 
 private
 
-  def request_url(base_path, from, to, metric)
-    "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}?from=#{from}&to=#{to}"
-  end
-
-  def time_series_request_url(base_path, from, to, metric)
-    "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}/time-series?from=#{from}&to=#{to}"
-  end
-
-  def content_data_api_endpoint
-    "#{Plek.current.find('content-performance-manager')}/api/v1"
-  end
-
-  def client
-    @client ||= GdsApi::Base.new(content_data_api_endpoint,
-                                 disable_cache: true,
-                                 bearer_token: ENV['CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN'] || 'example').client
+  def api
+    @api ||= GdsApi::ContentDataApi.new
   end
 end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,4 +1,9 @@
 <% content_for :title, "Metrics for #{@base_path}" %>
+
 Metrics for <%= @base_path %>
+
 Unique Pageviews: <%= @metrics['unique_pageviews']['total'] %>
-<%= render "components/chart", series_chart.chart_data %>
+<%= render "components/chart", series_chart('unique_pageviews').chart_data %>
+
+Pageviews: <%= @metrics['pageviews']['total'] %>
+<%= render "components/chart", series_chart('pageviews').chart_data %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,6 @@ Rails.application.routes.draw do
   }
   get '/dev' => 'development#index'
 
-  get '/metrics/:metric/*base_path', to: 'metrics#show'
+  get '/metrics/*base_path', to: 'metrics#show'
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -1,0 +1,30 @@
+require 'gds_api/base'
+
+class GdsApi::ContentDataApi < GdsApi::Base
+  def initialize
+    super("#{Plek.current.find('content-performance-manager')}/api/v1",
+        disable_cache: true,
+        bearer_token: ENV['CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN'] || 'example')
+  end
+
+  def request_url(base_path:, from:, to:, metrics:)
+    "#{content_data_api_endpoint}/metrics/#{base_path}#{query(from: from, to: to, metrics: metrics)}"
+  end
+
+  def time_series_request_url(base_path:, from:, to:, metrics:)
+    "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query(from: from, to: to, metrics: metrics)}"
+  end
+
+  def content_data_api_endpoint
+    "#{Plek.current.find('content-performance-manager')}/api/v1"
+  end
+
+  def query(from:, to:, metrics:)
+    query_params = {}
+    query_params[:from] = from
+    query_params[:to] = to
+    query_params[:metrics] = metrics
+
+    query_string(query_params)
+  end
+end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -5,21 +5,33 @@ RSpec.describe '/metrics/base/path', type: :feature do
   end
 
   before do
-    content_data_api_has_metric('base/path',
-                           'unique_pageviews',
-                           '2000-01-01',
-                           '2050-01-01',
-                           unique_pageviews: { total: 145_000 })
-    content_data_api_has_timeseries('base/path',
-                               'unique_pageviews',
-                               '2000-01-01',
-                               '2050-01-01',
-                               unique_pageviews: [
-                                 { date: '2018-01-13', value: 101 },
-                                 { date: '2018-01-14', value: 202 },
-                                 { date: '2018-01-15', value: 303 }
-                               ])
-    visit '/metrics/unique_pageviews/base/path?from=2000-01-01&to=2050-01-01'
+    content_data_api_has_metric(base_path: 'base/path',
+                           from: '2000-01-01',
+                           to: '2050-01-01',
+                           metrics: %w[unique_pageviews page_views],
+                           payload: {
+                               unique_pageviews: { total: 145_000 },
+                               pageviews: { total: 200_000 }
+                           })
+
+    content_data_api_has_timeseries(base_path: 'base/path',
+                               from: '2000-01-01',
+                               to: '2050-01-01',
+                               metrics: %w[unique_pageviews page_views],
+                               payload: {
+                                 unique_pageviews: [
+                                   { "date" => "2018-01-13", "value" => 101 },
+                                   { "date" => "2018-01-14", "value" => 202 },
+                                   { "date" => "2018-01-15", "value" => 303 }
+                                 ],
+                                 pageviews: [
+                                     { "date" => "2018-01-13", "value" => 10 },
+                                     { "date" => "2018-01-14", "value" => 20 },
+                                     { "date" => "2018-01-15", "value" => 30 }
+                                 ]
+                               })
+
+    visit '/metrics/base/path?from=2000-01-01&to=2050-01-01&metrics[]=unique_pageviews&metrics[]=page_views'
   end
 
   it 'renders the metric for unique_pageviews' do
@@ -29,11 +41,19 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
   it 'renders the metric timeseries for unique_pageviews' do
     click_on 'Unique pageviews table'
-    rows = all('table tr')
-    expect(rows.count).to eq 4
-    expect(rows[0].text).to eq 'Date'
-    expect(rows[1].text).to eq '01-13 101'
-    expect(rows[2].text).to eq '01-14 202'
-    expect(rows[3].text).to eq '01-15 303'
+    unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr')
+    pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
+
+    expect(unique_pageviews_rows.count).to eq 4
+    expect(unique_pageviews_rows[0].text).to eq 'Date'
+    expect(unique_pageviews_rows[1].text).to eq '01-13 101'
+    expect(unique_pageviews_rows[2].text).to eq '01-14 202'
+    expect(unique_pageviews_rows[3].text).to eq '01-15 303'
+
+    expect(pageviews_rows.count).to eq 4
+    expect(pageviews_rows[0].text).to eq 'Date'
+    expect(pageviews_rows[1].text).to eq '01-13 10'
+    expect(pageviews_rows[2].text).to eq '01-14 20'
+    expect(pageviews_rows[3].text).to eq '01-15 30'
   end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -1,12 +1,16 @@
 RSpec.describe ChartPresenter do
   subject do
     ChartPresenter.new(
-      unique_pageviews: [
-         { date: '2018-01-13', value: 101 },
-         { date: '2018-01-14', value: 202 },
-         { date: '2018-01-15', value: 303 }
-      ]
-  )
+      json:
+        {
+          unique_pageviews: [
+            { date: '2018-01-13', value: 101 },
+            { date: '2018-01-14', value: 202 },
+            { date: '2018-01-15', value: 303 }
+          ]
+        },
+      metric: 'unique_pageviews'
+    )
   end
 
   it 'returns start date' do
@@ -15,17 +19,16 @@ RSpec.describe ChartPresenter do
   it 'returns end date' do
     expect(subject.to).to eq '2018-01-15'
   end
-  it 'returns the metric' do
-    expect(subject.metric).to eq 'unique_pageviews'
-  end
+
   it 'returns the metric name in a human readable manner' do
     expect(subject.human_friendly_metric).to eq 'Unique pageviews'
   end
+
   it 'returns formatted hash of chart data' do
-    expect(subject.chart_data).to eq expected_chart_data
+    expect(subject.chart_data).to eq unique_pageviews_chart_data
   end
 
-  def expected_chart_data
+  def unique_pageviews_chart_data
     {
       caption: "Unique pageviews from 2018-01-13 to 2018-01-15",
       chart_id: "unique_pageviews_2018-01-13-2018-01-15_chart",

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -1,22 +1,20 @@
+require 'gds_api/content_data_api'
+
 module GdsApi
   module TestHelpers
     module ContentDataApi
-      def content_data_api_has_metric(base_path, metric, from, to, payload)
-        url = "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}?from=#{from}&to=#{to}"
+      def content_data_api_has_metric(base_path:, from:, to:, metrics:, payload:)
+        query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
+        url = "#{content_data_api_endpoint}/metrics/#{base_path}#{query}"
         body = payload.to_json
-        stub_request(:get, url).to_return(
-          status: 200,
-          body: body
-        )
+        stub_request(:get, url).to_return(status: 200, body: body)
       end
 
-      def content_data_api_has_timeseries(base_path, metric, from, to, payload)
-        url = "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}/time-series?from=#{from}&to=#{to}"
+      def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload:)
+        query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
+        url = "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query}"
         body = payload.to_json
-        stub_request(:get, url).to_return(
-          status: 200,
-          body: body
-        )
+        stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_endpoint


### PR DESCRIPTION
To reduce the number of requests for fetching multiple metrics,
we are sending metrics as a single query parameter with multiple
values.

This change is reflected in the Content Data API
(content-performance-manager) as well[0].

We also add a gds-api-adapter stub to be more closely
aligned to the way the code would be structured in the gem, allowing
code that does not belong in the MetricsService to be abstracted
into GdsApi:ContentDataApi.

[0] https://github.com/alphagov/content-performance-manager/pull/872

