### PR TITLE
Style and lay out single content item page to match design

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,3 +9,4 @@ $govuk-global-styles: true;
 @import "components/info-metric";
 @import "components/metadata";
 @import "components/time-select";
+@import "components/related-actions";

--- a/app/assets/stylesheets/components/_related-actions.scss
+++ b/app/assets/stylesheets/components/_related-actions.scss
@@ -1,0 +1,9 @@
+.app-c-related-actions {
+  border-top: 1px solid $govuk-border-colour;
+}
+
+.app-c-related-actions__link {
+  margin-left: 0;
+  @include govuk-responsive-margin(3, "bottom");
+}
+

--- a/app/views/components/_related-actions.html.erb
+++ b/app/views/components/_related-actions.html.erb
@@ -1,0 +1,17 @@
+<%
+  links ||= []
+%>
+<% if links.any? %>
+  <div class="app-c-related-actions">
+    <div class="govuk-body govuk-body-s">
+      <dl>
+        <% links.each do |l| %>
+          <% if l[:header] && l[:link_text] && l[:link_url] %>
+            <dt class="app-c-related-actions__header govuk-!-font-weight-bold"><%= l[:header] %></dt>
+            <dd class="app-c-related-actions__link"><a href="<%= l[:link_url] %>" class="govuk-link"><%= l[:link_text] %></a></dd>
+          <% end %>
+        <% end %>
+      </dl>
+    </div>
+  </div>
+<% end %>

--- a/app/views/components/docs/related-actions.yml
+++ b/app/views/components/docs/related-actions.yml
@@ -1,0 +1,21 @@
+name: "Related actions"
+description: "A list of actions that can be taken on the page"
+part_of_admin_layout: true
+body: |
+  This is a simple component that displays headers and links related to the page for users who want to take further actions
+
+accessibility_criteria: |
+
+shared_accessibility_criteria:
+  - link
+
+examples:
+  default:
+    data:
+      links:
+      - header: "View the page on GOV.UK"
+        link_url:   "http://www.gov.uk/government/publications/self-assessment-tax-return-sa100"
+        link_text: "Visit Tax return for Self Assessment"
+      - header: "Make changes to the page"
+        link_text: "Edit in Whitehall Publisher"
+        link_url: "http://whitehall.gov"

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,6 @@
     <% end %>
 
     <main class="govuk-main-wrapper " id="main-content" role="main">
-      <%= render "govuk_publishing_components/components/title", title: yield(:title) %>
       <%= yield %>
     </main>
   </div>

--- a/app/views/metrics/_metadata_row.html.erb
+++ b/app/views/metrics/_metadata_row.html.erb
@@ -1,3 +1,0 @@
-<div class="metadata-row">
-  <div class="metadata-label"><%= label %></div><div class="metadata-value"><%= value %></div>
-</div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,11 +1,38 @@
 <% content_for :title, "Page Data: #{@summary.title}" %>
-<h2>Page Data</h2>
-<h1 class="content-title"><%= @summary.title %></h1>
-<div class="page-metadata">
-  <%= render "components/metadata", @summary.metadata %>
-</div>
-
+<% content_for :back_link, "/" %>
 <% current_selection = @summary.date_range.time_period || 'last-30-days' %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <span class="govuk-caption-xl">Page data</span>
+  </div>
+</div>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= @summary.title %></h1>
+    <div class="page-metadata">
+      <%= render "components/metadata", @summary.metadata %>
+    </div>
+  </div>
+  <div class="govuk-grid-column-one-third">
+    <%= render "components/related-actions",
+      {
+        links: [
+                  {
+                    header: "View the page on GOV.UK",
+                    link_url: "//www.gov.uk#{@summary.metadata[:base_path]}",
+                    link_text: "Visit #{@summary.title}"
+                  },
+                  {
+                    header: "Make changes to the page",
+                    link_url: "//www.gov.uk/???",
+                    link_text: "Visit ???"
+                  }
+                ]
+      } %>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <%= render "components/time-select", {
   base_path: "/metrics#{@summary.metadata[:base_path]}",
   current_selection: current_selection,
@@ -43,32 +70,96 @@
   ]
 } %>
 
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "components/glance-metric", {
+      name: "Unique pageviews",
+      figure: @summary.unique_pageviews,
+      context: "Lorem ipsum blah blah blah",
+      trend_percentage: 0,
+      period: "from previous 30 days"
+    } %>
+  </div>
 
-<h2>Performance</h2>
-<div class="metric_summary unique_pageviews">
-  <%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews %>
-</div>
-<%= render 'chart', series: @summary.unique_pageviews_series %>
-<div class="metric_summary pageviews">
-  <%= render 'metric_header', title: 'Pageviews', value: @summary.pageviews %>
-</div>
-<%= render 'chart', series: @summary.pageviews_series %>
-<div class="metric_summary number_of_internal_searches">
-  <%= render 'metric_header', title: 'Searches from the page', value: @summary.number_of_internal_searches %>
-</div>
-<%= render 'chart', series: @summary.number_of_internal_searches_series %>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "components/glance-metric", {
+      name: "User satisfaction score",
+      figure: @summary.satisfaction_score,
+      context: "Lorem ipsum blah blah blah",
+      trend_percentage: 0,
+      period: "from previous 30 days"
+    } %>
+  </div>
 
-<h2>Feedback</h2>
-<div class="metric_summary satisfaction_score">
-  <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "components/glance-metric", {
+      name: "Searches from the page",
+      figure: @summary.number_of_internal_searches,
+      context: "Lorem ipsum blah blah blah",
+      trend_percentage: 0,
+      period: "from previous 30 days"
+    } %>
+  </div>
+
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "components/glance-metric", {
+      name: "Feedback comments",
+      figure: @summary.number_of_feedback_comments,
+      context: "Lorem ipsum blah blah blah",
+      trend_percentage: 0,
+      period: "from previous 30 days"
+    } %>
+  </div>
 </div>
-<%= render 'chart', series: @summary.satisfaction_score_series %>
 
-<div class="metric_summary number_of_feedback_comments">
-  <%= render 'metric_header', title: 'Number of feedback comments', value: @summary.number_of_feedback_comments %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-l">Performance</h2>
+    <div class="metric_summary unique_pageviews">
+      <%= render 'metric_header', title: 'Unique Pageviews', value: @summary.unique_pageviews %>
+    </div>
+    <%= render 'chart', series: @summary.unique_pageviews_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Unique pageviews CSV</a>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <div class="metric_summary pageviews">
+      <%= render 'metric_header', title: 'Pageviews', value: @summary.pageviews %>
+    </div>
+    <%= render 'chart', series: @summary.pageviews_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Pageviews CSV</a>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <div class="metric_summary number_of_internal_searches">
+      <%= render 'metric_header', title: 'Searches from the page', value: @summary.number_of_internal_searches %>
+    </div>
+    <%= render 'chart', series: @summary.number_of_internal_searches_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Searches from the page CSV</a>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-l">Feedback</h2>
+    <div class="metric_summary satisfaction_score">
+      <%= render 'metric_header', title: 'User satisfaction score', value: @summary.satisfaction_score %>
+    </div>
+    <%= render 'chart', series: @summary.satisfaction_score_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Satisfaction score CSV</a>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <div class="metric_summary number_of_feedback_comments">
+    <%= render 'metric_header', title: 'Number of feedback comments', value: @summary.number_of_feedback_comments %>
+    </div>
+    <%= render 'chart', series: @summary.number_of_feedback_comments_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Feedback CSV</a>
+
+  </div>
 </div>
-<%= render 'chart', series: @summary.number_of_feedback_comments_series %>
 
-<%= form_for('date', :url => "/metrics#{@summary.metadata[:base_path]}", :method => :get) do |f| %>
 
-<% end %>
+
+
+
+

--- a/spec/components/related_actions_spec.rb
+++ b/spec/components/related_actions_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe "Related actions", type: :view do
+  let(:data) {
+    {
+      links: [
+                {
+                  header: "View the page on GOV.UK",
+                  link_url: "//www.gov.uk/govpage",
+                  link_text: "Visit Govpage"
+                },
+                {
+                  header: "Make changes to the page",
+                  link_url: "//www.gov.uk/moregov",
+                  link_text: "Visit More gov"
+                }
+              ]
+      }
+  }
+
+  it "does not render when no data is passed" do
+    assert_empty render_component({})
+  end
+
+  it "renders supplied links correctly" do
+    render_component(data)
+  end
+
+  it "renders correctly when given valid data" do
+    render_component(data)
+    assert_select ".app-c-related-actions", 1
+    assert_select "dl", 1
+    assert_select "dt", 2
+    assert_select "dd", 2
+    assert_select ".app-c-related-actions__header", text: "View the page on GOV.UK"
+    assert_select ".app-c-related-actions__header", text: "Make changes to the page"
+    assert_select "a", href: "//www.gov.uk/govpage", text: "Visit Govpage"
+    assert_select "a", href: "//www.gov.uk/moregov", text: "Visit More gov"
+  end
+
+  def render_component(locals)
+    render partial: "components/related-actions", locals: locals
+  end
+end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the page title' do
-      expect(page).to have_selector '.content-title', text: 'Content Title'
+      expect(page).to have_selector 'h1.govuk-heading-xl', text: 'Content Title'
     end
 
     it 'renders a metric for on page searches' do


### PR DESCRIPTION
This included direct styling on the page, and adding an extra "related actions" component.

No screenshot as it would be the entire page, and should hopefully match the whole design for this page.

Example url: http://content-data-admin.dev.gov.uk/metrics/government/publications/self-assessment-tax-return-sa100?utf8=%E2%9C%93&date_range=last-6-months#number_of_internal_searches_chart

https://trello.com/c/u77qQMjx/674-build-view-for-single-content-item-page

