### PR TITLE
Remove `-` when displaying publishing application

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -28,7 +28,7 @@ class SingleContentItemPresenter
   def publishing_app
     publishing_app = @metrics['publishing_app']
 
-    publishing_app.present? ? publishing_app.capitalize : 'Unknown'
+    publishing_app.present? ? publishing_app.capitalize.tr('-', ' ') : 'Unknown'
   end
 
 private

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -37,9 +37,9 @@ RSpec.describe SingleContentItemPresenter do
     end
 
     it 'capitalizes the publishing_app if present' do
-      metrics['publishing_app'] = 'whitehall'
+      metrics['publishing_app'] = 'travel-advice'
 
-      expect(subject.publishing_app).to eq('Whitehall')
+      expect(subject.publishing_app).to eq('Travel advice')
     end
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/061BqCh7/688-1-display-the-application-that-published-the-page)

Fixes the issue when displaying the name of the rendering app. We 
were showing `Travel-advice` when processing `travel-advice`, because
we were not removing the `-`