### PR TITLE
Add outline of index page at /content

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,0 +1,21 @@
+class ContentController < ApplicationController
+  def index
+    @content = get_content
+  end
+
+private
+
+  def get_content
+    response = metrics_service.content_summary(date_range: date_range,
+      organisation: params[:organisation])
+    @content = ContentItemsPresenter.new(response.deep_symbolize_keys[:results])
+  end
+
+  def metrics_service
+    @metrics_service ||= MetricsService.new
+  end
+
+  def date_range
+    DateRange.new(params[:date_range])
+  end
+end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -37,11 +37,13 @@ class ChartPresenter
   end
 
   def keys
+    return [] unless json[metric]
     dates = json[metric].map { |hash| hash['date'] }
     dates.map { |date| date.last(5) }
   end
 
   def values
+    return [] unless json[metric]
     json[metric].map { |hash| hash['value'] }
   end
 end

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,0 +1,7 @@
+class ContentItemsPresenter
+  attr_reader :items, :title
+  def initialize(content_items)
+    @items = content_items.map { |ci| ContentRowPresenter.new(ci) }
+    @title = 'Content Items'
+  end
+end

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,0 +1,19 @@
+class ContentRowPresenter
+  attr_reader :title, :base_path, :document_type, :unique_pageviews,
+              :user_satisfaction_score, :number_of_internal_searches
+  def initialize(data)
+    @title = data[:title]
+    @base_path = data[:base_path]
+    @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
+    @unique_pageviews = data[:unique_pageviews]
+    @user_satisfaction_score = format_satisfaction_score(data[:satisfaction_score], data[:satisfaction_score_responses])
+    @number_of_internal_searches = data[:number_of_internal_searches]
+  end
+
+private
+
+  def format_satisfaction_score(score, responses)
+    return 'No responses' unless score
+    "#{(score * 100).round(1)}% (#{responses} responses)"
+  end
+end

--- a/app/services/metrics_service.rb
+++ b/app/services/metrics_service.rb
@@ -13,9 +13,19 @@ class MetricsService
     api.client.get_json(url).to_hash
   end
 
+  def content_summary(date_range:, organisation:)
+    api_with_long_timeout.content_summary(from: date_range.from, to: date_range.to, organisation: organisation)
+  end
+
 private
 
   def api
     @api ||= GdsApi::ContentDataApi.new
+  end
+
+  def api_with_long_timeout
+    api.tap do |client|
+      client.options[:timeout] = 30
+    end
   end
 end

--- a/app/views/content/_content_row.html.erb
+++ b/app/views/content/_content_row.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td><%= item.title %>
+    <span class="base-path"><%= item.base_path %></span>
+  </td>
+  <td><%= item.document_type %></td>
+  <td><%= number_with_delimiter(item.unique_pageviews, delimiter: ',') %></td>
+  <td><%= item.user_satisfaction_score %></td>
+  <td><%= item.number_of_internal_searches %></td>
+</tr>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -1,0 +1,14 @@
+<% content_for :title, @content.title %>
+<h3>Content data</h3>
+<div class="content-table">
+  <table>
+    <tr>
+      <th>Page title</th>
+      <th>Content type</th>
+      <th>Unique pageviews</th>
+      <th>User satisfaction score</th>
+      <th>Searches from page</th>
+    </tr>
+    <%= render partial: 'content_row', collection: @content.items, as: :item %>
+  </table>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,6 @@ Rails.application.routes.draw do
   get '/dev' => 'development#index'
 
   get '/metrics/*base_path', to: 'metrics#show'
+  get '/content', to: 'content#index'
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -19,12 +19,18 @@ class GdsApi::ContentDataApi < GdsApi::Base
     "#{Plek.current.find('content-performance-manager')}/api/v1"
   end
 
-  def query(from:, to:, metrics:)
-    query_params = {}
-    query_params[:from] = from
-    query_params[:to] = to
-    query_params[:metrics] = metrics
+  def content_summary(from:, to:, organisation:)
+    url = content_items_url(from, to, organisation)
+    get_json(url).to_hash
+  end
 
+  def query(query_params)
     query_string(query_params)
+  end
+
+private
+
+  def content_items_url(from, to, organisation)
+    "#{content_data_api_endpoint}/content#{query(from: from, to: to, organisation: organisation)}"
   end
 end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'date selection', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
-  include MetricsChartSpecHelpers
+  include TableDataSpecHelpers
   let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
 
   before do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe '/content' do
+  include GdsApi::TestHelpers::ContentDataApi
+  include TableDataSpecHelpers
+  let(:from) { Time.zone.today.last_month.beginning_of_month.to_s('%F') }
+  let(:to) { Time.zone.today.last_month.end_of_month.to_s('%F') }
+  let(:items) do
+    [
+      {
+        base_path: '/path/1',
+        title: 'The title',
+        unique_pageviews: 233_018,
+        document_type: 'news_story',
+        satisfaction_score: 0.81301,
+        satisfaction_score_responses: 250,
+        number_of_internal_searches: 220
+      },
+      {
+        base_path: '/path/2',
+        title: 'Another title',
+        unique_pageviews: 100_018,
+        document_type: 'guide',
+        satisfaction_score: 0.68,
+        satisfaction_score_responses: 42,
+        number_of_internal_searches: 12
+      }
+    ]
+  end
+
+  before do
+    content_data_api_has_content_items(from: from, to: to, organisation: 'org-id', items: items)
+    visit "/content?date_range=last-month&organisation=org-id"
+  end
+
+  it 'renders the page without error' do
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content('Content data')
+  end
+
+  it 'renders the data in a table' do
+    table_rows = extract_table_content('.content-table table')
+    expect(table_rows).to eq(
+      [
+        ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
+        ['The title /path/1', 'News story', '233,018', '81.3% (250 responses)', '220'],
+        ['Another title /path/2', 'Guide', '100,018', '68.0% (42 responses)', '12'],
+      ]
+    )
+  end
+end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
-  include MetricsChartSpecHelpers
+  include TableDataSpecHelpers
   let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -23,6 +23,13 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
+      def content_data_api_has_content_items(from:, to:, organisation:, items:)
+        query = GdsApi::ContentDataApi.new.query(from: from, to: to, organisation: organisation)
+        url = "#{content_data_api_endpoint}/content#{query}"
+        body = { results: items }.to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_endpoint
         "#{Plek.current.find('content-performance-manager')}/api/v1"
       end

--- a/spec/support/table_data_spec_helpers.rb
+++ b/spec/support/table_data_spec_helpers.rb
@@ -1,4 +1,4 @@
-module MetricsChartSpecHelpers
+module TableDataSpecHelpers
   def extract_table_content(css_selector)
     find(css_selector).all('tr').map do |el|
       el.all('th,td').map(&:text)


### PR DESCRIPTION
We now have a route that displays content items.

Example Url:

/content?date_range=last-30-days&organisation=6667cce2-e809-4e21-ae09-cb0bdc1ddda

This is not complete, This is an interim PR to allow the other stories on the index page 
to be played.

There is a [Related PR iin content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/919)