### PR TITLE
Refactor single content page for new data format

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -7,7 +7,7 @@ class MetricsController < ApplicationController
       base_path: params[:base_path],
       from: params[:from],
       to: params[:to],
-      metric: params[:metric]
+      metrics: [params[:metric]]
     ).to_hash
     @timeseries = service.fetch_timeseries(
       base_path: params[:base_path],

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -2,8 +2,8 @@ require 'gds_api/base'
 class MetricsService
   attr_reader :base_path, :from, :to, :metric
 
-  def fetch(base_path:, from:, to:, metric:)
-    url = request_url(base_path, from, to, metric)
+  def fetch(base_path:, from:, to:, metrics:)
+    url = request_url(base_path, from, to, metrics)
     client.get_json(url)
   end
 
@@ -14,8 +14,9 @@ class MetricsService
 
 private
 
-  def request_url(base_path, from, to, metric)
-    "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}?from=#{from}&to=#{to}"
+  def request_url(base_path, from, to, metrics)
+    metrics_query_string = metrics.map { |metric| "metrics[]=#{metric}" }.join('&')
+    "#{content_data_api_endpoint}/metrics/#{base_path}?from=#{from}&to=#{to}&#{metrics_query_string}"
   end
 
   def time_series_request_url(base_path, from, to, metric)

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,4 +1,4 @@
 <% content_for :title, "Metrics for #{@base_path}" %>
 Metrics for <%= @base_path %>
-Unique Pageviews: <%= @metrics['unique_pageviews']['total'] %>
+Unique Pageviews: <%= @metrics['unique_pageviews'] %>
 <%= render "components/chart", series_chart.chart_data %>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
   end
 
   before do
-    content_data_api_has_metric('base/path',
-                           'unique_pageviews',
+    content_data_api_has_metrics('base/path',
+                           %w[unique_pageviews],
                            '2000-01-01',
                            '2050-01-01',
                            unique_pageviews: 145_000)

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
                            'unique_pageviews',
                            '2000-01-01',
                            '2050-01-01',
-                           unique_pageviews: { total: 145_000 })
+                           unique_pageviews: 145_000)
     content_data_api_has_timeseries('base/path',
                                'unique_pageviews',
                                '2000-01-01',

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -1,8 +1,9 @@
 module GdsApi
   module TestHelpers
     module ContentDataApi
-      def content_data_api_has_metric(base_path, metric, from, to, payload)
-        url = "#{content_data_api_endpoint}/metrics/#{metric}/#{base_path}?from=#{from}&to=#{to}"
+      def content_data_api_has_metrics(base_path, metrics, from, to, payload)
+        metrics_query_string = metrics.map { |metric| "metrics[]=#{metric}" }.join('&')
+        url = "#{content_data_api_endpoint}/metrics/#{base_path}?from=#{from}&to=#{to}&#{metrics_query_string}"
         body = payload.to_json
         stub_request(:get, url).to_return(
           status: 200,


### PR DESCRIPTION
We have changed the format of the payload returned from
the backend service. The old format was:

{
  "unique_pageviews": {
    "total": 100,
    "latest": 50
   }
}

The new format is:

{
  "unique_pageviews": 100
}

Trello: https://trello.com/c/hjj6IJXH/621-3-show-metadata-information-in-the-single-performance-page-epic-2