### PR TITLE
Add time select component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,3 +8,4 @@ $govuk-global-styles: true;
 @import "components/glance-metric";
 @import "components/info-metric";
 @import "components/metadata";
+@import "components/time-select";

--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -1,0 +1,1 @@
+// All required styles are inherited

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -21,12 +21,14 @@
         1 => {lineWidth: 2, lineDashStyle: [10, 2], color: '#454a4c'}
     }
   }
-  chart_format_data = rows.each_with_object([]) do |row, acc|
-    acc << {
-    name: row[:label],
-    linewidth: 10,
-    data: keys.zip(row[:values])
-    }
+  if rows.length > 0 && keys.length > 0
+    chart_format_data = rows.each_with_object([]) do |row, acc|
+      acc << {
+      name: row[:label],
+      linewidth: 10,
+      data: keys.zip(row[:values])
+      }
+    end
   end
 %>
 <% if rows.length > 0 && keys.length > 0 && chart_id && table_id %>

--- a/app/views/components/_time-select.html.erb
+++ b/app/views/components/_time-select.html.erb
@@ -1,0 +1,29 @@
+<%
+  base_path ||= false
+  current_selection ||= false
+
+  if dates.length > 1
+    dates.each {|d| d[:bold] = "true"}
+  end
+
+  selectable = dates.find {|d| d[:value] == current_selection}
+  if selectable
+    selectable[:checked] = true
+  end
+%>
+<% if base_path && dates.length > 1 && current_selection %>
+  <div class="app-c-time-select">
+    <h2 class="govuk-heading-l">Page data: <%= dates.find {|d| d[:value] == current_selection }[:text] %></h2>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Change time period"
+    } do %>
+      <%= form_for('date', :url => "#{base_path}", :method => :get) do %>
+        <%= render "govuk_publishing_components/components/radio", {
+          name: "date_range",
+          items: dates
+        } %>
+        <%= render "govuk_publishing_components/components/button", {text: "Change dates"} %>
+      <% end %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/components/docs/time-select.yml
+++ b/app/views/components/docs/time-select.yml
@@ -1,0 +1,32 @@
+name: "Time select"
+description: "The time select component allows users to select from pre-defined time windows"
+part_of_admin_layout: true
+body: "The time select component is a header stating the current selection and a form containing radio buttons. It allows users to select from pre-defined time windows. It will not render without enough valid inputs to build a usable form and details of the currently selected dates."
+
+accessibility_criteria: |
+  - All text must have a contrast ratio higher than 4.5:1 against the background colour to meet [WCAG AA](https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast)
+
+examples:
+  default:
+    data:
+      current_selection: "past-6-months"
+      base_path: "/"
+      dates:
+        - value: "past-30-days"
+          text: "Past 30 Days"
+          hint_text: "21 July 2018 to 19 August 2018"
+        - value: "last-month"
+          text: "Last month"
+          hint_text: "1 July 2018 - 31 July 2018"
+        - value: "past-3-months"
+          text: "Past 3 months"
+          hint_text: "20 May 2018 - 19 August 2018"
+        - value: "past-6-months"
+          text: "Past 6 months"
+          hint_text: "20 February 2018 - 31 July 2018"
+        - value: "past-year"
+          text: "Past year"
+          hint_text: "20 August 2017 - 19 August 2018"
+        - value: "past-2-years"
+          text: "Past 2 years"
+          hint_text: "20 August 2016 - 19 August 2018"

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -5,6 +5,45 @@
   <%= render "components/metadata", @summary.metadata %>
 </div>
 
+<% current_selection = @summary.date_range.time_period || 'last-30-days' %>
+<%= render "components/time-select", {
+  base_path: "/metrics#{@summary.metadata[:base_path]}",
+  current_selection: current_selection,
+  dates: [
+    {
+      value: "last-30-days",
+      text: "Past 30 Days",
+      hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+    },
+    {
+      value: "last-month",
+      text: "Last month",
+      hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
+    },
+    {
+      value: "last-3-months",
+      text: "Past 3 months",
+      hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+    },
+    {
+      value: "last-6-months",
+      text: "Past 6 months",
+      hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+    },
+    {
+      value: "last-1-year",
+      text: "Past year",
+      hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+    },
+    {
+      value: "last-2-years",
+      text: "Past 2 years",
+      hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+    }
+  ]
+} %>
+
+
 <h2>Performance</h2>
 <div class="metric_summary unique_pageviews">
   <%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews %>
@@ -25,13 +64,5 @@
 </div>
 <%= render 'chart', series: @summary.satisfaction_score_series %>
 <%= form_for('date', :url => "/metrics#{@summary.metadata[:base_path]}", :method => :get) do |f| %>
-  <div class="field">
-    <%= radio_button_tag(:date_range, 'last-30-days', checked = (@summary.date_range == 'last-30-days' || ''), label: 'Last 30 Days') %> Last 30 Days <br>
-    <%= radio_button_tag(:date_range, 'last-month', checked = (@summary.date_range == 'last-month'), label: 'Last Month') %> Last Month <br>
-    <%= radio_button_tag(:date_range, 'last-3-months', checked = (@summary.date_range == 'last-3-months'), label: 'Last 3 Months') %> Last 3 Months <br>
-    <%= radio_button_tag(:date_range, 'last-6-months', checked = (@summary.date_range == 'last-6-months'), label: 'Last 6 Month') %> Last 6 Months <br>
-    <%= radio_button_tag(:date_range, 'last-1-year', checked = (@summary.date_range == 'last-year'), label: 'Last Year') %> Last 1 Year <br>
-    <%= radio_button_tag(:date_range, 'last-2-years', checked = (@summary.date_range == 'last-2-years'), label: 'Last 2 Years') %> Last 2 Years <br>
-    <%= submit_tag 'OK' %>
-  </div>
+
 <% end %>

--- a/spec/components/time_select_spec.rb
+++ b/spec/components/time_select_spec.rb
@@ -1,0 +1,64 @@
+require 'rails_helper'
+
+RSpec.describe "Time Select", type: :view do
+  let(:data) {
+    {
+    base_path: "/metrics",
+    current_selection: 'last-30-days',
+      dates: [
+        {
+          value: "last-30-days",
+          text: "Past 30 Days",
+          hint_text:  "19 August 2018 to 18 September 2018"
+        },
+        {
+          value: "last-month",
+          text: "Last month",
+          hint_text: "1 August 2018 to 31 August 2018"
+        },
+        {
+          value: "last-3-months",
+          text: "Past 3 months",
+          hint_text: "18 June 2018 to 18 September 2018"
+        }
+      ]
+    }
+  }
+
+  it "does not render when not enough dates are given" do
+    data[:dates] = []
+    assert_empty render_component(data)
+    data[:dates] = [{ value: "last-30-days", text: "Past 30 Days", hint_text: "19 August 2018 to 18 September 2018" }]
+    assert_empty render_component(data)
+  end
+
+  it "does not render when current_selection is not supplied" do
+    data[:current_selection] = false
+    assert_empty render_component(data)
+  end
+
+  it "does not render when base_path is not supplied" do
+    data[:base_path] = false
+    assert_empty render_component(data)
+  end
+
+  it "renders correctly when given valid data" do
+    render_component(data)
+    assert_select ".app-c-time-select", 1
+    assert_select ".govuk-radios__item", 3
+    assert_select "label", text: "Past 30 Days"
+    assert_select "label", text: "Last month"
+    assert_select "label", text: "Past 3 months"
+    assert_select "input[type=radio][value=last-30-days][checked=checked]"
+  end
+
+  it "preselects the radio button based on the current_selection parameter" do
+    data[:current_selection] = "last-3-months"
+    render_component(data)
+    assert_select "input[type=radio][value=last-3-months][checked=checked]"
+  end
+
+  def render_component(locals)
+    render partial: "components/time-select", locals: locals
+  end
+end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -13,42 +13,42 @@ RSpec.describe 'date selection', type: :feature do
     expect_default_date_period_metrics_to_be_displayed(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the last 30 days when `last 30 days` is selected' do
+  it 'renders data for the last 30 days when `Past 30 days` is selected' do
     date_range = build(:date_range, :last_30_days)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-30-days')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the previous month when `last month` is selected' do
+  it 'renders data for the previous month when `Past month` is selected' do
     date_range = build(:date_range, :last_month)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-month')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the last 3 months when `last 3 months` is selected' do
+  it 'renders data for the last 3 months when `Past 3 months` is selected' do
     date_range = build(:date_range, :last_3_months)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-3-months')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the last 6 months when `last6 months` is selected' do
+  it 'renders data for the last 6 months when `Past 6 months` is selected' do
     date_range = build(:date_range, :last_6_months)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-6-months')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the last year when `last year` is selected' do
+  it 'renders data for the last year when `Past year` is selected' do
     date_range = build(:date_range, :last_1_year)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-1-year')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 
-  it 'renders data for the last 2 years when `last 2 years` is selected' do
+  it 'renders data for the last 2 years when `Past 2 years` is selected' do
     date_range = build(:date_range, :last_2_years)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
     visit_page_and_filter_by_date_range('last-2-years')
@@ -129,8 +129,8 @@ RSpec.describe 'date selection', type: :feature do
 
   def visit_page_and_filter_by_date_range(date_range)
     visit '/metrics/base/path'
-    find("#date_range_#{date_range}").click
-    click_button 'OK'
+    find("input[type=radio][name=date_range][value=#{date_range}]").click
+    click_button 'Change dates'
     click_on 'Unique pageviews table'
   end
 end


### PR DESCRIPTION
This adds the component that allows users to select the timeframe for the data they are viewing.

It also updates the view to use the component, and updates related tests.

This can be seen at 
http://content-data-admin.dev.gov.uk/component-guide/time-select
or single content item pages such as
http://content-data-admin.dev.gov.uk/metrics/government/publications/self-assessment-tax-return-sa100?utf8=%E2%9C%93&date_range=last-2-years
(note that this branch has inherited the satisfaction score bug from master, so you'll need to work around that to view it - remove the satisfaction graph in the view and line 4 of app/services/metrics_service.rb) 

![screen shot 2018-09-19 at 09 39 37](https://user-images.githubusercontent.com/31649453/45747459-d46f8b00-bbfd-11e8-87b7-8072aa246425.png)
