### PR TITLE
Change link text as per designs

### DIFF
--- a/app/assets/stylesheets/components/_related-actions.scss
+++ b/app/assets/stylesheets/components/_related-actions.scss
@@ -1,3 +1,5 @@
+@import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
+
 .app-c-related-actions {
   border-top: 1px solid $govuk-border-colour;
 }
@@ -7,3 +9,6 @@
   @include govuk-responsive-margin(3, "bottom");
 }
 
+.app-c-related-actions__accessibility-message {
+  @include govuk-visually-hidden;
+}

--- a/app/views/components/_related-actions.html.erb
+++ b/app/views/components/_related-actions.html.erb
@@ -6,9 +6,18 @@
     <div class="govuk-body govuk-body-s">
       <dl>
         <% links.each do |l| %>
-          <% if l[:header] && l[:link_text] && l[:link_url] %>
+          <% if l[:header] && l[:label] && l[:link_url] %>
             <dt class="app-c-related-actions__header govuk-!-font-weight-bold"><%= l[:header] %></dt>
-            <dd class="app-c-related-actions__link"><a href="<%= l[:link_url] %>" class="govuk-link"><%= l[:link_text] %></a></dd>
+            <dd class="app-c-related-actions__link">
+              <a href="<%= l[:link_url] %>" class="govuk-link">
+                <% if l[:accessibility_message] %>
+                  <% p l[:accessibility_message] %> 
+                  <span class="app-c-related-actions__accessibility-message"><%=l[:accessibility_message]%></span> <%= l[:label] %>
+                <% else %>
+                  <%= l[:label] %>
+                <% end %>
+              </a>
+            </dd>
           <% end %>
         <% end %>
       </dl>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -21,12 +21,13 @@
                   {
                     header: t(".navigation.visit_page"),
                     link_url: "//www.gov.uk#{@performance_data.metadata[:base_path]}",
-                    link_text: t('.navigation.visit_link', content_title: @performance_data.title)
+                    accessibility_message: t('.navigation.accessibility_message'),
+                    label: @performance_data.title
                   },
                   {
                     header: "Make changes to the page",
                     link_url: "#",
-                    link_text: @performance_data.publishing_app
+                    label: t('.navigation.edit_link', publisher_app: @performance_data.publishing_app)
                   }
                 ]
       } %>
@@ -72,9 +73,9 @@
 
 <div class="govuk-grid-row">
   <%= render "glance_metric", metric_name: "unique_pageviews" %>
-  <%= render "glance_metric", metric_name: "satisfaction_score" %> 
-  <%= render "glance_metric", metric_name: "number_of_internal_searches" %> 
-  <%= render "glance_metric", metric_name: "number_of_feedback_comments" %> 
+  <%= render "glance_metric", metric_name: "satisfaction_score" %>
+  <%= render "glance_metric", metric_name: "number_of_internal_searches" %>
+  <%= render "glance_metric", metric_name: "number_of_feedback_comments" %>
 </div>
 
 <div class="govuk-grid-row">

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -10,7 +10,7 @@ en:
       navigation:
         back_link: 'View all pages'
         visit_page: 'View the page on GOV.UK'
-        visit_link: 'Visit %{content_title}'
+        accessibility_message: 'Visit on GOV.UK:'
         edit_page: 'Make changes to the page'
         edit_link: 'Edit on %{publisher_app}'
       section_headings:
@@ -21,19 +21,19 @@ en:
         download_data: 'Download the data'
         csv_link: '%{metric_name} CSV'
       time_periods:
-        last-30-days: 
+        last-30-days:
           leading: 'Past 30 days'
           reference: 'from previous 30 days'
-        last-month: 
+        last-month:
           leading: 'Last month'
           reference: 'from previous month'
-        last-3-months: 
+        last-3-months:
           leading: 'Past 3 months'
           reference: 'from previous 3 months'
-        last-6-months: 
+        last-6-months:
           leading: 'Past 6 months'
           reference: 'from previous 6 months'
-        last-year: 
+        last-year:
           leading: 'Past year'
           reference: 'from previous year'
         last-2-years:

--- a/spec/components/related_actions_spec.rb
+++ b/spec/components/related_actions_spec.rb
@@ -7,12 +7,13 @@ RSpec.describe "Related actions", type: :view do
                 {
                   header: "View the page on GOV.UK",
                   link_url: "//www.gov.uk/govpage",
-                  link_text: "Visit Govpage"
+                  label: "Govpage",
+                  accessibility_message: "Visit on GOV.UK:"
                 },
                 {
                   header: "Make changes to the page",
                   link_url: "//www.gov.uk/moregov",
-                  link_text: "Visit More gov"
+                  label: "More gov"
                 }
               ]
       }
@@ -34,9 +35,21 @@ RSpec.describe "Related actions", type: :view do
     assert_select "dd", 2
     assert_select ".app-c-related-actions__header", text: "View the page on GOV.UK"
     assert_select ".app-c-related-actions__header", text: "Make changes to the page"
-    assert_select "a", href: "//www.gov.uk/govpage", text: "Visit Govpage"
-    assert_select "a", href: "//www.gov.uk/moregov", text: "Visit More gov"
+    assert_select "a", href: "//www.gov.uk/govpage", text: "Visit on GOV.UK: Govpage"
+    assert_select "a", href: "//www.gov.uk/moregov", text: "More gov"
   end
+
+  context "recieves an accessibility_message" do
+    it "renders accessibility message which is visually hidden" do
+      render_component(data)
+      assert_select ".app-c-related-actions", 1
+      assert_select "dl", 1
+      assert_select "dt", 2
+      assert_select "dd", 2
+      assert_select ".app-c-related-actions__accessibility-message", 1
+    end
+  end
+
 
   def render_component(locals)
     render partial: "components/related-actions", locals: locals


### PR DESCRIPTION
Remove the word `visit` from the link to content item on gov.uk link on
the single content item page.

The word `visit` is necessary for accessibility purposes but not helpful for
the design so this PR hides it using the visually-hidden class to allow
screen readers to understand it.

Before: 
<img width="1035" alt="screen shot 2018-09-26 at 12 27 28" src="https://user-images.githubusercontent.com/13124899/46077099-95a27d80-c187-11e8-886a-540ed9e9badb.png">
After:
<img width="1040" alt="screen shot 2018-09-26 at 12 27 17" src="https://user-images.githubusercontent.com/13124899/46077106-9b985e80-c187-11e8-82af-aa0440ceda17.png">
