### PR TITLE
Fix format of percentage numbers

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -1,0 +1,12 @@
+module MetricsFormatterHelper
+  include ActionView::Helpers::NumberHelper
+  METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction_score).freeze
+
+  def format_metric_value(metric_name, figure)
+    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s)
+      number_to_percentage(figure * 100, precision: 0)
+    else
+      figure
+    end
+  end
+end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -44,6 +44,8 @@ class ChartPresenter
 
   def values
     return [] unless json[metric]
-    json[metric].map { |hash| hash['value'] }
+    json[metric].map do |hash|
+      metric == :satisfaction_score ? (hash['value'] * 100).round : hash['value']
+    end
   end
 end

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -1,4 +1,5 @@
 class ChartPresenter
+  include MetricsFormatterHelper
   attr_reader :json, :metric, :from, :to
 
   def initialize(json:, metric:, from:, to:)
@@ -44,8 +45,6 @@ class ChartPresenter
 
   def values
     return [] unless json[metric]
-    json[metric].map do |hash|
-      metric == :satisfaction_score ? (hash['value'] * 100).round : hash['value']
-    end
+    json[metric].map { |hash| format_metric_value(metric, hash['value']) }
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,4 +1,5 @@
 class SingleContentItemPresenter
+  include MetricsFormatterHelper
   attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
     :pageviews_series, :base_path, :title, :published_at, :last_updated,
     :publishing_organisation, :document_type, :number_of_internal_searches,
@@ -16,10 +17,10 @@ private
   attr_reader :from, :to
 
   def parse_metrics(metrics)
-    @unique_pageviews = metrics[:unique_pageviews]
-    @pageviews = metrics[:pageviews]
-    @number_of_internal_searches = metrics[:number_of_internal_searches]
-    @satisfaction_score = (metrics[:satisfaction_score] * 100).round
+    @unique_pageviews = format_metric_value('unique_pageviews', metrics[:unique_pageviews])
+    @pageviews = format_metric_value('pageviews', metrics[:pageviews])
+    @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
+    @satisfaction_score = format_metric_value('satisfaction_score', metrics[:satisfaction_score])
     @title = metrics[:title]
     @metadata = {
       base_path: metrics[:base_path],

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -19,7 +19,7 @@ private
     @unique_pageviews = metrics[:unique_pageviews]
     @pageviews = metrics[:pageviews]
     @number_of_internal_searches = metrics[:number_of_internal_searches]
-    @satisfaction_score = metrics[:satisfaction_score]
+    @satisfaction_score = (metrics[:satisfaction_score] * 100).round
     @title = metrics[:title]
     @metadata = {
       base_path: metrics[:base_path],

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -7,12 +7,11 @@
   context ||= false
 
 %>
-<% percentage_metrics = ['User satisfaction score'] %>
 <% if name && figure && context %>
   <div class="app-c-info-metric govuk-body">
     <h3 class="app-c-info-metric__heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
-    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %><%= '%' if percentage_metrics.include? name %></span>
+    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
     <% if trend_percentage %>
       <span class="app-c-info-metric__trend">
         <% if trend_percentage > 0 %>+<% end %><%= trend_percentage %>%

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -7,11 +7,12 @@
   context ||= false
 
 %>
+<% percentage_metrics = ['User satisfaction score'] %>
 <% if name && figure && context %>
   <div class="app-c-info-metric govuk-body">
     <h3 class="app-c-info-metric__heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
-    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
+    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %><%= '%' if percentage_metrics.include? name %></span>
     <% if trend_percentage %>
       <span class="app-c-info-metric__trend">
         <% if trend_percentage > 0 %>+<% end %><%= trend_percentage %>%

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders a metric for satisfaction_score' do
-      expect(page).to have_selector '.metric_summary.satisfaction_score', text: '25.5'
+      expect(page).to have_selector '.metric_summary.satisfaction_score', text: '26'
     end
 
     it 'renders the page title' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -93,9 +93,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
       expect(satisfaction_score_rows).to match_array([
         ['', ''],
-        [month_and_date_string_for_date1.to_s, "100"],
-        [month_and_date_string_for_date2.to_s, "90"],
-        [month_and_date_string_for_date3.to_s, "80"],
+        [month_and_date_string_for_date1.to_s, "100%"],
+        [month_and_date_string_for_date2.to_s, "90%"],
+        [month_and_date_string_for_date3.to_s, "80%"],
       ])
     end
   end

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe MetricsFormatterHelper do
+  context 'metric needs to be rendered as a percentage' do
+    it 'displays value as a percentage' do
+      value = format_metric_value('satisfaction_score', 0.9)
+      expect(value).to eq '90%'
+    end
+  end
+
+  context 'metric does not need to be rendered as a percentage' do
+    it 'displays value as an integer' do
+      value = format_metric_value('pageviews', 90)
+      expect(value).to eq 90
+    end
+  end
+end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe SingleContentItemPresenter do
       unique_pageviews: 2030,
       pageviews: 3000,
       number_of_internal_searches: 120,
-      satisfaction_score: 34,
+      satisfaction_score: '34%',
     )
   end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SingleContentItemPresenter do
       'document_type' => 'news_story',
       'unique_pageviews' => 2030,
       'pageviews' => 3000,
-      'satisfaction_score' => 33.5,
+      'satisfaction_score' => 0.335,
       'number_of_internal_searches' => 120,
     }
   end
@@ -42,7 +42,7 @@ RSpec.describe SingleContentItemPresenter do
       unique_pageviews: 2030,
       pageviews: 3000,
       number_of_internal_searches: 120,
-      satisfaction_score: 33.5,
+      satisfaction_score: 34,
     )
   end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -39,7 +39,7 @@ module GdsApi
           base_path: "/#{base_path}",
           unique_pageviews: 145_000,
           pageviews: 200_000,
-          satisfaction_score: 25.5,
+          satisfaction_score: 0.255,
           number_of_internal_searches: 250,
           title: "Content Title",
           first_published_at: '2018-02-01T00:00:00.000Z',
@@ -67,9 +67,9 @@ module GdsApi
             { "date" => (to + 1.day).to_s, "value" => 8 }
           ],
           satisfaction_score: [
-            { "date" => (from - 1.day).to_s, "value" => 100 },
-            { "date" => (from - 2.days).to_s, "value" => 90 },
-            { "date" => (to + 1.day).to_s, "value" => 80 }
+            { "date" => (from - 1.day).to_s, "value" => 1 },
+            { "date" => (from - 2.days).to_s, "value" => 0.9 },
+            { "date" => (to + 1.day).to_s, "value" => 0.8 }
           ]
         }
       end


### PR DESCRIPTION
The percentage figures for metrics are not presented as percentages but as whole numbers on the single page view.
This PR fixes that.

https://trello.com/c/DhJHJL6b/679-1-fix-formatting-of-numbers-percentages-for-single-page