### PR TITLE
Add feedback comments metric to single page view

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -39,12 +39,14 @@ class ChartPresenter
 
   def keys
     return [] unless json[metric]
+
     dates = json[metric].map { |hash| hash['date'] }
     dates.map { |date| date.last(5) }
   end
 
   def values
     return [] unless json[metric]
+
     json[metric].map { |hash| format_metric_value(metric, hash['value']) }
   end
 end

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -14,6 +14,7 @@ private
 
   def format_satisfaction_score(score, responses)
     return 'No responses' unless score
+
     "#{(score * 100).round(1)}% (#{responses} responses)"
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -4,7 +4,7 @@ class SingleContentItemPresenter
     :pageviews_series, :base_path, :title, :published_at, :last_updated,
     :publishing_organisation, :document_type, :number_of_internal_searches,
     :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series,
-    :date_range, :metadata
+    :number_of_feedback_comments, :number_of_feedback_comments_series, :date_range, :metadata
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
@@ -19,6 +19,7 @@ private
   def parse_metrics(metrics)
     @unique_pageviews = format_metric_value('unique_pageviews', metrics[:unique_pageviews])
     @pageviews = format_metric_value('pageviews', metrics[:pageviews])
+    @number_of_feedback_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
     @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
     @satisfaction_score = format_metric_value('satisfaction_score', metrics[:satisfaction_score])
     @title = metrics[:title]
@@ -35,6 +36,7 @@ private
     @unique_pageviews_series = get_chart_presenter(time_series, :unique_pageviews)
     @pageviews_series = get_chart_presenter(time_series, :pageviews)
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
+    @number_of_feedback_comments_series = get_chart_presenter(time_series, :feedex_comments)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
   end
 

--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -10,6 +10,6 @@ private
   end
 
   def default_metrics
-    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches].freeze
+    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches feedex_comments].freeze
   end
 end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -63,6 +63,12 @@
   <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
 </div>
 <%= render 'chart', series: @summary.satisfaction_score_series %>
+
+<div class="metric_summary number_of_feedback_comments">
+  <%= render 'metric_header', title: 'Number of feedback comments', value: @summary.number_of_feedback_comments %>
+</div>
+<%= render 'chart', series: @summary.number_of_feedback_comments_series %>
+
 <%= form_for('date', :url => "/metrics#{@summary.metadata[:base_path]}", :method => :get) do |f| %>
 
 <% end %>

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'date selection', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments] }
 
   before do
     initial_page_stub

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }
   let(:month_and_date_string_for_date1) { (from - 1.day).to_s.last(5) }
@@ -32,6 +32,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders a metric for satisfaction_score' do
       expect(page).to have_selector '.metric_summary.satisfaction_score', text: '26'
+    end
+
+    it 'renders a metric for number_of_feedback_comments' do
+      expect(page).to have_selector '.metric_summary.number_of_feedback_comments', text: '20'
     end
 
     it 'renders the page title' do
@@ -96,6 +100,18 @@ RSpec.describe '/metrics/base/path', type: :feature do
         [month_and_date_string_for_date1.to_s, "100%"],
         [month_and_date_string_for_date2.to_s, "90%"],
         [month_and_date_string_for_date3.to_s, "80%"],
+      ])
+    end
+
+    it 'renders the metric timeseries for ' do
+      click_on 'Number of internal searches table'
+      feedback_comment_rows = extract_table_content(".chart.feedex_comments table")
+
+      expect(feedback_comment_rows).to match_array([
+        ['', ''],
+        [month_and_date_string_for_date1.to_s, "20"],
+        [month_and_date_string_for_date2.to_s, "21"],
+        [month_and_date_string_for_date3.to_s, "22"],
       ])
     end
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe SingleContentItemPresenter do
       'pageviews' => 3000,
       'satisfaction_score' => 0.335,
       'number_of_internal_searches' => 120,
+      'feedex_comments' => 20,
     }
   end
   let(:time_series) { default_timeseries_payload(from.to_date, to.to_date) }
@@ -42,7 +43,8 @@ RSpec.describe SingleContentItemPresenter do
       unique_pageviews: 2030,
       pageviews: 3000,
       number_of_internal_searches: 120,
-      satisfaction_score: '34%',
+      number_of_feedback_comments: 20,
+      satisfaction_score: '34%'
     )
   end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -56,6 +56,7 @@ module GdsApi
           pageviews: 200_000,
           satisfaction_score: 0.255,
           number_of_internal_searches: 250,
+          feedex_comments: 20,
           title: "Content Title",
           first_published_at: '2018-02-01T00:00:00.000Z',
           public_updated_at: '2018-04-25T00:00:00.000Z',
@@ -80,6 +81,11 @@ module GdsApi
             { "date" => (from - 1.day).to_s, "value" => 8 },
             { "date" => (from - 2.days).to_s, "value" => 8 },
             { "date" => (to + 1.day).to_s, "value" => 8 }
+          ],
+          feedex_comments: [
+            { "date" => (from - 1.day).to_s, "value" => 20 },
+            { "date" => (from - 2.days).to_s, "value" => 21 },
+            { "date" => (to + 1.day).to_s, "value" => 22 }
           ],
           satisfaction_score: [
             { "date" => (from - 1.day).to_s, "value" => 1 },


### PR DESCRIPTION
Requests now support the feedex_comments metric to display the aggregated and time series data for number of feedback comments. Graph and metric info components added to single page view for feedback comments.