### PR TITLE
Show content metadata on the single item page

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,20 +1,16 @@
 class MetricsController < ApplicationController
   def show
-    @base_path = params[:base_path]
     service = MetricsService.new
 
-    @metrics = service.fetch(
+    service_params = {
       base_path: params[:base_path],
       from: params[:from],
       to: params[:to],
       metrics: params[:metrics]
-    )
+    }
 
-    @timeseries = service.fetch_timeseries(
-      base_path: params[:base_path],
-      from: params[:from],
-      to: params[:to],
-      metrics: params[:metrics]
-    )
+    @summary = SingleContentItemPresenter
+      .parse_metrics(service.fetch(service_params))
+      .parse_time_series(service.fetch_time_series(service_params))
   end
 end

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -1,5 +1,5 @@
 module ChartsHelper
-  def series_chart(metric)
-    ChartPresenter.new(json: @timeseries, metric: metric)
+  def render_chart(series)
+    render "components/chart", series.chart_data if series.has_values?
   end
 end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -19,7 +19,7 @@ class ChartPresenter
   end
 
   def human_friendly_metric
-    metric.tr('_', ' ').capitalize
+    metric.to_s.tr('_', ' ').capitalize
   end
 
   def chart_data

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,6 +1,7 @@
 class SingleContentItemPresenter
   attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
-    :pageviews_series, :base_path
+    :pageviews_series, :base_path, :title, :published_at, :last_updated,
+    :publishing_organisation, :document_type
 
   def self.parse_metrics(metrics)
     new.parse_metrics(metrics.deep_symbolize_keys)
@@ -10,6 +11,11 @@ class SingleContentItemPresenter
     @unique_pageviews = metrics[:unique_pageviews]
     @pageviews = metrics[:pageviews]
     @base_path = metrics[:base_path]
+    @title = metrics[:title]
+    @published_at = format_date metrics[:first_published_at]
+    @last_updated = format_date metrics[:public_updated_at]
+    @publishing_organisation = metrics[:primary_organisation_title]
+    @document_type = metrics[:document_type].tr('_', ' ').capitalize
     self
   end
 
@@ -17,5 +23,11 @@ class SingleContentItemPresenter
     @unique_pageviews_series = ChartPresenter.new(json: time_series, metric: :unique_pageviews)
     @pageviews_series = ChartPresenter.new(json: time_series, metric: :pageviews)
     self
+  end
+
+private
+
+  def format_date(date_str)
+    Date.parse(date_str).strftime('%-d %B %Y')
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,0 +1,21 @@
+class SingleContentItemPresenter
+  attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
+    :pageviews_series, :base_path
+
+  def self.parse_metrics(metrics)
+    new.parse_metrics(metrics.deep_symbolize_keys)
+  end
+
+  def parse_metrics(metrics)
+    @unique_pageviews = metrics[:unique_pageviews]
+    @pageviews = metrics[:pageviews]
+    @base_path = metrics[:base_path]
+    self
+  end
+
+  def parse_time_series(time_series)
+    @unique_pageviews_series = ChartPresenter.new(json: time_series, metric: :unique_pageviews)
+    @pageviews_series = ChartPresenter.new(json: time_series, metric: :pageviews)
+    self
+  end
+end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -6,7 +6,7 @@ class MetricsService
     api.client.get_json(url).to_hash
   end
 
-  def fetch_timeseries(base_path:, from:, to:, metrics:)
+  def fetch_time_series(base_path:, from:, to:, metrics:)
     url = api.time_series_request_url(base_path: base_path, from: from, to: to, metrics: metrics)
     api.client.get_json(url).to_hash
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
     <% end %>
 
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      <%= render "govuk_publishing_components/components/title", title: yield(:title) %>
+      <%#= render "govuk_publishing_components/components/title", title: yield(:title) %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/metrics/_metadata_row.html.erb
+++ b/app/views/metrics/_metadata_row.html.erb
@@ -1,0 +1,3 @@
+<div class="metadata-row">
+  <div class="metadata-label"><%= label %></div><div class="metadata-value"><%= value %></div>
+</div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,6 +1,13 @@
-<% content_for :title, "Metrics for #{@summary.base_path}" %>
-
-Metrics for <%= @summary.base_path %>
+<% content_for :title, "Page Data: #{@summary.title}" %>
+<h2>Page Data</h2>
+<h1><%= @summary.title %></h1>
+<div class="page-metadata">
+  <%= render :partial => 'metadata_row', locals: { label: 'Published', value: @summary.published_at } %>
+  <%= render :partial => 'metadata_row', locals: { label: 'Last updated', value: @summary.last_updated } %>
+  <%= render :partial => 'metadata_row', locals: {label: 'From', value:  @summary.publishing_organisation } %>
+  <%= render :partial => 'metadata_row', locals: {label: 'Type', value:  @summary.document_type } %>
+  <%= render :partial => 'metadata_row', locals: {label: 'URL', value:  @summary.base_path } %>
+</div>
 
 Unique Pageviews: <%= @summary.unique_pageviews %>
 <%= render_chart @summary.unique_pageviews_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,9 +1,9 @@
-<% content_for :title, "Metrics for #{@base_path}" %>
+<% content_for :title, "Metrics for #{@summary.base_path}" %>
 
-Metrics for <%= @base_path %>
+Metrics for <%= @summary.base_path %>
 
-Unique Pageviews: <%= @metrics['unique_pageviews'] %>
-<%= render "components/chart", series_chart('unique_pageviews').chart_data if series_chart('unique_pageviews').has_values? %>
+Unique Pageviews: <%= @summary.unique_pageviews %>
+<%= render_chart @summary.unique_pageviews_series %>
 
-Pageviews: <%= @metrics['pageviews'] %>
-<%= render "components/chart", series_chart('pageviews').chart_data if series_chart('pageviews').has_values? %>
+Pageviews: <%= @summary.pageviews %>
+<%= render_chart @summary.pageviews_series %>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -10,8 +10,14 @@ RSpec.describe '/metrics/base/path', type: :feature do
       to: '2050-01-01',
       metrics: %w[unique_pageviews page_views],
       payload: {
+        base_path: '/base/path',
         unique_pageviews: 145_000,
-        pageviews: 200_000
+        pageviews: 200_000,
+        title: "Content Title",
+        first_published_at: '2018-02-01T00:00:00.000Z',
+        public_updated_at: '2018-04-25T00:00:00.000Z',
+        primary_organisation_title: 'The ministry',
+        document_type: "news_story"
       })
 
     content_data_api_has_timeseries(base_path: 'base/path',
@@ -35,8 +41,28 @@ RSpec.describe '/metrics/base/path', type: :feature do
   end
 
   it 'renders the metric for unique_pageviews' do
-    expect(page).to have_content('Metrics')
     expect(page).to have_content('145000')
+  end
+
+  it 'renders the metric for pageviews' do
+    expect(page).to have_content('200000')
+  end
+
+  it 'renders the page title' do
+    expect(page).to have_content('Content Title')
+  end
+
+  it 'renders the metadata' do
+    metadata = find('.page-metadata').all('.metadata-row').map do |el|
+      el.all('.metadata-label,.metadata-value').map(&:text)
+    end
+    expect(metadata).to eq([
+      ['Published', '1 February 2018'],
+      ['Last updated', '25 April 2018'],
+      ['From', 'The ministry'],
+      ['Type', 'News story'],
+      ['URL', '/base/path']
+    ])
   end
 
   it 'renders the metric timeseries for unique_pageviews' do


### PR DESCRIPTION
This commit renders the metadata as shown in the [prototype](https://trello.com/c/tYOxhCi5/645-single-page-design-latest-updates) on the single content item page.

There is a [related pr in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/902)

Trello:  https://trello.com/c/hjj6IJXH/621-3-show-metadata-information-in-the-single-performance-page-epic-2
