### PR TITLE
Refactor single content page for new data format

### DIFF
--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -2,8 +2,9 @@
 
 Metrics for <%= @base_path %>
 
-Unique Pageviews: <%= @metrics['unique_pageviews']['total'] %>
+Unique Pageviews: <%= @metrics['unique_pageviews'] %>
 <%= render "components/chart", series_chart('unique_pageviews').chart_data %>
 
-Pageviews: <%= @metrics['pageviews']['total'] %>
+Pageviews: <%= @metrics['pageviews'] %>
 <%= render "components/chart", series_chart('pageviews').chart_data %>
+

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -6,30 +6,30 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
   before do
     content_data_api_has_metric(base_path: 'base/path',
-                           from: '2000-01-01',
-                           to: '2050-01-01',
-                           metrics: %w[unique_pageviews page_views],
-                           payload: {
-                               unique_pageviews: { total: 145_000 },
-                               pageviews: { total: 200_000 }
-                           })
+      from: '2000-01-01',
+      to: '2050-01-01',
+      metrics: %w[unique_pageviews page_views],
+      payload: {
+        unique_pageviews: 145_000,
+        pageviews: 200_000
+      })
 
     content_data_api_has_timeseries(base_path: 'base/path',
-                               from: '2000-01-01',
-                               to: '2050-01-01',
-                               metrics: %w[unique_pageviews page_views],
-                               payload: {
-                                 unique_pageviews: [
-                                   { "date" => "2018-01-13", "value" => 101 },
-                                   { "date" => "2018-01-14", "value" => 202 },
-                                   { "date" => "2018-01-15", "value" => 303 }
-                                 ],
-                                 pageviews: [
-                                     { "date" => "2018-01-13", "value" => 10 },
-                                     { "date" => "2018-01-14", "value" => 20 },
-                                     { "date" => "2018-01-15", "value" => 30 }
-                                 ]
-                               })
+      from: '2000-01-01',
+      to: '2050-01-01',
+      metrics: %w[unique_pageviews page_views],
+      payload: {
+        unique_pageviews: [
+          { "date" => "2018-01-13", "value" => 101 },
+          { "date" => "2018-01-14", "value" => 202 },
+          { "date" => "2018-01-15", "value" => 303 }
+        ],
+        pageviews: [
+          { "date" => "2018-01-13", "value" => 10 },
+          { "date" => "2018-01-14", "value" => 20 },
+          { "date" => "2018-01-15", "value" => 30 }
+        ]
+      })
 
     visit '/metrics/base/path?from=2000-01-01&to=2050-01-01&metrics[]=unique_pageviews&metrics[]=page_views'
   end


### PR DESCRIPTION
We have changed the format of the payload returned from
the backend service. The old format was:

{
  "unique_pageviews": {
    "total": 100,
    "latest": 50
   }
}

The new format is:

{
  "unique_pageviews": 100
}

This is part of Trello: https://trello.com/c/hjj6IJXH/621-3-show-metadata-information-in-the-single-performance-page-epic-2