### PR TITLE
Render the remaining metrics summaries/charts

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -9,7 +9,11 @@ class MetricsController < ApplicationController
     }
 
     @summary = SingleContentItemPresenter
-      .parse_metrics(service.fetch_aggregated_data(service_params))
+      .parse_metrics(
+        metrics: service.fetch_aggregated_data(service_params),
+        from: params[:from],
+        to: params[:to]
+      )
       .parse_time_series(service.fetch_time_series(service_params))
   end
 

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -9,7 +9,7 @@ class MetricsController < ApplicationController
     }
 
     @summary = SingleContentItemPresenter
-      .parse_metrics(service.fetch(service_params))
+      .parse_metrics(service.fetch_aggregated_data(service_params))
       .parse_time_series(service.fetch_time_series(service_params))
   end
 

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,14 +1,11 @@
 class MetricsController < ApplicationController
-  DEFAULT_METRICS = %w[pageviews unique_pageviews number_of_internal_searches].freeze
-
   def show
     service = MetricsService.new
 
     service_params = {
       base_path: params[:base_path],
       from: params[:from],
-      to: params[:to],
-      metrics: DEFAULT_METRICS
+      to: params[:to]
     }
 
     @summary = SingleContentItemPresenter

--- a/app/helpers/charts_helper.rb
+++ b/app/helpers/charts_helper.rb
@@ -1,5 +1,0 @@
-module ChartsHelper
-  def render_chart(series)
-    render "components/chart", series.chart_data if series.has_values?
-  end
-end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -16,6 +16,10 @@ class ChartPresenter
     metric.to_s.tr('_', ' ').capitalize
   end
 
+  def no_data_message
+    "No #{human_friendly_metric} data for the selected time period"
+  end
+
   def chart_data
     {
       caption: "#{human_friendly_metric} from #{from.to_date} to #{to.to_date}",

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -1,17 +1,11 @@
 class ChartPresenter
-  attr_reader :json, :metric
+  attr_reader :json, :metric, :from, :to
 
-  def initialize(json:, metric:)
+  def initialize(json:, metric:, from:, to:)
     @metric = metric
     @json = json.to_h.with_indifferent_access
-  end
-
-  def from
-    json.values.flatten.first[:date]
-  end
-
-  def to
-    json.values.flatten.last[:date]
+    @from = from
+    @to = to
   end
 
   def has_values?

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,7 +1,8 @@
 class SingleContentItemPresenter
   attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
     :pageviews_series, :base_path, :title, :published_at, :last_updated,
-    :publishing_organisation, :document_type
+    :publishing_organisation, :document_type, :number_of_internal_searches,
+    :number_of_internal_searches_series
 
   def self.parse_metrics(metrics)
     new.parse_metrics(metrics.deep_symbolize_keys)
@@ -16,12 +17,14 @@ class SingleContentItemPresenter
     @last_updated = format_date metrics[:public_updated_at]
     @publishing_organisation = metrics[:primary_organisation_title]
     @document_type = metrics[:document_type].tr('_', ' ').capitalize
+    @number_of_internal_searches = metrics[:number_of_internal_searches]
     self
   end
 
   def parse_time_series(time_series)
     @unique_pageviews_series = ChartPresenter.new(json: time_series, metric: :unique_pageviews)
     @pageviews_series = ChartPresenter.new(json: time_series, metric: :pageviews)
+    @number_of_internal_searches_series = ChartPresenter.new(json: time_series, metric: :number_of_internal_searches)
     self
   end
 

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -4,8 +4,13 @@ class SingleContentItemPresenter
     :publishing_organisation, :document_type, :number_of_internal_searches,
     :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series
 
-  def self.parse_metrics(metrics)
-    new.parse_metrics(metrics.deep_symbolize_keys)
+  def initialize(from, to)
+    @from = from
+    @to = to
+  end
+
+  def self.parse_metrics(metrics:, from:, to:)
+    new(from, to).parse_metrics(metrics.deep_symbolize_keys)
   end
 
   def parse_metrics(metrics)
@@ -23,14 +28,20 @@ class SingleContentItemPresenter
   end
 
   def parse_time_series(time_series)
-    @unique_pageviews_series = ChartPresenter.new(json: time_series, metric: :unique_pageviews)
-    @pageviews_series = ChartPresenter.new(json: time_series, metric: :pageviews)
-    @number_of_internal_searches_series = ChartPresenter.new(json: time_series, metric: :number_of_internal_searches)
-    @satisfaction_score_series = ChartPresenter.new(json: time_series, metric: :satisfaction_score)
+    @unique_pageviews_series = get_chart_presenter(time_series, :unique_pageviews)
+    @pageviews_series = get_chart_presenter(time_series, :pageviews)
+    @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
+    @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
     self
   end
 
 private
+
+  attr_reader :from, :to
+
+  def get_chart_presenter(time_series, metric)
+    ChartPresenter.new(json: time_series, metric: metric, from: from, to: to)
+  end
 
   def format_date(date_str)
     Date.parse(date_str).strftime('%-d %B %Y')

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -2,7 +2,7 @@ class SingleContentItemPresenter
   attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
     :pageviews_series, :base_path, :title, :published_at, :last_updated,
     :publishing_organisation, :document_type, :number_of_internal_searches,
-    :number_of_internal_searches_series
+    :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series
 
   def self.parse_metrics(metrics)
     new.parse_metrics(metrics.deep_symbolize_keys)
@@ -18,6 +18,7 @@ class SingleContentItemPresenter
     @publishing_organisation = metrics[:primary_organisation_title]
     @document_type = metrics[:document_type].tr('_', ' ').capitalize
     @number_of_internal_searches = metrics[:number_of_internal_searches]
+    @satisfaction_score = metrics[:satisfaction_score]
     self
   end
 
@@ -25,6 +26,7 @@ class SingleContentItemPresenter
     @unique_pageviews_series = ChartPresenter.new(json: time_series, metric: :unique_pageviews)
     @pageviews_series = ChartPresenter.new(json: time_series, metric: :pageviews)
     @number_of_internal_searches_series = ChartPresenter.new(json: time_series, metric: :number_of_internal_searches)
+    @satisfaction_score_series = ChartPresenter.new(json: time_series, metric: :satisfaction_score)
     self
   end
 

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -2,7 +2,8 @@ require 'gds_api/content_data_api'
 
 class MetricsService
   DEFAULT_METRICS = %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score].freeze
-  def fetch(base_path:, from:, to:)
+
+  def fetch_aggregated_data(base_path:, from:, to:)
     url = api.request_url(base_path: base_path, from: from, to: to, metrics: DEFAULT_METRICS)
     api.client.get_json(url).to_hash
   end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -1,13 +1,14 @@
 require 'gds_api/content_data_api'
 
 class MetricsService
-  def fetch(base_path:, from:, to:, metrics:)
-    url = api.request_url(base_path: base_path, from: from, to: to, metrics: metrics)
+  DEFAULT_METRICS = %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score].freeze
+  def fetch(base_path:, from:, to:)
+    url = api.request_url(base_path: base_path, from: from, to: to, metrics: DEFAULT_METRICS)
     api.client.get_json(url).to_hash
   end
 
-  def fetch_time_series(base_path:, from:, to:, metrics:)
-    url = api.time_series_request_url(base_path: base_path, from: from, to: to, metrics: metrics)
+  def fetch_time_series(base_path:, from:, to:)
+    url = api.time_series_request_url(base_path: base_path, from: from, to: to, metrics: DEFAULT_METRICS)
     api.client.get_json(url).to_hash
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
     <% end %>
 
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      <%#= render "govuk_publishing_components/components/title", title: yield(:title) %>
+      <%= render "govuk_publishing_components/components/title", title: yield(:title) %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/metrics/_chart.html.erb
+++ b/app/views/metrics/_chart.html.erb
@@ -1,5 +1,7 @@
 <% if series.has_values? %>
-  <%= render "components/chart", series.chart_data %>
+  <div class="chart <%= series.metric %>">
+    <%= render "components/chart", series.chart_data %>
+  </div>
 <% else %>
   <div><%= series.no_data_message %></div>
 <% end %>

--- a/app/views/metrics/_chart.html.erb
+++ b/app/views/metrics/_chart.html.erb
@@ -1,0 +1,5 @@
+<% if series.has_values? %>
+  <%= render "components/chart", series.chart_data %>
+<% else %>
+  <div><%= series.no_data_message %></div>
+<% end %>

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -1,0 +1,4 @@
+<h3><%= title %></h3>
+<div class="aggregated-value">
+  <%= value %>
+</div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -10,13 +10,13 @@
 </div>
 
 <h2>Performance</h2>
-<%= render partial: 'metric_header', locals: {title: 'Unique Pageviews', value: @summary.unique_pageviews } %>
+<%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews  %>
 <%= render_chart @summary.unique_pageviews_series %>
-<%= render partial: 'metric_header', locals: { title: 'Pageviews', value: @summary.pageviews } %>
+<%= render 'metric_header',  title: 'Pageviews', value: @summary.pageviews  %>
 <%= render_chart @summary.pageviews_series %>
-<%= render partial: 'metric_header', locals: { title: 'Searches from the page', value: @summary.number_of_internal_searches } %>
+<%= render 'metric_header',  title: 'Searches from the page', value: @summary.number_of_internal_searches  %>
 <%= render_chart @summary.number_of_internal_searches_series %>
 
 <h2>Feedback</h2>
-<%= render partial: 'metric_header', locals: { title: 'User satisfaction score', value: @summary.satisfaction_score } %>
+<%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score  %>
 <%= render_chart @summary.satisfaction_score_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -10,13 +10,21 @@
 </div>
 
 <h2>Performance</h2>
-<%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews  %>
+<div class="metric_summary unique_pageviews">
+  <%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews %>
+</div>
 <%= render_chart @summary.unique_pageviews_series %>
-<%= render 'metric_header',  title: 'Pageviews', value: @summary.pageviews  %>
+<div class="metric_summary pageviews">
+  <%= render 'metric_header', title: 'Pageviews', value: @summary.pageviews %>
+</div>
 <%= render_chart @summary.pageviews_series %>
-<%= render 'metric_header',  title: 'Searches from the page', value: @summary.number_of_internal_searches  %>
+<div class="metric_summary number_of_internal_searches">
+  <%= render 'metric_header', title: 'Searches from the page', value: @summary.number_of_internal_searches %>
+</div>
 <%= render_chart @summary.number_of_internal_searches_series %>
 
 <h2>Feedback</h2>
-<%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score  %>
+<div class="metric_summary satisfaction_score">
+  <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
+</div>
 <%= render_chart @summary.satisfaction_score_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -13,18 +13,18 @@
 <div class="metric_summary unique_pageviews">
   <%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews %>
 </div>
-<%= render_chart @summary.unique_pageviews_series %>
+<%= render 'chart', series: @summary.unique_pageviews_series %>
 <div class="metric_summary pageviews">
   <%= render 'metric_header', title: 'Pageviews', value: @summary.pageviews %>
 </div>
-<%= render_chart @summary.pageviews_series %>
+<%= render 'chart', series: @summary.pageviews_series %>
 <div class="metric_summary number_of_internal_searches">
   <%= render 'metric_header', title: 'Searches from the page', value: @summary.number_of_internal_searches %>
 </div>
-<%= render_chart @summary.number_of_internal_searches_series %>
+<%= render 'chart', series: @summary.number_of_internal_searches_series %>
 
 <h2>Feedback</h2>
 <div class="metric_summary satisfaction_score">
   <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
 </div>
-<%= render_chart @summary.satisfaction_score_series %>
+<%= render 'chart', series: @summary.satisfaction_score_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -2,15 +2,15 @@
 <h2>Page Data</h2>
 <h1><%= @summary.title %></h1>
 <div class="page-metadata">
-  <%= render :partial => 'metadata_row', locals: { label: 'Published', value: @summary.published_at } %>
-  <%= render :partial => 'metadata_row', locals: { label: 'Last updated', value: @summary.last_updated } %>
-  <%= render :partial => 'metadata_row', locals: {label: 'From', value:  @summary.publishing_organisation } %>
-  <%= render :partial => 'metadata_row', locals: {label: 'Type', value:  @summary.document_type } %>
-  <%= render :partial => 'metadata_row', locals: {label: 'URL', value:  @summary.base_path } %>
+  <%= render partial: 'metadata_row', locals: { label: 'Published', value: @summary.published_at } %>
+  <%= render partial: 'metadata_row', locals: { label: 'Last updated', value: @summary.last_updated } %>
+  <%= render partial: 'metadata_row', locals: { label: 'From', value: @summary.publishing_organisation } %>
+  <%= render partial: 'metadata_row', locals: { label: 'Type', value: @summary.document_type } %>
+  <%= render partial: 'metadata_row', locals: { label: 'URL', value: @summary.base_path } %>
 </div>
 
-Unique Pageviews: <%= @summary.unique_pageviews %>
+<h2>Performance</h2>
+<%= render partial: 'metric_header', locals: {title: 'Unique Pageviews', value: @summary.unique_pageviews } %>
 <%= render_chart @summary.unique_pageviews_series %>
-
-Pageviews: <%= @summary.pageviews %>
+<%= render partial: 'metric_header', locals: { title: 'Pageviews', value: @summary.pageviews } %>
 <%= render_chart @summary.pageviews_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -14,3 +14,5 @@
 <%= render_chart @summary.unique_pageviews_series %>
 <%= render partial: 'metric_header', locals: { title: 'Pageviews', value: @summary.pageviews } %>
 <%= render_chart @summary.pageviews_series %>
+<%= render partial: 'metric_header', locals: { title: 'Searches from the page', value: @summary.number_of_internal_searches } %>
+<%= render_chart @summary.number_of_internal_searches_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "Page Data: #{@summary.title}" %>
 <h2>Page Data</h2>
-<h1><%= @summary.title %></h1>
+<h1 class="content-title"><%= @summary.title %></h1>
 <div class="page-metadata">
   <%= render partial: 'metadata_row', locals: { label: 'Published', value: @summary.published_at } %>
   <%= render partial: 'metadata_row', locals: { label: 'Last updated', value: @summary.last_updated } %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -16,3 +16,7 @@
 <%= render_chart @summary.pageviews_series %>
 <%= render partial: 'metric_header', locals: { title: 'Searches from the page', value: @summary.number_of_internal_searches } %>
 <%= render_chart @summary.number_of_internal_searches_series %>
+
+<h2>Feedback</h2>
+<%= render partial: 'metric_header', locals: { title: 'User satisfaction score', value: @summary.satisfaction_score } %>
+<%= render_chart @summary.satisfaction_score_series %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -2,11 +2,11 @@
 <h2>Page Data</h2>
 <h1 class="content-title"><%= @summary.title %></h1>
 <div class="page-metadata">
-  <%= render partial: 'metadata_row', locals: { label: 'Published', value: @summary.published_at } %>
-  <%= render partial: 'metadata_row', locals: { label: 'Last updated', value: @summary.last_updated } %>
-  <%= render partial: 'metadata_row', locals: { label: 'From', value: @summary.publishing_organisation } %>
-  <%= render partial: 'metadata_row', locals: { label: 'Type', value: @summary.document_type } %>
-  <%= render partial: 'metadata_row', locals: { label: 'URL', value: @summary.base_path } %>
+  <%= render 'metadata_row', label: 'Published', value: @summary.published_at %>
+  <%= render 'metadata_row', label: 'Last updated', value: @summary.last_updated %>
+  <%= render 'metadata_row', label: 'From', value: @summary.publishing_organisation %>
+  <%= render 'metadata_row', label: 'Type', value: @summary.document_type %>
+  <%= render 'metadata_row', label: 'URL', value: @summary.base_path %>
 </div>
 
 <h2>Performance</h2>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
           first_published_at: '2018-02-01T00:00:00.000Z',
           public_updated_at: '2018-04-25T00:00:00.000Z',
           primary_organisation_title: 'The ministry',
-          document_type: "news_story"
+          document_type: "news_story",
+          number_of_internal_searches: 250
         })
 
       content_data_api_has_timeseries(base_path: 'base/path',
@@ -32,9 +33,13 @@ RSpec.describe '/metrics/base/path', type: :feature do
             { "date" => "2018-01-13", "value" => 10 },
             { "date" => "2018-01-14", "value" => 20 },
             { "date" => "2018-01-15", "value" => 30 }
+          ],
+          number_of_internal_searches: [
+            { "date" => "2018-01-13", "value" => 5 },
+            { "date" => "2018-01-14", "value" => 12 },
+            { "date" => "2018-01-15", "value" => 10 }
           ]
         })
-
       visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
     end
 
@@ -44,6 +49,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric for pageviews' do
       expect(page).to have_content('200000')
+    end
+
+    it 'renders a metric for on page searches' do
+      expect(page).to have_content('250')
     end
 
     it 'renders the page title' do
@@ -84,6 +93,16 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(pageviews_rows[2].text).to eq '01-14 20'
       expect(pageviews_rows[3].text).to eq '01-15 30'
     end
+
+    it 'renders the metric timeseries for on-page searches' do
+      click_on 'Number of internal searches table'
+      internal_searches_rows = find("#number_of_internal_searches_2018-01-13-2018-01-15_table").all('tr')
+      expect(internal_searches_rows.count).to eq 4
+      expect(internal_searches_rows[0].text).to eq ''
+      expect(internal_searches_rows[1].text).to eq '01-13 5'
+      expect(internal_searches_rows[2].text).to eq '01-14 12'
+      expect(internal_searches_rows[3].text).to eq '01-15 10'
+    end
   end
 
   context 'when the data-api has an error' do
@@ -92,7 +111,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
         from: '2000-01-01',
         to: '2050-01-01',
         metrics: %w[number_of_internal_searches pageviews unique_pageviews])
-
       visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
       expect(page.status_code).to eq(404)
       expect(page).to have_content "The page you were looking for doesn't exist."

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
+  include MetricsChartSpecHelpers
   let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
   context 'successful request' do
     before do
@@ -84,9 +85,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for unique_pageviews' do
       click_on 'Unique pageviews table'
-      unique_pageviews_rows = find("#unique_pageviews_2000-01-01-2050-01-01_table").all('tr').map do |el|
-        el.all('th,td').map(&:text)
-      end
+      unique_pageviews_rows = extract_table_content("#unique_pageviews_2000-01-01-2050-01-01_table")
       expect(unique_pageviews_rows).to match_array([
         ['', ''],
         ['01-13', '101'],
@@ -97,9 +96,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for pageviews' do
       click_on 'Pageviews table'
-      pageviews_rows = find("#pageviews_2000-01-01-2050-01-01_table").all('tr').map do |el|
-        el.all('th,td').map(&:text)
-      end
+      pageviews_rows = extract_table_content("#pageviews_2000-01-01-2050-01-01_table")
 
       expect(pageviews_rows).to match_array([
         ['', ''],
@@ -111,9 +108,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for on-page searches' do
       click_on 'Number of internal searches table'
-      internal_searches_rows = find("#number_of_internal_searches_2000-01-01-2050-01-01_table").all('tr').map do |el|
-        el.all('th,td').map(&:text)
-      end
+      internal_searches_rows = extract_table_content("#number_of_internal_searches_2000-01-01-2050-01-01_table")
 
       expect(internal_searches_rows).to match_array([
         ['', ''],
@@ -125,9 +120,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for satisfaction_score' do
       click_on 'Number of internal searches table'
-      satisfaction_score_rows = find("#satisfaction_score_2000-01-01-2050-01-01_table").all('tr').map do |el|
-        el.all('th,td').map(&:text)
-      end
+      satisfaction_score_rows = extract_table_content("#satisfaction_score_2000-01-01-2050-01-01_table")
 
       expect(satisfaction_score_rows).to match_array([
         ['', ''],

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,11 +1,12 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
+  let(:metrics) { MetricsService::DEFAULT_METRICS }
   context 'successful request' do
     before do
       content_data_api_has_metric(base_path: 'base/path',
         from: '2000-01-01',
         to: '2050-01-01',
-        metrics: %w[number_of_internal_searches pageviews unique_pageviews],
+        metrics: metrics,
         payload: {
           base_path: '/base/path',
           unique_pageviews: 145_000,
@@ -22,7 +23,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       content_data_api_has_timeseries(base_path: 'base/path',
         from: '2000-01-01',
         to: '2050-01-01',
-        metrics: %w[number_of_internal_searches pageviews unique_pageviews],
+        metrics: metrics,
         payload: {
           unique_pageviews: [
             { "date" => "2018-01-13", "value" => 101 },
@@ -135,7 +136,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       content_data_api_does_not_have_base_path(base_path: 'base/path',
         from: '2000-01-01',
         to: '2050-01-01',
-        metrics: %w[number_of_internal_searches pageviews unique_pageviews])
+        metrics: metrics)
       visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
       expect(page.status_code).to eq(404)
       expect(page).to have_content "The page you were looking for doesn't exist."

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for unique_pageviews' do
       click_on 'Unique pageviews table'
-      unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr').map do |el|
+      unique_pageviews_rows = find("#unique_pageviews_2000-01-01-2050-01-01_table").all('tr').map do |el|
         el.all('th,td').map(&:text)
       end
       expect(unique_pageviews_rows).to match_array([
@@ -97,7 +97,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for pageviews' do
       click_on 'Pageviews table'
-      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr').map do |el|
+      pageviews_rows = find("#pageviews_2000-01-01-2050-01-01_table").all('tr').map do |el|
         el.all('th,td').map(&:text)
       end
 
@@ -111,7 +111,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for on-page searches' do
       click_on 'Number of internal searches table'
-      internal_searches_rows = find("#number_of_internal_searches_2018-01-13-2018-01-15_table").all('tr').map do |el|
+      internal_searches_rows = find("#number_of_internal_searches_2000-01-01-2050-01-01_table").all('tr').map do |el|
         el.all('th,td').map(&:text)
       end
 
@@ -125,7 +125,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for satisfaction_score' do
       click_on 'Number of internal searches table'
-      satisfaction_score_rows = find("#satisfaction_score_2018-01-13-2018-01-15_table").all('tr').map do |el|
+      satisfaction_score_rows = find("#satisfaction_score_2000-01-01-2050-01-01_table").all('tr').map do |el|
         el.all('th,td').map(&:text)
       end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
-  let(:metrics) { MetricsService::DEFAULT_METRICS }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
   context 'successful request' do
     before do
       content_data_api_has_metric(base_path: 'base/path',

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
-
   context 'successful request' do
     before do
       content_data_api_has_metric(base_path: 'base/path',
@@ -16,7 +15,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
           public_updated_at: '2018-04-25T00:00:00.000Z',
           primary_organisation_title: 'The ministry',
           document_type: "news_story",
-          number_of_internal_searches: 250
+          number_of_internal_searches: 250,
+          satisfaction_score: 25.5
         })
 
       content_data_api_has_timeseries(base_path: 'base/path',
@@ -38,6 +38,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
             { "date" => "2018-01-13", "value" => 5 },
             { "date" => "2018-01-14", "value" => 12 },
             { "date" => "2018-01-15", "value" => 10 }
+          ],
+          satisfaction_score: [
+            { "date" => "2018-01-13", "value" => 30.3 },
+            { "date" => "2018-01-14", "value" => 20.3 },
+            { "date" => "2018-01-15", "value" => 40.1 }
           ]
         })
       visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
@@ -49,6 +54,14 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric for pageviews' do
       expect(page).to have_content('200000')
+    end
+
+    it 'renders a metric for satisfaction_score' do
+      expect(page).to have_content('25.5')
+    end
+
+    it 'renders the page title' do
+      expect(page).to have_content('Content Title')
     end
 
     it 'renders a metric for on page searches' do
@@ -97,11 +110,23 @@ RSpec.describe '/metrics/base/path', type: :feature do
     it 'renders the metric timeseries for on-page searches' do
       click_on 'Number of internal searches table'
       internal_searches_rows = find("#number_of_internal_searches_2018-01-13-2018-01-15_table").all('tr')
+
       expect(internal_searches_rows.count).to eq 4
       expect(internal_searches_rows[0].text).to eq ''
       expect(internal_searches_rows[1].text).to eq '01-13 5'
       expect(internal_searches_rows[2].text).to eq '01-14 12'
       expect(internal_searches_rows[3].text).to eq '01-15 10'
+    end
+
+    it 'renders the metric timeseries for satisfaction_score' do
+      click_on 'Number of internal searches table'
+      satisfaction_score_rows = find("#satisfaction_score_2018-01-13-2018-01-15_table").all('tr')
+
+      expect(satisfaction_score_rows.count).to eq 4
+      expect(satisfaction_score_rows[0].text).to eq ''
+      expect(satisfaction_score_rows[1].text).to eq '01-13 30.3'
+      expect(satisfaction_score_rows[2].text).to eq '01-14 20.3'
+      expect(satisfaction_score_rows[3].text).to eq '01-15 40.1'
     end
   end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -88,46 +88,57 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for unique_pageviews' do
       click_on 'Unique pageviews table'
-      unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr')
-
-      expect(unique_pageviews_rows.count).to eq 4
-      expect(unique_pageviews_rows[0].text).to eq ''
-      expect(unique_pageviews_rows[1].text).to eq '01-13 101'
-      expect(unique_pageviews_rows[2].text).to eq '01-14 202'
-      expect(unique_pageviews_rows[3].text).to eq '01-15 303'
+      unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr').map do |el|
+        el.all('th,td').map(&:text)
+      end
+      expect(unique_pageviews_rows).to match_array([
+        ['', ''],
+        ['01-13', '101'],
+        ['01-14', '202'],
+        ['01-15', '303']
+      ])
     end
 
     it 'renders the metric timeseries for pageviews' do
       click_on 'Pageviews table'
-      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
+      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr').map do |el|
+        el.all('th,td').map(&:text)
+      end
 
-      expect(pageviews_rows.count).to eq 4
-      expect(pageviews_rows[0].text).to eq ''
-      expect(pageviews_rows[1].text).to eq '01-13 10'
-      expect(pageviews_rows[2].text).to eq '01-14 20'
-      expect(pageviews_rows[3].text).to eq '01-15 30'
+      expect(pageviews_rows).to match_array([
+        ['', ''],
+        ['01-13', '10'],
+        ['01-14', '20'],
+        ['01-15', '30']
+      ])
     end
 
     it 'renders the metric timeseries for on-page searches' do
       click_on 'Number of internal searches table'
-      internal_searches_rows = find("#number_of_internal_searches_2018-01-13-2018-01-15_table").all('tr')
+      internal_searches_rows = find("#number_of_internal_searches_2018-01-13-2018-01-15_table").all('tr').map do |el|
+        el.all('th,td').map(&:text)
+      end
 
-      expect(internal_searches_rows.count).to eq 4
-      expect(internal_searches_rows[0].text).to eq ''
-      expect(internal_searches_rows[1].text).to eq '01-13 5'
-      expect(internal_searches_rows[2].text).to eq '01-14 12'
-      expect(internal_searches_rows[3].text).to eq '01-15 10'
+      expect(internal_searches_rows).to match_array([
+        ['', ''],
+        ['01-13', '5'],
+        ['01-14', '12'],
+        ['01-15', '10']
+      ])
     end
 
     it 'renders the metric timeseries for satisfaction_score' do
       click_on 'Number of internal searches table'
-      satisfaction_score_rows = find("#satisfaction_score_2018-01-13-2018-01-15_table").all('tr')
+      satisfaction_score_rows = find("#satisfaction_score_2018-01-13-2018-01-15_table").all('tr').map do |el|
+        el.all('th,td').map(&:text)
+      end
 
-      expect(satisfaction_score_rows.count).to eq 4
-      expect(satisfaction_score_rows[0].text).to eq ''
-      expect(satisfaction_score_rows[1].text).to eq '01-13 30.3'
-      expect(satisfaction_score_rows[2].text).to eq '01-14 20.3'
-      expect(satisfaction_score_rows[3].text).to eq '01-15 40.1'
+      expect(satisfaction_score_rows).to match_array([
+        ['', ''],
+        ['01-13', '30.3'],
+        ['01-14', '20.3'],
+        ['01-15', '40.1']
+      ])
     end
   end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for unique_pageviews' do
       click_on 'Unique pageviews table'
-      unique_pageviews_rows = extract_table_content("#unique_pageviews_2000-01-01-2050-01-01_table")
+      unique_pageviews_rows = extract_table_content(".chart.unique_pageviews table")
       expect(unique_pageviews_rows).to match_array([
         ['', ''],
         ['01-13', '101'],
@@ -96,7 +96,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for pageviews' do
       click_on 'Pageviews table'
-      pageviews_rows = extract_table_content("#pageviews_2000-01-01-2050-01-01_table")
+      pageviews_rows = extract_table_content(".chart.pageviews table")
 
       expect(pageviews_rows).to match_array([
         ['', ''],
@@ -108,7 +108,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for on-page searches' do
       click_on 'Number of internal searches table'
-      internal_searches_rows = extract_table_content("#number_of_internal_searches_2000-01-01-2050-01-01_table")
+      internal_searches_rows = extract_table_content(".chart.number_of_internal_searches table")
 
       expect(internal_searches_rows).to match_array([
         ['', ''],
@@ -120,7 +120,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders the metric timeseries for satisfaction_score' do
       click_on 'Number of internal searches table'
-      satisfaction_score_rows = extract_table_content("#satisfaction_score_2000-01-01-2050-01-01_table")
+      satisfaction_score_rows = extract_table_content(".chart.satisfaction_score table")
 
       expect(satisfaction_score_rows).to match_array([
         ['', ''],

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -66,13 +66,17 @@ RSpec.describe '/metrics/base/path', type: :feature do
     it 'renders the metric timeseries for unique_pageviews' do
       click_on 'Unique pageviews table'
       unique_pageviews_rows = find("#unique_pageviews_2018-01-13-2018-01-15_table").all('tr')
-      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
 
       expect(unique_pageviews_rows.count).to eq 4
       expect(unique_pageviews_rows[0].text).to eq ''
       expect(unique_pageviews_rows[1].text).to eq '01-13 101'
       expect(unique_pageviews_rows[2].text).to eq '01-14 202'
       expect(unique_pageviews_rows[3].text).to eq '01-15 303'
+    end
+
+    it 'renders the metric timeseries for pageviews' do
+      click_on 'Pageviews table'
+      pageviews_rows = find("#pageviews_2018-01-13-2018-01-15_table").all('tr')
 
       expect(pageviews_rows.count).to eq 4
       expect(pageviews_rows[0].text).to eq ''
@@ -88,6 +92,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         from: '2000-01-01',
         to: '2050-01-01',
         metrics: %w[number_of_internal_searches pageviews unique_pageviews])
+
       visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
       expect(page.status_code).to eq(404)
       expect(page).to have_content "The page you were looking for doesn't exist."

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -50,15 +50,15 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metric for unique_pageviews' do
-      expect(page).to have_content('145000')
+      expect(page).to have_selector '.metric_summary.unique_pageviews', text: '145000'
     end
 
     it 'renders the metric for pageviews' do
-      expect(page).to have_content('200000')
+      expect(page).to have_selector '.metric_summary.pageviews', text: '200000'
     end
 
     it 'renders a metric for satisfaction_score' do
-      expect(page).to have_content('25.5')
+      expect(page).to have_selector '.metric_summary.satisfaction_score', text: '25.5'
     end
 
     it 'renders the page title' do
@@ -66,7 +66,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders a metric for on page searches' do
-      expect(page).to have_content('250')
+      expect(page).to have_selector '.metric_summary.number_of_internal_searches', text: '250'
     end
 
     it 'renders the page title' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -149,4 +149,44 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_content "The page you were looking for doesn't exist."
     end
   end
+
+  context 'no time series from the data-api' do
+    before do
+      content_data_api_has_metric(base_path: 'base/path',
+        from: '2000-01-01',
+        to: '2050-01-01',
+        metrics: metrics,
+        payload: {
+          base_path: '/base/path',
+          title: "Content Title",
+          first_published_at: '2018-02-01T00:00:00.000Z',
+          public_updated_at: '2018-04-25T00:00:00.000Z',
+          primary_organisation_title: 'The ministry',
+          document_type: "news_story",
+          number_of_internal_searches: 250,
+          satisfaction_score: 25.5
+        })
+
+      content_data_api_has_timeseries(base_path: 'base/path',
+        from: '2000-01-01',
+        to: '2050-01-01',
+        metrics: metrics,
+        payload: {
+          unique_pageviews: [],
+        })
+      visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
+    end
+
+    it 'renders a div to indicate no data when empty' do
+      expect(page).not_to have_content('Unique pageviews table')
+      expect(page).to have_selector 'div',
+        text: 'No Unique pageviews data for the selected time period'
+    end
+
+    it 'renders a div to indicate no data when missing' do
+      expect(page).not_to have_content('Pageviews table')
+      expect(page).to have_selector 'div',
+        text: 'No Pageviews data for the selected time period'
+    end
+  end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -62,15 +62,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the page title' do
-      expect(page).to have_content('Content Title')
+      expect(page).to have_selector '.content-title', text: 'Content Title'
     end
 
     it 'renders a metric for on page searches' do
       expect(page).to have_selector '.metric_summary.number_of_internal_searches', text: '250'
-    end
-
-    it 'renders the page title' do
-      expect(page).to have_content('Content Title')
     end
 
     it 'renders the metadata' do

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -28,6 +28,10 @@ RSpec.describe ChartPresenter do
     expect(subject.human_friendly_metric).to eq 'Unique pageviews'
   end
 
+  it 'returns the correct message for no data' do
+    expect(subject.no_data_message).to eq 'No Unique pageviews data for the selected time period'
+  end
+
   it 'returns formatted hash of chart data' do
     expect(subject.chart_data).to eq unique_pageviews_chart_data
   end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe ChartPresenter do
+  let(:from) { '2018-01-13' }
+  let(:to) { '2018-01-15' }
   subject do
     ChartPresenter.new(
       json:
@@ -9,7 +11,9 @@ RSpec.describe ChartPresenter do
             { date: '2018-01-15', value: 303 }
           ]
         },
-      metric: 'unique_pageviews'
+      metric: 'unique_pageviews',
+      from: from,
+      to: to
     )
   end
 

--- a/spec/support/metrics_chart_spec_helpers.rb
+++ b/spec/support/metrics_chart_spec_helpers.rb
@@ -1,0 +1,7 @@
+module MetricsChartSpecHelpers
+  def extract_table_content(css_selector)
+    find(css_selector).all('tr').map do |el|
+      el.all('th,td').map(&:text)
+    end
+  end
+end


### PR DESCRIPTION
Add metric summary/chart for 

* number_of_internal_searches
* satisfaction_score

Also removed the unnecessary `metrics` parameter from the route as we don't need to configure which metrics we are showing and having to specify them is making it really annoying to test.