### PR TITLE
Adr editing microcopy

### DIFF
--- a/doc/arch/adr-000-document-architectural-decisions.md
+++ b/doc/arch/adr-000-document-architectural-decisions.md
@@ -1,0 +1,19 @@
+# ADR 000: Document architectural decisions
+
+## Context
+
+We aim to:
+
+- Make it easier to understand the codebase and its status
+- Reduce the number of meetings to handover information across teams
+- Facilitate team rotations across GOV.UK
+
+## Decision
+
+Track architectural decision that impact the status of the Content Data Admin, [following a lightweight format: ADR][1]
+
+## Status
+
+Accepted.
+
+[1]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions

--- a/doc/arch/adr-001-editing-microcopy.md
+++ b/doc/arch/adr-001-editing-microcopy.md
@@ -1,0 +1,3 @@
+# ADR 001: Editing microcopy in the Content Data App
+
+We will follow the [example set in the Content Publisher](https://github.com/alphagov/content-publisher/blob/master/docs/adr/0004-editing-microcopy.md) for how to allow Content Designers to edit microcopy in the app. This is for consistency and lower context switching for content designers working on both the Content Publisher and the Content Data App.


### PR DESCRIPTION
An rationale for why we are using Rails Internationalisation translations to power the microcopy in the app's interface.