### PR TITLE
Rename parameter: organisation to organisation_id

### DIFF
--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -1,5 +1,6 @@
 class FindContent
   include MetricsCommon
+
   def self.call(params)
     new(params).call
   end
@@ -8,10 +9,10 @@ class FindContent
     range = DateRange.new(params[:date_range])
     @from = range.from
     @to = range.to
-    @organisation = params[:organisation]
+    @organisation = params[:organisation_id]
   end
 
   def call
-    api.content(from: @from, to: @to, organisation: @organisation)
+    api.content(from: @from, to: @to, organisation_id: @organisation)
   end
 end

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -17,8 +17,8 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash
   end
 
-  def content(from:, to:, organisation:)
-    url = content_items_url(from, to, organisation)
+  def content(from:, to:, organisation_id:)
+    url = content_items_url(from, to, organisation_id)
     get_json(url).to_hash
   end
 
@@ -36,7 +36,7 @@ private
     "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
-  def content_items_url(from, to, organisation)
-    "#{content_data_api_endpoint}/content#{query_string(from: from, to: to, organisation: organisation)}"
+  def content_items_url(from, to, organisation_id)
+    "#{content_data_api_endpoint}/content#{query_string(from: from, to: to, organisation_id: organisation_id)}"
   end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe '/content' do
   end
 
   before do
-    content_data_api_has_content_items(from: from, to: to, organisation: 'org-id', items: items)
-    visit "/content?date_range=last-month&organisation=org-id"
+    content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
+    visit "/content?date_range=last-month&organisation_id=org-id"
   end
 
   it 'renders the page without error' do

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -23,8 +23,8 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation:, items:)
-        query = query(from: from, to: to, organisation: organisation)
+      def content_data_api_has_content_items(from:, to:, organisation_id:, items:)
+        query = query(from: from, to: to, organisation_id: organisation_id)
         url = "#{content_data_api_endpoint}/content#{query}"
         body = { results: items }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)


### PR DESCRIPTION
This is a continuation of https://github.com/alphagov/content-performance-manager/pull/921.

The API has changed so we also need to update the way we pass the organisation
because it has been renamed from `organisation` to `organisation_id`