### PR TITLE
Hook up components

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,8 +1,9 @@
 class SingleContentItemPresenter
-  attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
-    :pageviews_series, :base_path, :title, :published_at, :last_updated,
-    :publishing_organisation, :document_type, :number_of_internal_searches,
-    :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series
+  attr_reader :unique_pageviews, :unique_pageviews_series,
+    :pageviews, :pageviews_series,
+    :number_of_internal_searches, :number_of_internal_searches_series,
+    :satisfaction_score, :satisfaction_score_series,
+    :metadata, :title
 
   def initialize(from, to)
     @from = from
@@ -16,14 +17,16 @@ class SingleContentItemPresenter
   def parse_metrics(metrics)
     @unique_pageviews = metrics[:unique_pageviews]
     @pageviews = metrics[:pageviews]
-    @base_path = metrics[:base_path]
-    @title = metrics[:title]
-    @published_at = format_date metrics[:first_published_at]
-    @last_updated = format_date metrics[:public_updated_at]
-    @publishing_organisation = metrics[:primary_organisation_title]
-    @document_type = metrics[:document_type].tr('_', ' ').capitalize
     @number_of_internal_searches = metrics[:number_of_internal_searches]
     @satisfaction_score = metrics[:satisfaction_score]
+    @title = metrics[:title]
+    @metadata = {
+      base_path: metrics[:base_path],
+      document_type: metrics[:document_type].tr('_', ' ').capitalize,
+      published_at: format_date(metrics[:first_published_at]),
+      last_updated: format_date(metrics[:public_updated_at]),
+      publishing_organisation: metrics[:primary_organisation_title],
+    }
     self
   end
 

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -1,4 +1,12 @@
-<h3><%= title %></h3>
-<div class="aggregated-value">
-  <%= value %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "components/info-metric", {
+        name: title,
+        figure: number_with_delimiter(value, delimiter: ','),
+        context: "Number of sessions during which the page was viewed at least once",
+        trend_percentage: 0,
+        period: "From previous 30 days",
+        about: "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent vestibulum quam vitae felis.</p><p>Data source: Google Analytics</p>".html_safe
+    } %>
+  </div>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -2,11 +2,7 @@
 <h2>Page Data</h2>
 <h1 class="content-title"><%= @summary.title %></h1>
 <div class="page-metadata">
-  <%= render 'metadata_row', label: 'Published', value: @summary.published_at %>
-  <%= render 'metadata_row', label: 'Last updated', value: @summary.last_updated %>
-  <%= render 'metadata_row', label: 'From', value: @summary.publishing_organisation %>
-  <%= render 'metadata_row', label: 'Type', value: @summary.document_type %>
-  <%= render 'metadata_row', label: 'URL', value: @summary.base_path %>
+  <%= render "components/metadata", @summary.metadata %>
 </div>
 
 <h2>Performance</h2>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -51,11 +51,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metric for unique_pageviews' do
-      expect(page).to have_selector '.metric_summary.unique_pageviews', text: '145000'
+      expect(page).to have_selector '.metric_summary.unique_pageviews', text: '145,000'
     end
 
     it 'renders the metric for pageviews' do
-      expect(page).to have_selector '.metric_summary.pageviews', text: '200000'
+      expect(page).to have_selector '.metric_summary.pageviews', text: '200,000'
     end
 
     it 'renders a metric for satisfaction_score' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
   let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
   context 'successful request' do
     before do
-      content_data_api_has_metric(base_path: 'base/path',
+      content_data_api_has_metric(base_path: 'base/path/with-slug',
         from: '2000-01-01',
         to: '2050-01-01',
         metrics: metrics,
         payload: {
-          base_path: '/base/path',
+          base_path: '/base/path/with-slug',
           unique_pageviews: 145_000,
           pageviews: 200_000,
           title: "Content Title",
@@ -21,7 +21,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
           satisfaction_score: 25.5
         })
 
-      content_data_api_has_timeseries(base_path: 'base/path',
+      content_data_api_has_timeseries(base_path: 'base/path/with-slug',
         from: '2000-01-01',
         to: '2050-01-01',
         metrics: metrics,
@@ -47,7 +47,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
             { "date" => "2018-01-15", "value" => 40.1 }
           ]
         })
-      visit '/metrics/base/path?from=2000-01-01&to=2050-01-01'
+      visit '/metrics/base/path/with-slug?from=2000-01-01&to=2050-01-01'
     end
 
     it 'renders the metric for unique_pageviews' do
@@ -71,15 +71,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metadata' do
-      metadata = find('.page-metadata').all('.metadata-row').map do |el|
-        el.all('.metadata-label,.metadata-value').map(&:text)
+      metadata = find('.page-metadata').all('dl').map do |el|
+        el.all('dt,dd').map(&:text)
       end
       expect(metadata).to eq([
-        ['Published', '1 February 2018'],
-        ['Last updated', '25 April 2018'],
-        ['From', 'The ministry'],
-        ['Type', 'News story'],
-        ['URL', '/base/path']
+        ['Published', '1 February 2018', 'Last updated', '25 April 2018'],
+        ['From', 'The ministry', 'Type', 'News story', 'URL', '/.../with-slug']
       ])
     end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe SingleContentItemPresenter do
+  let(:from) { '2018-01-01' }
+  let(:to) { '2018-06-01' }
+  let(:metrics) do
+    {
+      'title' => 'The title',
+      'base_path' => '/the/base/path',
+      'primary_organisation_title' => 'UK Visas and Immigration',
+      'first_published_at' => '2016-09-01T00:00:00.000Z',
+      'public_updated_at' => '2017-10-01T00:00:00.000Z',
+      'document_type' => 'news_story',
+      'unique_pageviews' => 2030,
+      'pageviews' => 3000,
+      'satisfaction_score' => 33.5,
+      'number_of_internal_searches' => 120,
+    }
+  end
+
+  subject do
+    SingleContentItemPresenter.parse_metrics(metrics: metrics,
+      from: from,
+      to: to)
+  end
+
+  describe '#metadata' do
+    it 'returns a hash with the metadata' do
+      expect(subject.metadata).to eq(
+        base_path: '/the/base/path',
+        published_at: "1 September 2016",
+        last_updated: "1 October 2017",
+        publishing_organisation: 'UK Visas and Immigration',
+        document_type: "News story",
+      )
+    end
+  end
+
+  it 'returns the aggregated metrics' do
+    expect(subject).to have_attributes(
+      unique_pageviews: 2030,
+      pageviews: 3000,
+      number_of_internal_searches: 120,
+      satisfaction_score: 33.5,
+    )
+  end
+
+  it 'returns the title' do
+    expect(subject.title).to eq('The title')
+  end
+end


### PR DESCRIPTION
This commit shows the data in the components we have so far.

The components we are now using:

* components/metadata
* components/info-metric
* components/chart

## Before
![before](https://user-images.githubusercontent.com/511319/45486036-9aac0980-b751-11e8-9ef8-efe54b76dc44.png)

## After
Stuff in green - real data
Stuff in red - placeholders
![after](https://user-images.githubusercontent.com/511319/45486404-e14e3380-b752-11e8-8089-6e0c4fa66579.png)

Url: http://content-data-admin.dev.gov.uk/metrics/check-mot-history?from=2018-01-01&to=2018-10-01