### PR TITLE
Add date range picker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,11 @@ gem "chartkick"
 gem "gds-api-adapters", "~> 53"
 gem "gds-sso", "~> 13"
 gem "govuk_app_config", "~> 1"
-gem "govuk_publishing_components", "~> 9.21"
+gem "govuk_publishing_components", "~> 9.20"
+gem 'logstasher'
 gem "pg", "~> 1"
 gem "plek", "~> 2"
 gem "uglifier", "~> 4"
-gem 'logstasher'
 
 group :development do
   gem "listen", "~> 3"
@@ -26,6 +26,7 @@ end
 group :development, :test do
   gem "byebug", "~> 10"
   gem "capybara"
+  gem "factory_bot_rails"
   gem "govuk-lint", "~> 3"
   gem "rspec-rails", "~> 3"
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (4.11.1)
+      activesupport (>= 3.0.0)
+    factory_bot_rails (4.11.1)
+      factory_bot (~> 4.11.1)
+      railties (>= 3.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.25)
@@ -343,11 +348,12 @@ DEPENDENCIES
   byebug (~> 10)
   capybara
   chartkick
+  factory_bot_rails
   gds-api-adapters (~> 53)
   gds-sso (~> 13)
   govuk-lint (~> 3)
   govuk_app_config (~> 1)
-  govuk_publishing_components (~> 9.21)
+  govuk_publishing_components (~> 9.20)
   listen (~> 3)
   logstasher
   pg (~> 1)

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,20 +1,16 @@
 class MetricsController < ApplicationController
   def show
     service = MetricsService.new
+    date_range = DateRange.new(params[:date_range])
 
     service_params = {
       base_path: params[:base_path],
-      from: params[:from],
-      to: params[:to]
+      date_range: date_range,
     }
 
-    @summary = SingleContentItemPresenter
-      .parse_metrics(
-        metrics: service.fetch_aggregated_data(service_params),
-        from: params[:from],
-        to: params[:to]
-      )
-      .parse_time_series(service.fetch_time_series(service_params))
+    metrics = service.fetch_aggregated_data(service_params)
+    time_series = service.fetch_time_series(service_params)
+    @summary = SingleContentItemPresenter.new(metrics, time_series, date_range)
   end
 
   rescue_from GdsApi::HTTPNotFound do

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -1,0 +1,51 @@
+class DateRange
+  attr_reader :time_period
+  def initialize(time_period)
+    @time_period = time_period
+  end
+
+  def to
+    date_to_range[:to]
+  end
+
+  def from
+    date_to_range[:from]
+  end
+
+private
+
+  def date_to_range
+    case time_period
+    when 'last-month'
+      {
+        from: Time.zone.today.last_month.beginning_of_month.to_s,
+        to: Time.zone.today.last_month.end_of_month.to_s
+      }
+    when 'last-3-months'
+      {
+        from: (Time.zone.today - 3.months).to_s,
+        to: Time.zone.today.to_s
+      }
+    when 'last-6-months'
+      {
+        from: (Time.zone.today - 6.months).to_s,
+        to: Time.zone.today.to_s
+      }
+    when 'last-1-year'
+      {
+        from: (Time.zone.today - 1.year).to_s,
+        to: Time.zone.today.to_s
+      }
+    when 'last-2-years'
+      {
+        from: (Time.zone.today - 2.years).to_s,
+        to: Time.zone.today.to_s
+      }
+    else
+      {
+        from: (Time.zone.today - 30.days).to_s,
+        to: Time.zone.today.to_s
+      }
+    end
+  end
+end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -25,8 +25,8 @@ class ChartPresenter
       caption: "#{human_friendly_metric} from #{from.to_date} to #{to.to_date}",
       chart_label: "#{human_friendly_metric} chart",
       table_label: "#{human_friendly_metric} table",
-      chart_id: "#{metric}_#{from}-#{to}_chart",
-      table_id: "#{metric}_#{from}-#{to}_table",
+      chart_id: "#{metric}_chart",
+      table_id: "#{metric}_table",
       keys: keys,
       rows: [
         {

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,18 +1,19 @@
 class SingleContentItemPresenter
-  attr_reader :unique_pageviews, :unique_pageviews_series,
-    :pageviews, :pageviews_series,
-    :number_of_internal_searches, :number_of_internal_searches_series,
-    :satisfaction_score, :satisfaction_score_series,
-    :metadata, :title
+  attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
+    :pageviews_series, :base_path, :title, :published_at, :last_updated,
+    :publishing_organisation, :document_type, :number_of_internal_searches,
+    :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series,
+    :date_range, :metadata
 
-  def initialize(from, to)
-    @from = from
-    @to = to
+  def initialize(metrics, time_series, date_range)
+    @date_range = date_range
+    parse_metrics(metrics.with_indifferent_access)
+    parse_time_series(time_series.with_indifferent_access)
   end
 
-  def self.parse_metrics(metrics:, from:, to:)
-    new(from, to).parse_metrics(metrics.deep_symbolize_keys)
-  end
+private
+
+  attr_reader :from, :to
 
   def parse_metrics(metrics)
     @unique_pageviews = metrics[:unique_pageviews]
@@ -27,7 +28,6 @@ class SingleContentItemPresenter
       last_updated: format_date(metrics[:public_updated_at]),
       publishing_organisation: metrics[:primary_organisation_title],
     }
-    self
   end
 
   def parse_time_series(time_series)
@@ -35,15 +35,10 @@ class SingleContentItemPresenter
     @pageviews_series = get_chart_presenter(time_series, :pageviews)
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
-    self
   end
 
-private
-
-  attr_reader :from, :to
-
   def get_chart_presenter(time_series, metric)
-    ChartPresenter.new(json: time_series, metric: metric, from: from, to: to)
+    ChartPresenter.new(json: time_series, metric: metric, from: date_range.from, to: date_range.to)
   end
 
   def format_date(date_str)

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -3,13 +3,13 @@ require 'gds_api/content_data_api'
 class MetricsService
   DEFAULT_METRICS = %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score].freeze
 
-  def fetch_aggregated_data(base_path:, from:, to:)
-    url = api.request_url(base_path: base_path, from: from, to: to, metrics: DEFAULT_METRICS)
+  def fetch_aggregated_data(base_path:, date_range:)
+    url = api.request_url(base_path: base_path, from: date_range.from, to: date_range.to, metrics: DEFAULT_METRICS)
     api.client.get_json(url).to_hash
   end
 
-  def fetch_time_series(base_path:, from:, to:)
-    url = api.time_series_request_url(base_path: base_path, from: from, to: to, metrics: DEFAULT_METRICS)
+  def fetch_time_series(base_path:, date_range:)
+    url = api.time_series_request_url(base_path: base_path, from: date_range.from, to: date_range.to, metrics: DEFAULT_METRICS)
     api.client.get_json(url).to_hash
   end
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -24,3 +24,14 @@
   <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
 </div>
 <%= render 'chart', series: @summary.satisfaction_score_series %>
+<%= form_for('date', :url => "/metrics#{@summary.metadata[:base_path]}", :method => :get) do |f| %>
+  <div class="field">
+    <%= radio_button_tag(:date_range, 'last-30-days', checked = (@summary.date_range == 'last-30-days' || ''), label: 'Last 30 Days') %> Last 30 Days <br>
+    <%= radio_button_tag(:date_range, 'last-month', checked = (@summary.date_range == 'last-month'), label: 'Last Month') %> Last Month <br>
+    <%= radio_button_tag(:date_range, 'last-3-months', checked = (@summary.date_range == 'last-3-months'), label: 'Last 3 Months') %> Last 3 Months <br>
+    <%= radio_button_tag(:date_range, 'last-6-months', checked = (@summary.date_range == 'last-6-months'), label: 'Last 6 Month') %> Last 6 Months <br>
+    <%= radio_button_tag(:date_range, 'last-1-year', checked = (@summary.date_range == 'last-year'), label: 'Last Year') %> Last 1 Year <br>
+    <%= radio_button_tag(:date_range, 'last-2-years', checked = (@summary.date_range == 'last-2-years'), label: 'Last 2 Years') %> Last 2 Years <br>
+    <%= submit_tag 'OK' %>
+  </div>
+<% end %>

--- a/spec/factories/date_range.rb
+++ b/spec/factories/date_range.rb
@@ -1,0 +1,27 @@
+FactoryBot.define do
+  factory :date_range, class: DateRange do
+    trait :last_30_days do
+      initialize_with { new('last-30-days') }
+    end
+
+    trait :last_month do
+      initialize_with { new('last-month') }
+    end
+
+    trait :last_3_months do
+      initialize_with { new('last-3-months') }
+    end
+
+    trait :last_6_months do
+      initialize_with { new('last-6-months') }
+    end
+
+    trait :last_1_year do
+      initialize_with { new('last-1-year') }
+    end
+
+    trait :last_2_years do
+      initialize_with { new('last-2-years') }
+    end
+  end
+end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,0 +1,136 @@
+RSpec.describe 'date selection', type: :feature do
+  include GdsApi::TestHelpers::ContentDataApi
+  include MetricsChartSpecHelpers
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
+
+  before do
+    initial_page_stub
+  end
+
+  it 'renders data for the last 30 days if no date period is selected' do
+    date_range = build(:date_range, :last_30_days)
+    visit '/metrics/base/path'
+    expect_default_date_period_metrics_to_be_displayed(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the last 30 days when `last 30 days` is selected' do
+    date_range = build(:date_range, :last_30_days)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-30-days')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the previous month when `last month` is selected' do
+    date_range = build(:date_range, :last_month)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-month')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the last 3 months when `last 3 months` is selected' do
+    date_range = build(:date_range, :last_3_months)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-3-months')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the last 6 months when `last6 months` is selected' do
+    date_range = build(:date_range, :last_6_months)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-6-months')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the last year when `last year` is selected' do
+    date_range = build(:date_range, :last_1_year)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-1-year')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  it 'renders data for the last 2 years when `last 2 years` is selected' do
+    date_range = build(:date_range, :last_2_years)
+    stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
+    visit_page_and_filter_by_date_range('last-2-years')
+    expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
+  end
+
+  def initial_page_stub
+    from = Time.zone.today - 30.days
+    to = Time.zone.today
+    content_data_api_has_metric(base_path: 'base/path',
+                                from: from,
+                                to: to,
+                                metrics: metrics)
+    content_data_api_has_timeseries(base_path: 'base/path',
+                                    from: from,
+                                    to: to,
+                                    metrics: metrics,
+                                    payload: {
+       unique_pageviews: [
+         { "date" => (from - 1.day).to_s, "value" => 0 },
+         { "date" => (from - 2.days).to_s, "value" => 9 },
+         { "date" => (to + 1.day).to_s, "value" => 9 }
+       ],
+       pageviews: [
+         { "date" => (from - 1.day).to_s, "value" => 8 },
+         { "date" => (from - 2.days).to_s, "value" => 8 },
+         { "date" => (to + 1.day).to_s, "value" => 8 }
+       ],
+       number_of_internal_searches: [
+         { "date" => (from - 1.day).to_s, "value" => 8 },
+         { "date" => (from - 2.days).to_s, "value" => 8 },
+         { "date" => (to + 1.day).to_s, "value" => 8 }
+       ],
+       satisfaction_score: [
+         { "date" => (from - 1.day).to_s, "value" => 100 },
+         { "date" => (from - 2.days).to_s, "value" => 90 },
+         { "date" => (to + 1.day).to_s, "value" => 80 }
+       ]
+     })
+  end
+
+  def stub_response_for_date_range(from, to)
+    content_data_api_has_metric(base_path: 'base/path',
+      from: from,
+      to: to,
+      metrics: metrics)
+    content_data_api_has_timeseries(base_path: 'base/path',
+      from: from,
+      to: to,
+      metrics: metrics)
+  end
+
+  def expect_metrics_for_each_date_to_be_correct(from, to)
+    month_and_date_string_for_date1 = (from - 1.day).to_s.last(5)
+    month_and_date_string_for_date2 = (from - 2.days).to_s.last(5)
+    month_and_date_string_for_date3 = (to + 1.day).to_s.last(5)
+    unique_pageviews_rows = extract_table_content("#unique_pageviews_table")
+    expect(unique_pageviews_rows).to match_array([
+      ['', ''],
+      [month_and_date_string_for_date1.to_s, "1"],
+      [month_and_date_string_for_date2.to_s, "2"],
+      [month_and_date_string_for_date3.to_s, "30"],
+    ])
+  end
+
+  def expect_default_date_period_metrics_to_be_displayed(from, to)
+    month_and_date_string_for_date1 = (from - 1.day).to_s.last(5)
+    month_and_date_string_for_date2 = (from - 2.days).to_s.last(5)
+    month_and_date_string_for_date3 = (to + 1.day).to_s.last(5)
+    unique_pageviews_rows = extract_table_content("#unique_pageviews_table")
+    expect(unique_pageviews_rows).to match_array([
+      ['', ''],
+      [month_and_date_string_for_date1.to_s, "0"],
+      [month_and_date_string_for_date2.to_s, "9"],
+      [month_and_date_string_for_date3.to_s, "9"],
+    ])
+  end
+
+  def visit_page_and_filter_by_date_range(date_range)
+    visit '/metrics/base/path'
+    find("#date_range_#{date_range}").click
+    click_button 'OK'
+    click_on 'Unique pageviews table'
+  end
+end

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe DateRange do
+  describe '#to' do
+    it 'returns today`s date if selected time period is `last-30-days`' do
+      expect(DateRange.new('last-30-days').to).to eq(Time.zone.today.to_s)
+    end
+    it 'returns today`s date if selected time period is `last-3-months`' do
+      expect(DateRange.new('last-3-months').to).to eq(Time.zone.today.to_s)
+    end
+    it 'returns today`s date if selected time period is `last-6-months`' do
+      expect(DateRange.new('last-6-months').to).to eq(Time.zone.today.to_s)
+    end
+    it 'returns today`s date if selected time period is `last-1-year`' do
+      expect(DateRange.new('last-1-year').to).to eq(Time.zone.today.to_s)
+    end
+    it 'returns today`s date if selected time period is `last-2-years`' do
+      expect(DateRange.new('last-2-years').to).to eq(Time.zone.today.to_s)
+    end
+    it 'returns date of last day of previous month if selected time period is `last-month`' do
+      expect(DateRange.new('last-month').to).to eq(Time.zone.today.last_month.end_of_month.to_s)
+    end
+  end
+  describe '#from' do
+    it 'returns date of 30 days ago if selected time period is `last-30-days`' do
+      expect(DateRange.new('last-30-days').from).to eq((Time.zone.today - 30.days).to_s)
+    end
+    it 'returns date of 3 months ago if selected time period is `last-3-months`' do
+      expect(DateRange.new('last-3-months').from).to eq((Time.zone.today - 3.months).to_s)
+    end
+    it 'returns date of 6 months ago if selected time period is `last-6-months`' do
+      expect(DateRange.new('last-6-months').from).to eq((Time.zone.today - 6.months).to_s)
+    end
+    it 'returns date of 1 year ago if selected time period is `last-1-year`' do
+      expect(DateRange.new('last-1-year').from).to eq((Time.zone.today - 1.year).to_s)
+    end
+    it 'returns date of 2 years ago if selected time period is `last-2-years`' do
+      expect(DateRange.new('last-2-years').from).to eq((Time.zone.today - 2.years).to_s)
+    end
+    it 'returns date of first day of previous month if selected time period is `last-month`' do
+      expect(DateRange.new('last-month').from).to eq(Time.zone.today.last_month.beginning_of_month.to_s)
+    end
+  end
+end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ChartPresenter do
   def unique_pageviews_chart_data
     {
       caption: "Unique pageviews from 2018-01-13 to 2018-01-15",
-      chart_id: "unique_pageviews_2018-01-13-2018-01-15_chart",
+      chart_id: "unique_pageviews_chart",
       chart_label: "Unique pageviews chart",
       keys: [
         "01-13",
@@ -55,7 +55,7 @@ RSpec.describe ChartPresenter do
           ]
         }
       ],
-      table_id: "unique_pageviews_2018-01-13-2018-01-15_table",
+      table_id: "unique_pageviews_table",
       table_label: "Unique pageviews table"
     }
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe SingleContentItemPresenter do
+  include GdsApi::TestHelpers::ContentDataApi
   let(:from) { '2018-01-01' }
   let(:to) { '2018-06-01' }
   let(:metrics) do
@@ -15,11 +16,13 @@ RSpec.describe SingleContentItemPresenter do
       'number_of_internal_searches' => 120,
     }
   end
+  let(:time_series) { default_timeseries_payload(from.to_date, to.to_date) }
+  let(:date_range) { build(:date_range, :last_30_days) }
 
   subject do
-    SingleContentItemPresenter.parse_metrics(metrics: metrics,
-      from: from,
-      to: to)
+    SingleContentItemPresenter.new(metrics,
+      time_series,
+      date_range)
   end
 
   describe '#metadata' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,4 +15,5 @@ end
 RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -3,11 +3,11 @@ require 'gds_api/content_data_api'
 module GdsApi
   module TestHelpers
     module ContentDataApi
-      def content_data_api_has_metric(base_path:, from:, to:, metrics:, payload:)
+      def content_data_api_has_metric(base_path:, from:, to:, metrics:)
         query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
         url = "#{content_data_api_endpoint}/metrics/#{base_path}#{query}"
-        body = payload.to_json
-        stub_request(:get, url).to_return(status: 200, body: body)
+        body = default_metric_payload(base_path)
+        stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_does_not_have_base_path(base_path:, from:, to:, metrics:)
@@ -16,15 +16,55 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload:)
+      def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload: nil)
         query = GdsApi::ContentDataApi.new.query(from: from, to: to, metrics: metrics)
         url = "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query}"
-        body = payload.to_json
-        stub_request(:get, url).to_return(status: 200, body: body)
+        body = payload.nil? ? default_timeseries_payload(from.to_date, to.to_date) : payload
+        stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_endpoint
         "#{Plek.current.find('content-performance-manager')}/api/v1"
+      end
+
+      def default_metric_payload(base_path)
+        {
+          base_path: "/#{base_path}",
+          unique_pageviews: 145_000,
+          pageviews: 200_000,
+          satisfaction_score: 25.5,
+          number_of_internal_searches: 250,
+          title: "Content Title",
+          first_published_at: '2018-02-01T00:00:00.000Z',
+          public_updated_at: '2018-04-25T00:00:00.000Z',
+          primary_organisation_title: 'The ministry',
+          document_type: "news_story"
+        }
+      end
+
+      def default_timeseries_payload(from, to)
+        {
+          unique_pageviews: [
+            { "date" => (from - 1.day).to_s, "value" => 1 },
+            { "date" => (from - 2.days).to_s, "value" => 2 },
+            { "date" => (to + 1.day).to_s, "value" => 30 }
+          ],
+          pageviews: [
+            { "date" => (from - 1.day).to_s, "value" => 10 },
+            { "date" => (from - 2.days).to_s, "value" => 20 },
+            { "date" => (to + 1.day).to_s, "value" => 30 }
+          ],
+          number_of_internal_searches: [
+            { "date" => (from - 1.day).to_s, "value" => 8 },
+            { "date" => (from - 2.days).to_s, "value" => 8 },
+            { "date" => (to + 1.day).to_s, "value" => 8 }
+          ],
+          satisfaction_score: [
+            { "date" => (from - 1.day).to_s, "value" => 100 },
+            { "date" => (from - 2.days).to_s, "value" => 90 },
+            { "date" => (to + 1.day).to_s, "value" => 80 }
+          ]
+        }
       end
     end
   end


### PR DESCRIPTION
Add date range picker to single content item page in order to let end users get metrics for the time period in which they are interested in. Use `last 30 days` as default time period if none is specified.

No styling on the radio buttons as a component will be coming in the future which handles this.

Change the id's of charts and tables to make them easier to query. The date is not an important part of the chart because there will only be one per query and if we display two different time series on the same chart it could be difficult to handle.