### PR TITLE
Increase the timeout for GdsApi::ContentDataApi

### DIFF
--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -4,7 +4,9 @@ module MetricsCommon
 private
 
   def api
-    @api ||= GdsApi::ContentDataApi.new
+    @api ||= GdsApi::ContentDataApi.new.tap do |client|
+      client.options[:timeout] = 15
+    end
   end
 
   def default_metrics


### PR DESCRIPTION
We are currently experiencing performance problems
when retrieving data for the index page.

This commit (temporarily) increases the timeout
so we can render the page and development on it
can continue.

We will reduce the timeout again once the
query has been optimised in the content-data-api.