### PR TITLE
Show publishing app in metadata section for the Single Performance Page

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -9,7 +9,7 @@ class MetricsController < ApplicationController
 
     metrics = FetchAggregatedMetrics.call(service_params)
     time_series = FetchTimeSeries.call(service_params)
-    @summary = SingleContentItemPresenter.new(metrics, time_series, date_range)
+    @performance_data = SingleContentItemPresenter.new(metrics, time_series, date_range)
   end
 
   rescue_from GdsApi::HTTPNotFound do

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -17,12 +17,18 @@ class SingleContentItemPresenter
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
+    @metrics = metrics
     parse_metrics(metrics.with_indifferent_access)
     parse_time_series(time_series.with_indifferent_access)
   end
 
-private
+  def publishing_app
+    publishing_app = @metrics['publishing_app']
 
+    publishing_app.present? ? publishing_app.capitalize : 'Unknown'
+  end
+
+private
 
   def parse_metrics(metrics)
     @unique_pageviews = format_metric_value('unique_pageviews', metrics[:unique_pageviews])

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -23,7 +23,6 @@ class SingleContentItemPresenter
 
 private
 
-  attr_reader :from, :to
 
   def parse_metrics(metrics)
     @unique_pageviews = format_metric_value('unique_pageviews', metrics[:unique_pageviews])

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,10 +1,19 @@
 class SingleContentItemPresenter
   include MetricsFormatterHelper
-  attr_reader :unique_pageviews, :pageviews, :unique_pageviews_series,
-    :pageviews_series, :base_path, :title, :published_at, :last_updated,
-    :publishing_organisation, :document_type, :number_of_internal_searches,
-    :number_of_internal_searches_series, :satisfaction_score, :satisfaction_score_series,
-    :number_of_feedback_comments, :number_of_feedback_comments_series, :date_range, :metadata
+
+  attr_reader :date_range,
+              :metadata,
+              :number_of_feedback_comments,
+              :number_of_feedback_comments_series,
+              :number_of_internal_searches,
+              :number_of_internal_searches_series,
+              :pageviews,
+              :pageviews_series,
+              :satisfaction_score,
+              :satisfaction_score_series,
+              :title,
+              :unique_pageviews,
+              :unique_pageviews_series
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,8 +1,4 @@
-<<<<<<< HEAD
 <% content_for :title, t('.browser_title', content_title: @performance_data.title) %>
-=======
-<% content_for :title, "Page Data: #{@performance_data.title}" %>
->>>>>>> 8442c49... Rename instance variable @performance_data
 <% content_for :back_link, "/" %>
 <% current_selection = @performance_data.date_range.time_period || 'last-30-days' %>
 
@@ -18,7 +14,7 @@
       <%= render "components/metadata", @performance_data.metadata %>
     </div>
   </div>
-  <div class="govuk-grid-column-one-third">
+  <div class="govuk-grid-column-one-third related-actions">
     <%= render "components/related-actions",
       {
         links: [
@@ -28,9 +24,9 @@
                     link_text: t('.navigation.visit_link', content_title: @performance_data.title)
                   },
                   {
-                    header: t(".navigation.edit_page"),
-                    link_url: "//www.gov.uk/???",
-                    link_text: t('.navigation.edit_link', publisher_app: "<Publisher>")
+                    header: "Make changes to the page",
+                    link_url: "#",
+                    link_text: @performance_data.publishing_app
                   }
                 ]
       } %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,6 +1,10 @@
-<% content_for :title, t('.browser_title', content_title: @summary.title) %>
+<<<<<<< HEAD
+<% content_for :title, t('.browser_title', content_title: @performance_data.title) %>
+=======
+<% content_for :title, "Page Data: #{@performance_data.title}" %>
+>>>>>>> 8442c49... Rename instance variable @performance_data
 <% content_for :back_link, "/" %>
-<% current_selection = @summary.date_range.time_period || 'last-30-days' %>
+<% current_selection = @performance_data.date_range.time_period || 'last-30-days' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -9,9 +13,9 @@
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl"><%= @summary.title %></h1>
+    <h1 class="govuk-heading-xl"><%= @performance_data.title %></h1>
     <div class="page-metadata">
-      <%= render "components/metadata", @summary.metadata %>
+      <%= render "components/metadata", @performance_data.metadata %>
     </div>
   </div>
   <div class="govuk-grid-column-one-third">
@@ -20,8 +24,8 @@
         links: [
                   {
                     header: t(".navigation.visit_page"),
-                    link_url: "//www.gov.uk#{@summary.metadata[:base_path]}",
-                    link_text: t('.navigation.visit_link', content_title: @summary.title)
+                    link_url: "//www.gov.uk#{@performance_data.metadata[:base_path]}",
+                    link_text: t('.navigation.visit_link', content_title: @performance_data.title)
                   },
                   {
                     header: t(".navigation.edit_page"),
@@ -34,7 +38,7 @@
 </div>
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <%= render "components/time-select", {
-  base_path: "/metrics#{@summary.metadata[:base_path]}",
+  base_path: "/metrics#{@performance_data.metadata[:base_path]}",
   current_selection: current_selection,
   dates: [
     {
@@ -74,7 +78,7 @@
   <div class="govuk-grid-column-one-quarter">
     <%= render "components/glance-metric", {
       name: t("metrics.unique_pageviews.title"),
-      figure: @summary.unique_pageviews,
+      figure: @performance_data.unique_pageviews,
       context: t("metrics.unique_pageviews.context"),
       trend_percentage: 0,
       period: "from previous 30 days"
@@ -84,7 +88,7 @@
   <div class="govuk-grid-column-one-quarter">
     <%= render "components/glance-metric", {
       name: t("metrics.satisfaction_score.title"),
-      figure: @summary.satisfaction_score,
+      figure: @performance_data.satisfaction_score,
       context: t("metrics.satisfaction_score.context"),
       trend_percentage: 0,
       period: "from previous 30 days"
@@ -94,7 +98,7 @@
   <div class="govuk-grid-column-one-quarter">
     <%= render "components/glance-metric", {
       name: t("metrics.internal_searches.title"),
-      figure: @summary.number_of_internal_searches,
+      figure: @performance_data.number_of_internal_searches,
       context: t("metrics.internal_searches.context"),
       trend_percentage: 0,
       period: "from previous 30 days"
@@ -104,7 +108,7 @@
   <div class="govuk-grid-column-one-quarter">
     <%= render "components/glance-metric", {
       name: t("metrics.feedback_comments.title"),
-      figure: @summary.number_of_feedback_comments,
+      figure: @performance_data.number_of_feedback_comments,
       context: t("metrics.feedback_comments.context"),
       trend_percentage: 0,
       period: "from previous 30 days"
@@ -117,46 +121,45 @@
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.performance" %></h2>
     <div class="metric_summary unique_pageviews">
-      <%= render 'metric_header', title: t("metrics.unique_pageviews.title"), value: @summary.unique_pageviews %>
+      <%= render 'metric_header', title: t("metrics.unique_pageviews.title"), value: @performance_data.unique_pageviews %>
     </div>
-    <%= render 'chart', series: @summary.unique_pageviews_series %>
+    <%= render 'chart', series: @performance_data.unique_pageviews_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
     <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.unique_pageviews.title") %></a>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary pageviews">
-      <%= render 'metric_header', title: t("metrics.pageviews.title"), value: @summary.pageviews %>
+      <%= render 'metric_header', title: t("metrics.pageviews.title"), value: @performance_data.pageviews %>
     </div>
-    <%= render 'chart', series: @summary.pageviews_series %>
+    <%= render 'chart', series: @performance_data.pageviews_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
     <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.pageviews.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary number_of_internal_searches">
-      <%= render 'metric_header', title: t("metrics.internal_searches.title"), value: @summary.number_of_internal_searches %>
+      <%= render 'metric_header', title: t("metrics.internal_searches.title"), value: @performance_data.number_of_internal_searches %>
     </div>
-    <%= render 'chart', series: @summary.number_of_internal_searches_series %>
+    <%= render 'chart', series: @performance_data.number_of_internal_searches_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
     <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.internal_searches.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
     <div class="metric_summary satisfaction_score">
-      <%= render 'metric_header', title: t("metrics.satisfaction_score.title"), value: @summary.satisfaction_score %>
+      <%= render 'metric_header', title: 'User satisfaction score', value: @performance_data.satisfaction_score %>
     </div>
-    <%= render 'chart', series: @summary.satisfaction_score_series %>
-    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
-    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.satisfaction_score.title") %></a>
+    <%= render 'chart', series: @performance_data.satisfaction_score_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Satisfaction score CSV</a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary number_of_feedback_comments">
-    <%= render 'metric_header', title: t("metrics.feedback_comments.title"), value: @summary.number_of_feedback_comments %>
+    <%= render 'metric_header', title: 'Number of feedback comments', value: @performance_data.number_of_feedback_comments %>
     </div>
-    <%= render 'chart', series: @summary.number_of_feedback_comments_series %>
-    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
-    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.feedback_comments.title") %></a>
-
+    <%= render 'chart', series: @performance_data.number_of_feedback_comments_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
+    <a href="" class="govuk-link">Feedback CSV</a>
   </div>
 </div>
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
+
   let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -46,6 +46,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.number_of_internal_searches', text: '250'
     end
 
+    it 'renders the publishing application' do
+      expect(page).to have_selector '.related-actions', text: 'Whitehall'
+    end
+
     it 'renders the metadata' do
       metadata = find('.page-metadata').all('dl').map do |el|
         el.all('dt,dd').map(&:text)

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,7 +1,9 @@
 RSpec.describe SingleContentItemPresenter do
   include GdsApi::TestHelpers::ContentDataApi
+
   let(:from) { '2018-01-01' }
   let(:to) { '2018-06-01' }
+
   let(:metrics) do
     {
       'title' => 'The title',

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -28,6 +28,21 @@ RSpec.describe SingleContentItemPresenter do
       date_range)
   end
 
+
+  describe '#publishing_app' do
+    it 'does not fail if no publishing app' do
+      metrics['publishing_app'] = nil
+
+      expect(subject.publishing_app).to eq('Unknown')
+    end
+
+    it 'capitalizes the publishing_app if present' do
+      metrics['publishing_app'] = 'whitehall'
+
+      expect(subject.publishing_app).to eq('Whitehall')
+    end
+  end
+
   describe '#metadata' do
     it 'returns a hash with the metadata' do
       expect(subject.metadata).to eq(

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -61,7 +61,8 @@ module GdsApi
           first_published_at: '2018-02-01T00:00:00.000Z',
           public_updated_at: '2018-04-25T00:00:00.000Z',
           primary_organisation_title: 'The ministry',
-          document_type: "news_story"
+          document_type: "news_story",
+          publishing_app: 'whitehall',
         }
       end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/061BqCh7/688-1-display-the-application-that-published-the-page)


**As a** Content Designer
**I want** to know what application has created the document
**So** that I can edit it with the right application

## What

Use the field `publishing_app` to display the application that edited 
the document. 

In future stories we will provide a link to open the document directly
in the publishing-app, but to keep the story simple, we will just render
the name of the application.

## Why

Adding a link to the publishing app depends on the specific format
of each application, so we would rather take this approach in smaller
steps and prioritise this work accordingly.

### After:

![image](https://user-images.githubusercontent.com/227328/45882673-c4df7600-bda6-11e8-9c8f-0ec76f7c1763.png)

