### PR TITLE
Use locales for table tabs

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -42,7 +42,7 @@
     </div>
     <div class="app-c-chart__table" id="<%= table_id %>">
       <%= render "govuk_publishing_components/components/details", {
-              title: "View #{chart_label} table"
+              title: t(".table_dropdown", metric_name: chart_label)
             } do %>
           <div tabindex="0">
              <table class="govuk-table">

--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -1,8 +1,7 @@
 en:
   components:
     chart:
-      chart_tab: '%{metric_name} chart'
-      table_tab: '%{metric_name} tab'
+      table_dropdown: 'View %{metric_name} table'
     metadata:
       labels:
         status: 'Status'


### PR DESCRIPTION
The dropdown text for the table tab is rendered using locales.