### PR TITLE
Add glance metric presenter

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -8,14 +8,9 @@ class MetricsController < ApplicationController
       date_range: date_range,
     }
 
-    glance_metrics_names = %w[unique_pageviews satisfaction_score number_of_internal_searches number_of_feedback_comments]
-
-    aggregated_metrics = FetchAggregatedMetrics.call(service_params)
+    metrics = FetchAggregatedMetrics.call(service_params)
     time_series = FetchTimeSeries.call(service_params)
-    @performance_data = SingleContentItemPresenter.new(aggregated_metrics, time_series, date_range)
-    @glance_metrics = Hash[
-      glance_metrics_names.collect { |name| [name, GlanceMetricPresenter.new(name, @performance_data.instance_variable_get("@#{name}"), time_period)] }
-    ]
+    @performance_data = SingleContentItemPresenter.new(metrics, time_series, date_range)
   end
 
   rescue_from GdsApi::HTTPNotFound do

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -8,13 +8,13 @@ class MetricsController < ApplicationController
       date_range: date_range,
     }
 
-    glance_metrics_names = %w[unique_pageviews satisfaction_score number_of_internal_searches feedex_comments]
+    glance_metrics_names = %w[unique_pageviews satisfaction_score number_of_internal_searches number_of_feedback_comments]
 
     aggregated_metrics = FetchAggregatedMetrics.call(service_params)
     time_series = FetchTimeSeries.call(service_params)
     @performance_data = SingleContentItemPresenter.new(aggregated_metrics, time_series, date_range)
     @glance_metrics = Hash[
-      glance_metrics_names.collect { |name| [name, GlanceMetricPresenter.new(name, aggregated_metrics[name], time_period)] }
+      glance_metrics_names.collect { |name| [name, GlanceMetricPresenter.new(name, @performance_data.instance_variable_get("@#{name}"), time_period)] }
     ]
   end
 

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -31,7 +31,7 @@ private
         from: (Time.zone.today - 6.months).to_s,
         to: Time.zone.today.to_s
       }
-    when 'last-1-year'
+    when 'last-year'
       {
         from: (Time.zone.today - 1.year).to_s,
         to: Time.zone.today.to_s

--- a/app/presenters/glance_metric_presenter.rb
+++ b/app/presenters/glance_metric_presenter.rb
@@ -1,0 +1,37 @@
+class GlanceMetricPresenter
+  def initialize(metric_name, metric_value, time_period)
+    @metric_name = metric_name
+    @metric_value = metric_value
+    @time_period = time_period
+
+    # Context metrics are variables that can be used in the locales.
+    # Dummy values are being used until they are available from API
+    @context_metrics = {
+      percent_org_views: 2.74,
+      total_responses: 505,
+      percent_users_searched: 0.18
+    }
+  end
+
+  def name
+    short_title = I18n.t("metrics.#{@metric_name}.short_title")
+    title = I18n.t("metrics.#{@metric_name}.title")
+    short_title.empty? ? title : short_title
+  end
+
+  def value
+    @metric_value
+  end
+
+  def trend_percentage
+    0
+  end
+
+  def context
+    I18n.t("metrics.#{@metric_name}.context", @context_metrics)
+  end
+
+  def period
+    I18n.t("metrics.show.time_periods.#{@time_period}.reference")
+  end
+end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -22,6 +22,7 @@ class SingleContentItemPresenter
     @metrics = metrics
     parse_metrics(metrics.with_indifferent_access)
     parse_time_series(time_series.with_indifferent_access)
+    add_glance_metric_presenters
   end
 
   def publishing_app
@@ -56,6 +57,14 @@ private
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
     @number_of_feedback_comments_series = get_chart_presenter(time_series, :feedex_comments)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
+  end
+
+  def add_glance_metric_presenters
+    time_period = @date_range.time_period
+    @unique_pageviews_glance_metric = GlanceMetricPresenter.new('unique_pageviews', @unique_pageviews, time_period)
+    @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
+    @number_of_internal_searches_glance_metric = GlanceMetricPresenter.new('number_of_internal_searches', @number_of_internal_searches, time_period)
+    @number_of_feedback_comments_glance_metric = GlanceMetricPresenter.new('number_of_feedback_comments', @number_of_feedback_comments, time_period)
   end
 
   def get_chart_presenter(time_series, metric)

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -1,3 +1,6 @@
+<%
+  metric = @glance_metrics[metric_name]
+%>
 <% if metric %>
   <div class="govuk-grid-column-one-quarter">
     <%= render "components/glance-metric", {

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -1,5 +1,5 @@
 <%
-  metric = @glance_metrics[metric_name]
+  metric = @performance_data.instance_variable_get("@#{metric_name}_glance_metric")
 %>
 <% if metric %>
   <div class="govuk-grid-column-one-quarter">

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -1,0 +1,11 @@
+<% if metric %>
+  <div class="govuk-grid-column-one-quarter">
+    <%= render "components/glance-metric", {
+        name: metric.name,
+        figure: metric.value,
+        context: metric.context,
+        trend_percentage: metric.trend_percentage,
+        period: metric.period
+      } %>
+  </div>
+<% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -107,7 +107,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
-    
+
     <div class="metric_summary satisfaction_score">
       <%= render 'metric_header', title: 'User satisfaction score', value: @performance_data.satisfaction_score %>
     </div>
@@ -119,15 +119,10 @@
     <div class="metric_summary number_of_feedback_comments">
       <%= render 'metric_header', title: t("metrics.feedex_comments.title"), value: @performance_data.number_of_feedback_comments %>
     </div>
-    <%= render 'chart', series: @summary.number_of_feedback_comments_series %>
+    <%= render 'chart', series: @performance_data.number_of_feedback_comments_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
     <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.feedex_comments.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-
-  </div>
-</div>
-
-
 
     <h2 class="govuk-heading-l">Page Content</h2>
     <div class="govuk-grid-column-one-half">

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -71,10 +71,10 @@
 } %>
 
 <div class="govuk-grid-row">
-  <%= render "glance_metric", metric: @glance_metrics["unique_pageviews"] %>
-  <%= render "glance_metric", metric: @glance_metrics["satisfaction_score"] %> 
-  <%= render "glance_metric", metric: @glance_metrics["number_of_internal_searches"] %> 
-  <%= render "glance_metric", metric: @glance_metrics["feedex_comments"] %> 
+  <%= render "glance_metric", metric_name: "unique_pageviews" %>
+  <%= render "glance_metric", metric_name: "satisfaction_score" %> 
+  <%= render "glance_metric", metric_name: "number_of_internal_searches" %> 
+  <%= render "glance_metric", metric_name: "feedex_comments" %> 
 </div>
 
 <div class="govuk-grid-row">

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -74,7 +74,7 @@
   <%= render "glance_metric", metric_name: "unique_pageviews" %>
   <%= render "glance_metric", metric_name: "satisfaction_score" %> 
   <%= render "glance_metric", metric_name: "number_of_internal_searches" %> 
-  <%= render "glance_metric", metric_name: "feedex_comments" %> 
+  <%= render "glance_metric", metric_name: "number_of_feedback_comments" %> 
 </div>
 
 <div class="govuk-grid-row">
@@ -117,11 +117,11 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary number_of_feedback_comments">
-      <%= render 'metric_header', title: t("metrics.feedex_comments.title"), value: @performance_data.number_of_feedback_comments %>
+      <%= render 'metric_header', title: t("metrics.number_of_feedback_comments.title"), value: @performance_data.number_of_feedback_comments %>
     </div>
     <%= render 'chart', series: @performance_data.number_of_feedback_comments_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
-    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.feedex_comments.title") %></a>
+    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.number_of_feedback_comments.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-l">Page Content</h2>
@@ -136,7 +136,6 @@
       <%= render 'metric_header', title: 'Number of PDFs', value: @performance_data.number_of_pdfs %>
       </div>
     </div>
-
 
   </div>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -39,32 +39,32 @@
   dates: [
     {
       value: "last-30-days",
-      text: t(".time_periods.last_30_days"),
+      text: t(".time_periods.last-30-days.leading"),
       hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
     {
       value: "last-month",
-      text: t(".time_periods.last_month"),
+      text: t(".time_periods.last-month.leading"),
       hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
     },
     {
       value: "last-3-months",
-      text: t(".time_periods.last_3_months"),
+      text: t(".time_periods.last-3-months.leading"),
       hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
     {
       value: "last-6-months",
-      text: t(".time_periods.last_6_months"),
+      text: t(".time_periods.last-6-months.leading"),
       hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
     {
       value: "last-1-year",
-      text: t(".time_periods.last_year"),
+      text: t(".time_periods.last-year.leading"),
       hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
     {
       value: "last-2-years",
-      text: t(".time_periods.last_2_years"),
+      text: t(".time_periods.last-2-years.leading"),
       hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     }
   ]

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -58,7 +58,7 @@
       hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
     {
-      value: "last-1-year",
+      value: "last-year",
       text: t(".time_periods.last-year.leading"),
       hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
     },
@@ -71,45 +71,10 @@
 } %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-quarter">
-    <%= render "components/glance-metric", {
-      name: t("metrics.unique_pageviews.title"),
-      figure: @performance_data.unique_pageviews,
-      context: t("metrics.unique_pageviews.context"),
-      trend_percentage: 0,
-      period: "from previous 30 days"
-    } %>
-  </div>
-
-  <div class="govuk-grid-column-one-quarter">
-    <%= render "components/glance-metric", {
-      name: t("metrics.satisfaction_score.title"),
-      figure: @performance_data.satisfaction_score,
-      context: t("metrics.satisfaction_score.context"),
-      trend_percentage: 0,
-      period: "from previous 30 days"
-    } %>
-  </div>
-
-  <div class="govuk-grid-column-one-quarter">
-    <%= render "components/glance-metric", {
-      name: t("metrics.internal_searches.title"),
-      figure: @performance_data.number_of_internal_searches,
-      context: t("metrics.internal_searches.context"),
-      trend_percentage: 0,
-      period: "from previous 30 days"
-    } %>
-  </div>
-
-  <div class="govuk-grid-column-one-quarter">
-    <%= render "components/glance-metric", {
-      name: t("metrics.feedback_comments.title"),
-      figure: @performance_data.number_of_feedback_comments,
-      context: t("metrics.feedback_comments.context"),
-      trend_percentage: 0,
-      period: "from previous 30 days"
-    } %>
-  </div>
+  <%= render "glance_metric", metric: @glance_metrics["unique_pageviews"] %>
+  <%= render "glance_metric", metric: @glance_metrics["satisfaction_score"] %> 
+  <%= render "glance_metric", metric: @glance_metrics["number_of_internal_searches"] %> 
+  <%= render "glance_metric", metric: @glance_metrics["feedex_comments"] %> 
 </div>
 
 <div class="govuk-grid-row">
@@ -134,14 +99,15 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary number_of_internal_searches">
-      <%= render 'metric_header', title: t("metrics.internal_searches.title"), value: @performance_data.number_of_internal_searches %>
+      <%= render 'metric_header', title: t("metrics.number_of_internal_searches.title"), value: @performance_data.number_of_internal_searches %>
     </div>
     <%= render 'chart', series: @performance_data.number_of_internal_searches_series %>
     <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
-    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.internal_searches.title") %></a>
+    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.number_of_internal_searches.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
+    
     <div class="metric_summary satisfaction_score">
       <%= render 'metric_header', title: 'User satisfaction score', value: @performance_data.satisfaction_score %>
     </div>
@@ -151,12 +117,17 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <div class="metric_summary number_of_feedback_comments">
-    <%= render 'metric_header', title: 'Number of feedback comments', value: @performance_data.number_of_feedback_comments %>
+      <%= render 'metric_header', title: t("metrics.feedex_comments.title"), value: @performance_data.number_of_feedback_comments %>
     </div>
-    <%= render 'chart', series: @performance_data.number_of_feedback_comments_series %>
-    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold">Download the data</span><br>
-    <a href="" class="govuk-link">Feedback CSV</a>
+    <%= render 'chart', series: @summary.number_of_feedback_comments_series %>
+    <span class="govuk-body govuk-body-s govuk-!-font-weight-bold"><%= t ".download.download_data" %></span><br>
+    <a href="" class="govuk-link"><%= t ".download.csv_link", metric_name: t("metrics.feedex_comments.title") %></a>
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+  </div>
+</div>
+
+
 
     <h2 class="govuk-heading-l">Page Content</h2>
     <div class="govuk-grid-column-one-half">

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -55,7 +55,7 @@ en:
         The more users who responded, the more reliable the score is. For a more reliable score
         on a page that doens't have many responses, choose a longer time period. This survey was
         introduced in February 2018 so there are no responses before this date.
-    feedex_comments:
+    number_of_feedback_comments:
       title: 'Number of feedback comments'
       short_title: 'Feedback comments'
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -6,8 +6,9 @@ en:
   metrics:
     unique_pageviews:
       title: 'Unique pageviews'
+      short_title: ''
       summary: 'Number of visits during which the page was viewed at least once'
-      context: 'Ranked %{position} of %{total_items} content items'
+      context: 'This page makes up %{percent_org_views}% of all views.'
       unit: ''
       about: >
         This represents the number of visits in which the page was viewed at least once. 
@@ -15,6 +16,7 @@ en:
         it will show up as 1 unique pageview.
     pageviews:
       title: 'Pageviews'
+      short_title: ''
       summary: 'Number of times the page was viewed'
       context: ''
       unit: ''
@@ -24,6 +26,7 @@ en:
         1 unique pageview).
     pageviews_per_visit:
       title: 'Pageviews per visit'
+      short_title: ''
       summary: 'Number of times per visit the page was viewed'
       context: ''
       unit: ''
@@ -32,16 +35,18 @@ en:
         shows on average how many times a page was viewed during users' session. If a page has a 
         high ratio (above 1.4), this indicates that users have to come back to that page within 
         their session - investigate the navigation from that page further to identify any issues.
-    internal_searches:
+    number_of_internal_searches:
       title: 'Searches from the page'
+      short_title: ''
       summary: 'Number of on-page searches'
-      context: '%{percentage} of users searched from the page'
+      context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       about: >
         This is the number of internal site search that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.
     satisfaction_score:
       title: 'User satisfaction score'
+      short_title: ''
       summary: 'Percentage of users who answered ''yes'' to the ''Is this page useful?'' survey'
       context: 'Users who found this page useful, out of %{total_responses} responses'
       unit: ''
@@ -50,8 +55,9 @@ en:
         The more users who responded, the more reliable the score is. For a more reliable score
         on a page that doens't have many responses, choose a longer time period. This survey was
         introduced in February 2018 so there are no responses before this date.
-    feedback_comments:
+    feedex_comments:
       title: 'Number of feedback comments'
+      short_title: 'Feedback comments'
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''
       context: ''
       unit: 'comments'
@@ -64,6 +70,7 @@ en:
         You'll need a Signon account with Feedback Explorer permissions to see the comments.
     word_count:
       title: 'Word count'
+      short_title: ''
       summary: 'Number of words on the page'
       context: ''
       unit: ''
@@ -73,6 +80,7 @@ en:
         be shorter. Otherwise, does it have headings and bulletpoint to help users scan?
     pdf_count:
       title: 'Number of PDFs'
+      short_title: ''
       summary: 'Number of .pdf attachements on the page'
       context: ''
       unit: ''

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -17,9 +17,21 @@ en:
         download_data: 'Download the data'
         csv_link: '%{metric_name} CSV'
       time_periods:
-        last_30_days: 'Past 30 days'
-        last_month: 'Last month'
-        last_3_months: 'Past 3 months'
-        last_6_months: 'Past 6 months'
-        last_year: 'Past year'
-        last_2_years: 'Past 2 years'
+        last-30-days: 
+          leading: 'Past 30 days'
+          reference: 'from previous 30 days'
+        last-month: 
+          leading: 'Last month'
+          reference: 'from previous month'
+        last-3-months: 
+          leading: 'Past 3 months'
+          reference: 'from previous 3 months'
+        last-6-months: 
+          leading: 'Past 6 months'
+          reference: 'from previous 6 months'
+        last-year: 
+          leading: 'Past year'
+          reference: 'from previous year'
+        last-2-years:
+          leading: 'Past 2 years '
+          reference: 'from previous 2 years'

--- a/spec/factories/date_range.rb
+++ b/spec/factories/date_range.rb
@@ -16,8 +16,8 @@ FactoryBot.define do
       initialize_with { new('last-6-months') }
     end
 
-    trait :last_1_year do
-      initialize_with { new('last-1-year') }
+    trait :last_year do
+      initialize_with { new('last-year') }
     end
 
     trait :last_2_years do

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe 'date selection', type: :feature do
   end
 
   it 'renders data for the last year when `Past year` is selected' do
-    date_range = build(:date_range, :last_1_year)
+    date_range = build(:date_range, :last_year)
     stub_response_for_date_range(date_range.from.to_date, date_range.to.to_date)
-    visit_page_and_filter_by_date_range('last-1-year')
+    visit_page_and_filter_by_date_range('last-year')
     expect_metrics_for_each_date_to_be_correct(date_range.from.to_date, date_range.to.to_date)
   end
 

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe DateRange do
     it 'returns today`s date if selected time period is `last-6-months`' do
       expect(DateRange.new('last-6-months').to).to eq(Time.zone.today.to_s)
     end
-    it 'returns today`s date if selected time period is `last-1-year`' do
-      expect(DateRange.new('last-1-year').to).to eq(Time.zone.today.to_s)
+    it 'returns today`s date if selected time period is `last-year`' do
+      expect(DateRange.new('last-year').to).to eq(Time.zone.today.to_s)
     end
     it 'returns today`s date if selected time period is `last-2-years`' do
       expect(DateRange.new('last-2-years').to).to eq(Time.zone.today.to_s)
@@ -29,8 +29,8 @@ RSpec.describe DateRange do
     it 'returns date of 6 months ago if selected time period is `last-6-months`' do
       expect(DateRange.new('last-6-months').from).to eq((Time.zone.today - 6.months).to_s)
     end
-    it 'returns date of 1 year ago if selected time period is `last-1-year`' do
-      expect(DateRange.new('last-1-year').from).to eq((Time.zone.today - 1.year).to_s)
+    it 'returns date of 1 year ago if selected time period is `last-year`' do
+      expect(DateRange.new('last-year').from).to eq((Time.zone.today - 1.year).to_s)
     end
     it 'returns date of 2 years ago if selected time period is `last-2-years`' do
       expect(DateRange.new('last-2-years').from).to eq((Time.zone.today - 2.years).to_s)

--- a/spec/presenters/glance_metric_presenter_spec.rb
+++ b/spec/presenters/glance_metric_presenter_spec.rb
@@ -1,0 +1,63 @@
+RSpec.describe GlanceMetricPresenter do
+  let(:from) { '2018-01-13' }
+  let(:to) { '2018-01-15' }
+
+  before(:each) do
+    en = { metrics: {
+            example_metric: {
+              title: 'Example metric full title',
+              short_title: 'Example metric short title',
+              context: 'Metric context'
+            },
+            show: {
+              time_periods: {
+                last_30_days: {
+                  reference: "from previous 30 days"
+                }
+              }
+            }
+        } }
+    I18n.backend.store_translations(:en, en)
+  end
+
+  subject do
+    GlanceMetricPresenter.new(
+      "example_metric", 10, 'last-30-days'
+    )
+  end
+
+  it 'returns short metric name when available' do
+    expect(subject.name).to eq I18n.t('metrics.example_metric.short_title')
+  end
+
+  it 'returns full metric name when short title unavailable' do
+    change_metric_translation(:short_title, '')
+    expect(subject.name).to eq I18n.t('metrics.example_metric.title')
+  end
+
+  it 'returns metric value' do
+    expect(subject.value).to eq 10
+  end
+
+  it 'returns trend percentage' do
+    expect(subject.trend_percentage).to eq 0
+  end
+
+  it 'returns context' do
+    expect(subject.context).to eq I18n.t('metrics.example_metric.context')
+  end
+
+  it 'returns context using context metrics' do
+    change_metric_translation(:context, 'Metric context with %<total_responses>s')
+    expect(subject.context).to eq I18n.t('metrics.example_metric.context', total_responses: 505)
+  end
+
+  it 'returns time period text' do
+    expect(subject.period).to eq I18n.t('metrics.show.time_periods.last_30_days.reference')
+  end
+
+  def change_metric_translation(attribute, value)
+    en = { metrics: { example_metric: { attribute => value } } }
+    I18n.backend.store_translations(:en, en)
+  end
+end


### PR DESCRIPTION
This adds a glance metric presenter that helps combine metrics and text for locales to produce formatted text for use in views. This refactor allows better use of partials to reduce repetative code in the `metrics/show` view.