### PR TITLE
Fix error when the backend has no data

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -14,6 +14,10 @@ class ChartPresenter
     json.values.flatten.last[:date]
   end
 
+  def has_values?
+    !json.values.empty?
+  end
+
   def human_friendly_metric
     metric.tr('_', ' ').capitalize
   end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -3,8 +3,7 @@
 Metrics for <%= @base_path %>
 
 Unique Pageviews: <%= @metrics['unique_pageviews'] %>
-<%= render "components/chart", series_chart('unique_pageviews').chart_data %>
+<%= render "components/chart", series_chart('unique_pageviews').chart_data if series_chart('unique_pageviews').has_values? %>
 
 Pageviews: <%= @metrics['pageviews'] %>
-<%= render "components/chart", series_chart('pageviews').chart_data %>
-
+<%= render "components/chart", series_chart('pageviews').chart_data if series_chart('pageviews').has_values? %>


### PR DESCRIPTION
Currently the app raises an error when no
time series data is returned from the back-end.

This commit checks foe empty series before
attempting to render the chart.

Trello: https://trello.com/c/hjj6IJXH/621-3-show-metadata-information-in-the-single-performance-page-epic-2