### PR TITLE
Update components to match latest design

### DIFF
--- a/app/assets/stylesheets/components/_glance-metric.scss
+++ b/app/assets/stylesheets/components/_glance-metric.scss
@@ -33,18 +33,7 @@
 
   @include media(mobile) {
     min-height: 0;
-  }
-}
-
-.app-c-glance-metric__link-wrapper {
-  min-height: 1.4em;
-
-  @include media-down(tablet) {
-    min-height: 2.8em;
-  }
-
-  @include media(mobile) {
-    min-height: 0;
+    border-bottom: 0;
   }
 }
 

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -2,8 +2,6 @@
   name ||= false
   figure ||= false
   period ||= false
-  link_text ||= false
-  link_url ||= false
   measurement_display_label ||= ""
   measurement_explicit_label ||= ""
   context ||= ""
@@ -29,15 +27,10 @@
       <span>
     <% else %>
       <span class="app-c-glance-metric__trend--no-change">
-        <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#8210;</span>
+        <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9679;</span>
         <span class="app-c-glance-metric__trend-text">No change</span>
       <span>
     <% end %>
     <p class="app-c-glance-metric__period govuk-body-xs"><%= period %></p>
-    <div class="app-c-glance-metric__link-wrapper govuk-body-xs">
-      <% if link_text && link_url %>
-        <a class="app-c-glance-metric__link" href="<%= link_url %>"><%= link_text %></a>
-      <% end %>
-    </div>
   </div>
 <% end %>

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -1,0 +1,49 @@
+<%
+  name ||= false
+  figure ||= false
+  period ||= false
+  about ||= false
+  trend_percentage ||= false
+  context ||= false
+
+%>
+<% if name && figure && context %>
+  <div class="app-c-info-metric govuk-body">
+    <h3 class="app-c-info-metric__heading"><%= name %></h3>
+    <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
+    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
+    <% if trend_percentage %>
+      <span class="app-c-info-metric__trend">
+        <% if trend_percentage > 0 %>+<% end %><%= trend_percentage %>%
+      </span>
+      <% if trend_percentage.to_f > 0 %>
+        <span class="app-c-info-metric__trend--up">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9650;</span>
+          <span class="app-c-info-metric__trend-text">Upward trend</span>
+        <span>
+      <% elsif trend_percentage.to_f < 0 %>
+        <span class="app-c-info-metric__trend--down">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9660;</span>
+          <span class="app-c-info-metric__trend-text">Downward trend</span>
+        <span>
+      <% else %>
+        <span class="app-c-info-metric__trend--no-change">
+          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9679;</span>
+          <span class="app-c-info-metric__trend-text">No change</span>
+        <span>
+      <% end %>
+    <% end %>
+    <% if period %>
+      <span class="app-c-info-metric__period"><%= period %></span>
+    <% end %>
+    <% if about %>
+      <div class="app-c-info-metric__about govuk-body-s">
+        <%= render "govuk_publishing_components/components/details", {
+          title: "About this data"
+        } do %>
+          <%= about %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -60,25 +60,6 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric__trend--no-change .app-c-glance-metric__trend-text", text: "No change"
   end
 
-  it "renders a link only if both url and text are supplied" do
-    render_component(data)
-    assert_select ".app-c-glance-metric__link", 0
-
-    data[:link_text] = "My link"
-    render_component(data)
-    assert_select ".app-c-glance-metric__link", 0
-
-    data[:link_text] = false
-    data[:link_url] = "http://www.google.com"
-    render_component(data)
-    assert_select ".app-c-glance-metric__link", 0
-
-    data[:link_text] = "Reinstated link text"
-    data[:link_url] = "http://www.google.com"
-    render_component(data)
-    assert_select ".app-c-glance-metric__link", text: "Reinstated link text"
-  end
-
   def render_component(locals)
     render partial: "components/glance-metric", locals: locals
   end


### PR DESCRIPTION
- switches the symbol used when there is no change in metric
- removes a border at mobile size
- removes link from glance metric, along with associated test

https://trello.com/c/xWh1yAwa/603-3-build-glance-metrics-component