### PR TITLE
Disable satifaction score

### DIFF
--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -1,3 +1,5 @@
+require 'gds_api/content_data_api'
+
 module MetricsCommon
 private
 
@@ -6,6 +8,6 @@ private
   end
 
   def default_metrics
-    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score].freeze
+    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches].freeze
   end
 end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'date selection', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches] }
 
   before do
     initial_page_stub

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches satisfaction_score] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }
   let(:month_and_date_string_for_date1) { (from - 1.day).to_s.last(5) }


### PR DESCRIPTION
here is a problem with content-data-api that
causes a 500 error when there are nils in the
satisfaction_score column.

This PR temporarily removes this metric from the
call to content-data-api