### PR TITLE
Update `/content` endpoint: no longe lives within `/api`

### DIFF
--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -25,15 +25,15 @@ class GdsApi::ContentDataApi < GdsApi::Base
 private
 
   def content_data_api_endpoint
-    "#{Plek.current.find('content-performance-manager')}/api/v1"
+    Plek.current.find('content-performance-manager').to_s
   end
 
   def aggregated_metrics_url(base_path, from, to, metrics)
-    "#{content_data_api_endpoint}/metrics/#{base_path}#{query_string(from: from, to: to, metrics: metrics)}"
+    "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
   def time_series_request_url(base_path, from, to, metrics)
-    "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
+    "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
   def content_items_url(from, to, organisation_id)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -5,20 +5,20 @@ module GdsApi
     module ContentDataApi
       def content_data_api_has_metric(base_path:, from:, to:, metrics:)
         query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/metrics/#{base_path}#{query}"
+        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}#{query}"
         body = default_metric_payload(base_path)
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_does_not_have_base_path(base_path:, from:, to:, metrics:)
         query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/metrics/#{base_path}#{query}"
+        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}#{query}"
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
       def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload: nil)
         query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/metrics/#{base_path}/time-series#{query}"
+        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query}"
         body = payload.nil? ? default_timeseries_payload(from.to_date, to.to_date) : payload
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
@@ -31,7 +31,7 @@ module GdsApi
       end
 
       def content_data_api_endpoint
-        "#{Plek.current.find('content-performance-manager')}/api/v1"
+        Plek.current.find('content-performance-manager').to_s
       end
 
       def query(params)


### PR DESCRIPTION
`/content` is no longer part of our public API as it is only intended
for exploration in beta testing. 

This will prevent us from updating a documentation that is not currently
in used.

In incoming PRs we will:

Use a single endpoint to retrieve series and aggregations; this will allow us
to extract other endpoints out of our public API.