### PR TITLE
Fix error when the backend has no data

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -15,7 +15,7 @@ class ChartPresenter
   end
 
   def has_values?
-    !json.values.empty?
+    !json.values.flatten.empty?
   end
 
   def human_friendly_metric


### PR DESCRIPTION
Currently the app raises an error when no
time series data is returned from the back-end.

This commit checks foe empty series before
attempting to render the chart.