### PR TITLE
Add additional metrics to single content item page

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -13,7 +13,9 @@ class SingleContentItemPresenter
               :satisfaction_score_series,
               :title,
               :unique_pageviews,
-              :unique_pageviews_series
+              :unique_pageviews_series,
+              :number_of_pdfs,
+              :word_count
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
@@ -35,6 +37,8 @@ private
     @pageviews = format_metric_value('pageviews', metrics[:pageviews])
     @number_of_feedback_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
     @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
+    @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
+    @word_count = format_metric_value('word_count', metrics[:word_count])
     @satisfaction_score = format_metric_value('satisfaction_score', metrics[:satisfaction_score])
     @title = metrics[:title]
     @metadata = {

--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -10,6 +10,6 @@ private
   end
 
   def default_metrics
-    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches feedex_comments].freeze
+    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count].freeze
   end
 end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -156,11 +156,21 @@
     <%= render 'chart', series: @performance_data.number_of_feedback_comments_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
     <a href="" class="govuk-link">Feedback CSV</a>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+    <h2 class="govuk-heading-l">Page Content</h2>
+    <div class="govuk-grid-column-one-half">
+      <div class="metric_summary word_count">
+      <%= render 'metric_header', title: 'Word Count', value: @performance_data.word_count %>
+      </div>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <div class="metric_summary number_of_pdfs">
+      <%= render 'metric_header', title: 'Number of PDFs', value: @performance_data.number_of_pdfs %>
+      </div>
+    </div>
+
+
   </div>
 </div>
-
-
-
-
-
-

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'date selection', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count] }
 
   before do
     initial_page_stub

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,8 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments word_count number_of_pdfs] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }
   let(:month_and_date_string_for_date1) { (from - 1.day).to_s.last(5) }
@@ -37,6 +36,14 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     it 'renders a metric for number_of_feedback_comments' do
       expect(page).to have_selector '.metric_summary.number_of_feedback_comments', text: '20'
+    end
+
+    it 'renders a metric for number_of_pdfs' do
+      expect(page).to have_selector '.metric_summary.number_of_pdfs', text: '3'
+    end
+
+    it 'renders a metric for word_count' do
+      expect(page).to have_selector '.metric_summary.word_count', text: '200'
     end
 
     it 'renders the page title' do

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -57,6 +57,8 @@ module GdsApi
           satisfaction_score: 0.255,
           number_of_internal_searches: 250,
           feedex_comments: 20,
+          number_of_pdfs: 3,
+          word_count: 200,
           title: "Content Title",
           first_published_at: '2018-02-01T00:00:00.000Z',
           public_updated_at: '2018-04-25T00:00:00.000Z',
@@ -92,6 +94,16 @@ module GdsApi
             { "date" => (from - 1.day).to_s, "value" => 1 },
             { "date" => (from - 2.days).to_s, "value" => 0.9 },
             { "date" => (to + 1.day).to_s, "value" => 0.8 }
+          ],
+          word_count: [
+            { "date" => (from - 1.day).to_s, "value" => 200 },
+            { "date" => (from - 2.days).to_s, "value" => 200 },
+            { "date" => (to + 1.day).to_s, "value" => 200 }
+          ],
+          number_of_pdfs: [
+            { "date" => (from - 1.day).to_s, "value" => 3 },
+            { "date" => (from - 2.days).to_s, "value" => 3 },
+            { "date" => (to + 1.day).to_s, "value" => 3 }
           ]
         }
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/tYOxhCi5/645-single-page-design-latest-updates)

As a Content Designer
I want to know how many PDFs a content item has and how long it is
So that I can make the content item more accessible and readable

What
Add `number of pdfs` and `word count` metrics to single content item page.

Why
To illustrate the number of closed format attachments a single content item has
and the length of the content.

After:
<img width="1090" alt="screen shot 2018-09-24 at 12 35 52" src="https://user-images.githubusercontent.com/13124899/45950238-da4adf00-bff6-11e8-979d-a869d57f6566.png">

