### PR TITLE
Enable displaying of satisfaction score

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -4,7 +4,7 @@ module MetricsFormatterHelper
 
   def format_metric_value(metric_name, figure)
     if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s) && figure
-      number_to_percentage(figure * 100, precision: 0)
+      number_to_percentage(figure, precision: 0)
     else
       figure
     end

--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -10,6 +10,6 @@ private
   end
 
   def default_metrics
-    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count].freeze
+    @default_metrics ||= %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count satisfaction_score].freeze
   end
 end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe 'date selection', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments number_of_pdfs word_count satisfaction_score] }
 
   before do
     initial_page_stub

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe '/content' do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments word_count number_of_pdfs] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments word_count number_of_pdfs satisfaction_score] }
   let(:from) { Time.zone.today.last_month.beginning_of_month.to_s('%F') }
   let(:to) { Time.zone.today.last_month.end_of_month.to_s('%F') }
   let(:items) do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
-  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments word_count number_of_pdfs] }
+  let(:metrics) { %w[pageviews unique_pageviews number_of_internal_searches feedex_comments word_count number_of_pdfs satisfaction_score] }
   let(:from) { Time.zone.today - 30.days }
   let(:to) { Time.zone.today }
   let(:month_and_date_string_for_date1) { (from - 1.day).to_s.last(5) }

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe MetricsFormatterHelper do
   context 'metric needs to be rendered as a percentage' do
     it 'displays value as a percentage' do
-      value = format_metric_value('satisfaction_score', 0.9)
+      value = format_metric_value('satisfaction_score', 90.000)
       expect(value).to eq '90%'
     end
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SingleContentItemPresenter do
       'document_type' => 'news_story',
       'unique_pageviews' => 2030,
       'pageviews' => 3000,
-      'satisfaction_score' => 0.335,
+      'satisfaction_score' => 33.5,
       'number_of_internal_searches' => 120,
       'feedex_comments' => 20,
     }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -54,7 +54,7 @@ module GdsApi
           base_path: "/#{base_path}",
           unique_pageviews: 145_000,
           pageviews: 200_000,
-          satisfaction_score: 0.255,
+          satisfaction_score: 25.55,
           number_of_internal_searches: 250,
           feedex_comments: 20,
           number_of_pdfs: 3,
@@ -91,9 +91,9 @@ module GdsApi
             { "date" => (to + 1.day).to_s, "value" => 22 }
           ],
           satisfaction_score: [
-            { "date" => (from - 1.day).to_s, "value" => 1 },
-            { "date" => (from - 2.days).to_s, "value" => 0.9 },
-            { "date" => (to + 1.day).to_s, "value" => 0.8 }
+            { "date" => (from - 1.day).to_s, "value" => 100.0000 },
+            { "date" => (from - 2.days).to_s, "value" => 90.0000 },
+            { "date" => (to + 1.day).to_s, "value" => 80.0000 }
           ],
           word_count: [
             { "date" => (from - 1.day).to_s, "value" => 200 },


### PR DESCRIPTION
Also fix the formatting of percentage figures. The API already
calculates what the percentage figure should be, so we don't need to
multiply by 100 any longer. Also the design shows the percentages as
whole figures, as in 90% not 90.123%, so have tweaked that output to
match.