### PR TITLE
Fix bug metrics formatting bug

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -3,7 +3,7 @@ module MetricsFormatterHelper
   METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction_score).freeze
 
   def format_metric_value(metric_name, figure)
-    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s)
+    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s) && figure
       number_to_percentage(figure * 100, precision: 0)
     else
       figure

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -12,4 +12,10 @@ RSpec.describe MetricsFormatterHelper do
       expect(value).to eq 90
     end
   end
+
+  context 'if figure for percentage metric is not supplied' do
+    it 'does not raise an error' do
+      expect { format_metric_value('satisfaction_score', nil) }.to_not raise_error
+    end
+  end
 end


### PR DESCRIPTION
When satisfaction score is not recieved due to existing problems with that metric
then currently we have an error raised in the format_metric_value method.

This PR ensures that this error will not be raised and that our app can handle nil
values for metrics which are measured as percentages.