### PR TITLE
Handle a GdsApi::HTTPNotFound when getting data

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,4 +1,6 @@
 class MetricsController < ApplicationController
+  DEFAULT_METRICS = %w[pageviews unique_pageviews number_of_internal_searches].freeze
+
   def show
     service = MetricsService.new
 
@@ -6,11 +8,15 @@ class MetricsController < ApplicationController
       base_path: params[:base_path],
       from: params[:from],
       to: params[:to],
-      metrics: params[:metrics]
+      metrics: DEFAULT_METRICS
     }
 
     @summary = SingleContentItemPresenter
       .parse_metrics(service.fetch(service_params))
       .parse_time_series(service.fetch_time_series(service_params))
+  end
+
+  rescue_from GdsApi::HTTPNotFound do
+    render file: Rails.root.join('public', '404.html'), status: :not_found
   end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,85 +1,96 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
-  let(:metrics_response) do
-    {}
-  end
 
-  before do
-    content_data_api_has_metric(base_path: 'base/path',
-      from: '2000-01-01',
-      to: '2050-01-01',
-      metrics: %w[unique_pageviews page_views],
-      payload: {
-        base_path: '/base/path',
-        unique_pageviews: 145_000,
-        pageviews: 200_000,
-        title: "Content Title",
-        first_published_at: '2018-02-01T00:00:00.000Z',
-        public_updated_at: '2018-04-25T00:00:00.000Z',
-        primary_organisation_title: 'The ministry',
-        document_type: "news_story"
-      })
+  context 'successful request' do
+    before do
+      content_data_api_has_metric(base_path: 'base/path',
+        from: '2000-01-01',
+        to: '2050-01-01',
+        metrics: %w[number_of_internal_searches pageviews unique_pageviews],
+        payload: {
+          base_path: '/base/path',
+          unique_pageviews: 145_000,
+          pageviews: 200_000,
+          title: "Content Title",
+          first_published_at: '2018-02-01T00:00:00.000Z',
+          public_updated_at: '2018-04-25T00:00:00.000Z',
+          primary_organisation_title: 'The ministry',
+          document_type: "news_story"
+        })
 
-    content_data_api_has_timeseries(base_path: 'base/path',
-      from: '2000-01-01',
-      to: '2050-01-01',
-      metrics: %w[unique_pageviews page_views],
-      payload: {
-        unique_pageviews: [
-          { "date" => "2018-01-13", "value" => 101 },
-          { "date" => "2018-01-14", "value" => 202 },
-          { "date" => "2018-01-15", "value" => 303 }
-        ],
-        pageviews: [
-          { "date" => "2018-01-13", "value" => 10 },
-          { "date" => "2018-01-14", "value" => 20 },
-          { "date" => "2018-01-15", "value" => 30 }
-        ]
-      })
+      content_data_api_has_timeseries(base_path: 'base/path',
+        from: '2000-01-01',
+        to: '2050-01-01',
+        metrics: %w[number_of_internal_searches pageviews unique_pageviews],
+        payload: {
+          unique_pageviews: [
+            { "date" => "2018-01-13", "value" => 101 },
+            { "date" => "2018-01-14", "value" => 202 },
+            { "date" => "2018-01-15", "value" => 303 }
+          ],
+          pageviews: [
+            { "date" => "2018-01-13", "value" => 10 },
+            { "date" => "2018-01-14", "value" => 20 },
+            { "date" => "2018-01-15", "value" => 30 }
+          ]
+        })
 
-    visit '/metrics/base/path?from=2000-01-01&to=2050-01-01&metrics[]=unique_pageviews&metrics[]=page_views'
-  end
-
-  it 'renders the metric for unique_pageviews' do
-    expect(page).to have_content('145000')
-  end
-
-  it 'renders the metric for pageviews' do
-    expect(page).to have_content('200000')
-  end
-
-  it 'renders the page title' do
-    expect(page).to have_content('Content Title')
-  end
-
-  it 'renders the metadata' do
-    metadata = find('.page-metadata').all('.metadata-row').map do |el|
-      el.all('.metadata-label,.metadata-value').map(&:text)
+      visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
     end
-    expect(metadata).to eq([
-      ['Published', '1 February 2018'],
-      ['Last updated', '25 April 2018'],
-      ['From', 'The ministry'],
-      ['Type', 'News story'],
-      ['URL', '/base/path']
-    ])
+
+    it 'renders the metric for unique_pageviews' do
+      expect(page).to have_content('145000')
+    end
+
+    it 'renders the metric for pageviews' do
+      expect(page).to have_content('200000')
+    end
+
+    it 'renders the page title' do
+      expect(page).to have_content('Content Title')
+    end
+
+    it 'renders the metadata' do
+      metadata = find('.page-metadata').all('.metadata-row').map do |el|
+        el.all('.metadata-label,.metadata-value').map(&:text)
+      end
+      expect(metadata).to eq([
+        ['Published', '1 February 2018'],
+        ['Last updated', '25 April 2018'],
+        ['From', 'The ministry'],
+        ['Type', 'News story'],
+        ['URL', '/base/path']
+      ])
+    end
+
+    it 'renders the metric timeseries for unique_pageviews' do
+      click_on 'Unique pageviews table'
+      unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr')
+      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
+
+      expect(unique_pageviews_rows.count).to eq 4
+      expect(unique_pageviews_rows[0].text).to eq ''
+      expect(unique_pageviews_rows[1].text).to eq '01-13 101'
+      expect(unique_pageviews_rows[2].text).to eq '01-14 202'
+      expect(unique_pageviews_rows[3].text).to eq '01-15 303'
+
+      expect(pageviews_rows.count).to eq 4
+      expect(pageviews_rows[0].text).to eq ''
+      expect(pageviews_rows[1].text).to eq '01-13 10'
+      expect(pageviews_rows[2].text).to eq '01-14 20'
+      expect(pageviews_rows[3].text).to eq '01-15 30'
+    end
   end
 
-  it 'renders the metric timeseries for unique_pageviews' do
-    click_on 'Unique pageviews table'
-    unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr')
-    pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
-
-    expect(unique_pageviews_rows.count).to eq 4
-    expect(unique_pageviews_rows[0].text).to eq ''
-    expect(unique_pageviews_rows[1].text).to eq '01-13 101'
-    expect(unique_pageviews_rows[2].text).to eq '01-14 202'
-    expect(unique_pageviews_rows[3].text).to eq '01-15 303'
-
-    expect(pageviews_rows.count).to eq 4
-    expect(pageviews_rows[0].text).to eq ''
-    expect(pageviews_rows[1].text).to eq '01-13 10'
-    expect(pageviews_rows[2].text).to eq '01-14 20'
-    expect(pageviews_rows[3].text).to eq '01-15 30'
+  context 'when the data-api has an error' do
+    it 'returns a 404 for a Gds::NotFound' do
+      content_data_api_does_not_have_base_path(base_path: 'base/path',
+        from: '2000-01-01',
+        to: '2050-01-01',
+        metrics: %w[number_of_internal_searches pageviews unique_pageviews])
+      visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
+      expect(page.status_code).to eq(404)
+      expect(page).to have_content "The page you were looking for doesn't exist."
+    end
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -10,6 +10,12 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
+      def content_data_api_does_not_have_base_path(base_path:, from:, to:, metrics:)
+        query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
+        url = "#{content_data_api_endpoint}/metrics/#{base_path}#{query}"
+        stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
+      end
+
       def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload:)
         query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
         url = "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query}"


### PR DESCRIPTION
Currently the app fails with a 500 error
when we get a 404 from the content-data-api.

This commit traps the error and renders the 404 page.