### PR TITLE
Add metadata component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,3 +7,4 @@ $govuk-global-styles: true;
 @import "components/chart";
 @import "components/glance-metric";
 @import "components/info-metric";
+@import "components/metadata";

--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,0 +1,20 @@
+.app-c-metadata__title {
+  @include grid-column( 1 / 5);
+  padding: 0;
+  margin: 0;
+
+  @include media-down(mobile) {
+    @include grid-column( 1 / 4, mobile );
+    padding: 0;
+    margin: 0;
+  }
+}
+
+.app-c-metadata__description {
+
+  @include media-down(mobile) {
+    @include grid-column( 3 / 4, mobile );
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,0 +1,31 @@
+<%
+    published_at ||= ""
+    last_updated ||= ""
+    publishing_organisation ||= ""
+    document_type ||= ""
+    base_path ||= ""
+    status ||= ""
+%>
+
+<div class="app-c-metadata govuk-body govuk-body-xs">
+  <% if status != "" %>
+    <dl class="app-c-metadata__list">
+      <dt class="app-c-metadata__title">Status</dt>
+      <dd class="app-c-metadata__description govuk-!-font-weight-bold"><%= status %></dd>
+    </dl>
+  <% end %>
+  <dl class="app-c-metadata__list">
+    <dt class="app-c-metadata__title">Published</dt>
+    <dd class="app-c-metadata__description"><%= published_at %></dd>
+    <dt class="app-c-metadata__title">Last updated</dt>
+    <dd class="app-c-metadata__description"><%= last_updated %></dd>
+  </dl>
+  <dl class="app-c-metadata__list">
+    <dt class="app-c-metadata__title">From</dt>
+    <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>
+    <dt class="app-c-metadata__title">Type</dt>
+    <dd class="app-c-metadata__description"><%= document_type %></dd>
+    <dt class="app-c-metadata__title">URL</dt>
+    <dd class="app-c-metadata__description"><% if base_path != "" %>/.../<%= base_path.split("/")[-1] %><% end %></dd>
+  </dl>
+</div>

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -1,0 +1,25 @@
+name: "Metadata"
+description: "The metadata component shows defined metadata about a content item"
+part_of_admin_layout: true
+body: "This is a simple component that shows defined data about a content item in three lists with a specified order: Status, date info, and other metadata. The first of these is conditional on a relevant status being passed in."
+
+accessibility_criteria: |
+  - All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+examples:
+  default:
+    data:
+      status: "withdrawn"
+      published_at: "1 September 2016"
+      last_updated: "1 October 2017"
+      publishing_organisation: "UK Visas and Immigration"
+      document_type: "Guidance"
+      base_path: "/government/publications/visitor-visa-guide-to-supporting-documents"
+  without_status:
+    description: Without a status
+    data:
+      published_at: "1 September 2016"
+      last_updated: "1 October 2017"
+      publishing_organisation: "UK Visas and Immigration"
+      document_type: "Guidance"
+      base_path: "/government/publications/visitor-visa-guide-to-supporting-documents"

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,13 +1,37 @@
 <%= content_for :title, "Dev page" %>
 
-<span class="govuk-caption-xl">Data analytics for</span>
-<h1 class="govuk-heading-xl">The page being analysed</h1>
+<div class="govuk-grid-row">
+  <span class="govuk-caption-xl">Page data</span>
+  <div class="govuk-grid-column-two-thirds">
 
-<%= render "govuk_publishing_components/components/govspeak" do %>
-  <p>
-    Metrics were last updated yesterday at 00:00.
-  </p>
-<% end %>
+    <h1 class="govuk-heading-xl">The name of the page being analysed</h1>
+
+    <%= render "govuk_publishing_components/components/govspeak" do %>
+      <p>
+        Metrics were last updated yesterday at 00:00.
+      </p>
+    <% end %>
+
+    <%
+      metadata = {
+        status: "withdrawn",
+        published_at: "1 September 2016",
+        last_updated: "1 October 2017",
+        publishing_organisation: "UK Visas and Immigration",
+        document_type: "Guidance",
+        base_path: "/government/publications/visitor-visa-guide-to-supporting-documents",
+      }
+    %>
+    <%= render "components/metadata", metadata %>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    View the page on GOV.UK:
+    <a href="http://www.gov.uk/random">http://www.gov.uk/random</a>
+
+    Make changes to the page:
+    <a href="http://www.gov.uk/random">http://www.gov.uk/random</a>
+  </div>
+</div>
 
 <%
   # This data will come from models/controllers/the api eventually, hard coded for now to produce working views.
@@ -17,6 +41,7 @@
     table_label: "Unique page views table",
     chart_id: 'pageviews_jan_chart',
     table_id: 'pageviews_jan_table',
+    table_direction: 'vertical',
     keys: [*(1..30)],
     rows: [
       {

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe "Metadata", type: :view do
+  let(:data) {
+    {
+        status: "withdrawn",
+        published_at: "1 September 2016",
+        last_updated: "1 October 2017",
+        publishing_organisation: "UK Visas and Immigration",
+        document_type: "Guidance",
+        base_path: "/government/publications/visitor-visa-guide-to-supporting-documents",
+    }
+  }
+
+  it "renders correctly when given valid data" do
+    render_component(data)
+    assert_select ".app-c-metadata"
+    assert_select ".app-c-metadata__title", 6
+    assert_select ".app-c-metadata__title", text: "Status"
+    assert_select ".app-c-metadata__description", text: "withdrawn"
+    assert_select ".app-c-metadata__title", text: "Published"
+    assert_select ".app-c-metadata__description", text: "1 September 2016"
+    assert_select ".app-c-metadata__title", text: "Last updated"
+    assert_select ".app-c-metadata__description", text: "1 October 2017"
+    assert_select ".app-c-metadata__title", text: "From"
+    assert_select ".app-c-metadata__description", text: "UK Visas and Immigration"
+    assert_select ".app-c-metadata__title", text: "Type"
+    assert_select ".app-c-metadata__description", text: "Guidance"
+    assert_select ".app-c-metadata__title", text: "URL"
+    assert_select ".app-c-metadata__description", text: "/.../visitor-visa-guide-to-supporting-documents"
+  end
+
+  it "renders blank values for expected fields when data items aren't provided" do
+    data = false
+    render_component(data)
+    assert_select ".app-c-metadata__description", text: "", count: 5
+  end
+
+  it "does not render status info when a status is not supplied" do
+    data[:status] = false
+    render_component(data)
+    assert_select ".app-c-metadata__title", text: "Status", count: 0
+  end
+
+  def render_component(locals)
+    render partial: "components/metadata", locals: locals
+  end
+end


### PR DESCRIPTION
This adds the component for metadata. It expects the named parameters and whatever string is passed as each. Only status is optional. An example is included on the dev page:
http://http://content-data-admin.dev.gov.uk/dev

The docs are on the component guide page:
http://content-data-admin.dev.gov.uk/component-guide/metadata

Screenshot:

![screen shot 2018-09-12 at 13 46 43](https://user-images.githubusercontent.com/31649453/45425965-bc928700-b692-11e8-8bb9-af7cacd8a1b6.png)

Trello: https://trello.com/c/jx0D5HKF/670-2-implement-metadata-component