### PR TITLE
Rename attributes in content data admin

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -1,6 +1,6 @@
 module MetricsFormatterHelper
   include ActionView::Helpers::NumberHelper
-  METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction_score).freeze
+  METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction).freeze
 
   def format_metric_value(metric_name, figure)
     if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s) && figure

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -14,7 +14,11 @@ class ChartPresenter
   end
 
   def human_friendly_metric
-    metric.to_s.tr('_', ' ').capitalize
+    if metric == :upviews
+      'Unique pageviews'
+    else
+      metric.to_s.tr('_', ' ').capitalize
+    end
   end
 
   def no_data_message

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -14,11 +14,7 @@ class ChartPresenter
   end
 
   def human_friendly_metric
-    if metric == :upviews
-      'Unique pageviews'
-    else
-      metric.to_s.tr('_', ' ').capitalize
-    end
+    I18n.t "metrics.#{metric}.title"
   end
 
   def no_data_message

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,11 +1,11 @@
 class ContentRowPresenter
-  attr_reader :title, :base_path, :document_type, :unique_pageviews,
+  attr_reader :title, :base_path, :document_type, :upviews,
               :user_satisfaction_score, :number_of_internal_searches
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
     @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
-    @unique_pageviews = data[:upviews]
+    @upviews = data[:upviews]
     @user_satisfaction_score = format_satisfaction_score(data[:satisfaction], data[:satisfaction_score_responses])
     @number_of_internal_searches = data[:searches]
   end

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,13 +1,13 @@
 class ContentRowPresenter
   attr_reader :title, :base_path, :document_type, :upviews,
-              :user_satisfaction_score, :number_of_internal_searches
+              :user_satisfaction_score, :searches
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
     @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
     @upviews = data[:upviews]
     @user_satisfaction_score = format_satisfaction_score(data[:satisfaction], data[:satisfaction_score_responses])
-    @number_of_internal_searches = data[:searches]
+    @searches = data[:searches]
   end
 
 private

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,18 +1,18 @@
 class ContentRowPresenter
   attr_reader :title, :base_path, :document_type, :upviews,
-              :user_satisfaction_score, :searches
+              :user_satisfaction, :searches
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
     @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
     @upviews = data[:upviews]
-    @user_satisfaction_score = format_satisfaction_score(data[:satisfaction], data[:satisfaction_score_responses])
+    @user_satisfaction = format_satisfaction(data[:satisfaction], data[:satisfaction_responses])
     @searches = data[:searches]
   end
 
 private
 
-  def format_satisfaction_score(score, responses)
+  def format_satisfaction(score, responses)
     return 'No responses' unless score
 
     "#{(score * 100).round(1)}% (#{responses} responses)"

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -15,7 +15,7 @@ class SingleContentItemPresenter
               :upviews,
               :upviews_series,
               :number_of_pdfs,
-              :word_count
+              :words
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
@@ -39,7 +39,7 @@ private
     @feedex = format_metric_value('feedex', metrics[:feedex])
     @searches = format_metric_value('searches', metrics[:searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
-    @word_count = format_metric_value('word_count', metrics[:word_count])
+    @words = format_metric_value('words', metrics[:words])
     @satisfaction = format_metric_headline_figure('satisfaction', metrics[:satisfaction])
     @title = metrics[:title]
     @metadata = {

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -3,8 +3,8 @@ class SingleContentItemPresenter
 
   attr_reader :date_range,
               :metadata,
-              :number_of_feedback_comments,
-              :number_of_feedback_comments_series,
+              :feedex_comments,
+              :feedex_comments_series,
               :number_of_internal_searches,
               :number_of_internal_searches_series,
               :pageviews,
@@ -36,7 +36,7 @@ private
   def parse_metrics(metrics)
     @upviews = format_metric_value('upviews', metrics[:upviews])
     @pageviews = format_metric_value('pageviews', metrics[:pageviews])
-    @number_of_feedback_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
+    @feedex_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
     @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
     @word_count = format_metric_value('word_count', metrics[:word_count])
@@ -55,7 +55,7 @@ private
     @upviews_series = get_chart_presenter(time_series, :upviews)
     @pageviews_series = get_chart_presenter(time_series, :pageviews)
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
-    @number_of_feedback_comments_series = get_chart_presenter(time_series, :feedex_comments)
+    @feedex_comments_series = get_chart_presenter(time_series, :feedex_comments)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
   end
 
@@ -64,7 +64,7 @@ private
     @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
     @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
     @number_of_internal_searches_glance_metric = GlanceMetricPresenter.new('number_of_internal_searches', @number_of_internal_searches, time_period)
-    @number_of_feedback_comments_glance_metric = GlanceMetricPresenter.new('number_of_feedback_comments', @number_of_feedback_comments, time_period)
+    @feedex_comments_glance_metric = GlanceMetricPresenter.new('feedex_comments', @feedex_comments, time_period)
   end
 
   def get_chart_presenter(time_series, metric)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -12,8 +12,8 @@ class SingleContentItemPresenter
               :satisfaction_score,
               :satisfaction_score_series,
               :title,
-              :unique_pageviews,
-              :unique_pageviews_series,
+              :upviews,
+              :upviews_series,
               :number_of_pdfs,
               :word_count
 
@@ -34,7 +34,7 @@ class SingleContentItemPresenter
 private
 
   def parse_metrics(metrics)
-    @unique_pageviews = format_metric_value('unique_pageviews', metrics[:unique_pageviews])
+    @upviews = format_metric_value('upviews', metrics[:upviews])
     @pageviews = format_metric_value('pageviews', metrics[:pageviews])
     @number_of_feedback_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
     @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
@@ -52,7 +52,7 @@ private
   end
 
   def parse_time_series(time_series)
-    @unique_pageviews_series = get_chart_presenter(time_series, :unique_pageviews)
+    @upviews_series = get_chart_presenter(time_series, :upviews)
     @pageviews_series = get_chart_presenter(time_series, :pageviews)
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
     @number_of_feedback_comments_series = get_chart_presenter(time_series, :feedex_comments)
@@ -61,7 +61,7 @@ private
 
   def add_glance_metric_presenters
     time_period = @date_range.time_period
-    @unique_pageviews_glance_metric = GlanceMetricPresenter.new('unique_pageviews', @unique_pageviews, time_period)
+    @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
     @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
     @number_of_internal_searches_glance_metric = GlanceMetricPresenter.new('number_of_internal_searches', @number_of_internal_searches, time_period)
     @number_of_feedback_comments_glance_metric = GlanceMetricPresenter.new('number_of_feedback_comments', @number_of_feedback_comments, time_period)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -5,8 +5,8 @@ class SingleContentItemPresenter
               :metadata,
               :feedex_comments,
               :feedex_comments_series,
-              :number_of_internal_searches,
-              :number_of_internal_searches_series,
+              :searches,
+              :searches_series,
               :pviews,
               :pviews_series,
               :satisfaction_score,
@@ -37,7 +37,7 @@ private
     @upviews = format_metric_value('upviews', metrics[:upviews])
     @pviews = format_metric_value('pviews', metrics[:pviews])
     @feedex_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
-    @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
+    @searches = format_metric_value('searches', metrics[:searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
     @word_count = format_metric_value('word_count', metrics[:word_count])
     @satisfaction_score = format_metric_headline_figure('satisfaction_score', metrics[:satisfaction_score])
@@ -54,7 +54,7 @@ private
   def parse_time_series(time_series)
     @upviews_series = get_chart_presenter(time_series, :upviews)
     @pviews_series = get_chart_presenter(time_series, :pviews)
-    @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
+    @searches_series = get_chart_presenter(time_series, :searches)
     @feedex_comments_series = get_chart_presenter(time_series, :feedex_comments)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
   end
@@ -63,7 +63,7 @@ private
     time_period = @date_range.time_period
     @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
     @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
-    @number_of_internal_searches_glance_metric = GlanceMetricPresenter.new('number_of_internal_searches', @number_of_internal_searches, time_period)
+    @searches_glance_metric = GlanceMetricPresenter.new('searches', @searches, time_period)
     @feedex_comments_glance_metric = GlanceMetricPresenter.new('feedex_comments', @feedex_comments, time_period)
   end
 

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -7,8 +7,8 @@ class SingleContentItemPresenter
               :feedex_comments_series,
               :number_of_internal_searches,
               :number_of_internal_searches_series,
-              :pageviews,
-              :pageviews_series,
+              :pviews,
+              :pviews_series,
               :satisfaction_score,
               :satisfaction_score_series,
               :title,
@@ -35,7 +35,7 @@ private
 
   def parse_metrics(metrics)
     @upviews = format_metric_value('upviews', metrics[:upviews])
-    @pageviews = format_metric_value('pageviews', metrics[:pageviews])
+    @pviews = format_metric_value('pviews', metrics[:pviews])
     @feedex_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
     @number_of_internal_searches = format_metric_value('number_of_internal_searches', metrics[:number_of_internal_searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
@@ -53,7 +53,7 @@ private
 
   def parse_time_series(time_series)
     @upviews_series = get_chart_presenter(time_series, :upviews)
-    @pageviews_series = get_chart_presenter(time_series, :pageviews)
+    @pviews_series = get_chart_presenter(time_series, :pviews)
     @number_of_internal_searches_series = get_chart_presenter(time_series, :number_of_internal_searches)
     @feedex_comments_series = get_chart_presenter(time_series, :feedex_comments)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -14,7 +14,7 @@ class SingleContentItemPresenter
               :title,
               :upviews,
               :upviews_series,
-              :number_of_pdfs,
+              :pdf_count,
               :words
 
   def initialize(metrics, time_series, date_range)
@@ -38,7 +38,7 @@ private
     @pviews = format_metric_value('pviews', metrics[:pviews])
     @feedex = format_metric_value('feedex', metrics[:feedex])
     @searches = format_metric_value('searches', metrics[:searches])
-    @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
+    @pdf_count = format_metric_value('pdf_count', metrics[:pdf_count])
     @words = format_metric_value('words', metrics[:words])
     @satisfaction = format_metric_headline_figure('satisfaction', metrics[:satisfaction])
     @title = metrics[:title]

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -9,8 +9,8 @@ class SingleContentItemPresenter
               :searches_series,
               :pviews,
               :pviews_series,
-              :satisfaction_score,
-              :satisfaction_score_series,
+              :satisfaction,
+              :satisfaction_series,
               :title,
               :upviews,
               :upviews_series,
@@ -40,7 +40,7 @@ private
     @searches = format_metric_value('searches', metrics[:searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
     @word_count = format_metric_value('word_count', metrics[:word_count])
-    @satisfaction_score = format_metric_headline_figure('satisfaction_score', metrics[:satisfaction_score])
+    @satisfaction = format_metric_headline_figure('satisfaction', metrics[:satisfaction])
     @title = metrics[:title]
     @metadata = {
       base_path: metrics[:base_path],
@@ -56,13 +56,13 @@ private
     @pviews_series = get_chart_presenter(time_series, :pviews)
     @searches_series = get_chart_presenter(time_series, :searches)
     @feedex_series = get_chart_presenter(time_series, :feedex)
-    @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
+    @satisfaction_series = get_chart_presenter(time_series, :satisfaction)
   end
 
   def add_glance_metric_presenters
     time_period = @date_range.time_period
     @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
-    @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
+    @satisfaction_glance_metric = GlanceMetricPresenter.new('satisfaction', @satisfaction, time_period)
     @searches_glance_metric = GlanceMetricPresenter.new('searches', @searches, time_period)
     @feedex_glance_metric = GlanceMetricPresenter.new('feedex', @feedex, time_period)
   end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -3,8 +3,8 @@ class SingleContentItemPresenter
 
   attr_reader :date_range,
               :metadata,
-              :feedex_comments,
-              :feedex_comments_series,
+              :feedex,
+              :feedex_series,
               :searches,
               :searches_series,
               :pviews,
@@ -36,7 +36,7 @@ private
   def parse_metrics(metrics)
     @upviews = format_metric_value('upviews', metrics[:upviews])
     @pviews = format_metric_value('pviews', metrics[:pviews])
-    @feedex_comments = format_metric_value('feedex_comments', metrics[:feedex_comments])
+    @feedex = format_metric_value('feedex', metrics[:feedex])
     @searches = format_metric_value('searches', metrics[:searches])
     @number_of_pdfs = format_metric_value('number_of_pdfs', metrics[:number_of_pdfs])
     @word_count = format_metric_value('word_count', metrics[:word_count])
@@ -55,7 +55,7 @@ private
     @upviews_series = get_chart_presenter(time_series, :upviews)
     @pviews_series = get_chart_presenter(time_series, :pviews)
     @searches_series = get_chart_presenter(time_series, :searches)
-    @feedex_comments_series = get_chart_presenter(time_series, :feedex_comments)
+    @feedex_series = get_chart_presenter(time_series, :feedex)
     @satisfaction_score_series = get_chart_presenter(time_series, :satisfaction_score)
   end
 
@@ -64,7 +64,7 @@ private
     @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
     @satisfaction_score_glance_metric = GlanceMetricPresenter.new('satisfaction_score', @satisfaction_score, time_period)
     @searches_glance_metric = GlanceMetricPresenter.new('searches', @searches, time_period)
-    @feedex_comments_glance_metric = GlanceMetricPresenter.new('feedex_comments', @feedex_comments, time_period)
+    @feedex_glance_metric = GlanceMetricPresenter.new('feedex', @feedex, time_period)
   end
 
   def get_chart_presenter(time_series, metric)

--- a/app/views/components/docs/chart.yml
+++ b/app/views/components/docs/chart.yml
@@ -25,8 +25,8 @@ examples:
       caption: 'Unique page views in February'
       h_axis_title: "Day"
       v_axis_title: "Views"
-      chart_id: 'pageviews_chart'
-      table_id: 'pageviews_table'
+      chart_id: 'pviews_chart'
+      table_id: 'pviews_table'
       chart_title: 'Page views chart'
       table_title: 'Page views table'
       keys:
@@ -47,8 +47,8 @@ examples:
       caption: 'Unique page views in February'
       h_axis_title: "Day"
       v_axis_title: "Views"
-      chart_id: 'second_pageviews_chart'
-      table_id: 'second_pageviews_table'
+      chart_id: 'second_pviews_chart'
+      table_id: 'second_pviews_table'
       chart_title: 'Page views chart'
       table_title: 'Page views table'
       keys:
@@ -76,8 +76,8 @@ examples:
       table_direction: "horizontal"
       h_axis_title: "Day"
       v_axis_title: "Views"
-      chart_id: 'third_pageviews_chart'
-      table_id: 'third_pageviews_table'
+      chart_id: 'third_pviews_chart'
+      table_id: 'third_pviews_table'
       chart_title: 'Page views chart'
       table_title: 'Page views table'
       keys:

--- a/app/views/content/_content_row.html.erb
+++ b/app/views/content/_content_row.html.erb
@@ -3,7 +3,7 @@
     <span class="base-path">/<%= item.base_path %></span>
   </td>
   <td><%= item.document_type %></td>
-  <td><%= number_with_delimiter(item.unique_pageviews, delimiter: ',') %></td>
+  <td><%= number_with_delimiter(item.upviews, delimiter: ',') %></td>
   <td><%= item.user_satisfaction_score %></td>
   <td><%= item.number_of_internal_searches %></td>
 </tr>

--- a/app/views/content/_content_row.html.erb
+++ b/app/views/content/_content_row.html.erb
@@ -5,5 +5,5 @@
   <td><%= item.document_type %></td>
   <td><%= number_with_delimiter(item.upviews, delimiter: ',') %></td>
   <td><%= item.user_satisfaction_score %></td>
-  <td><%= item.number_of_internal_searches %></td>
+  <td><%= item.searches %></td>
 </tr>

--- a/app/views/content/_content_row.html.erb
+++ b/app/views/content/_content_row.html.erb
@@ -4,6 +4,6 @@
   </td>
   <td><%= item.document_type %></td>
   <td><%= number_with_delimiter(item.upviews, delimiter: ',') %></td>
-  <td><%= item.user_satisfaction_score %></td>
+  <td><%= item.user_satisfaction %></td>
   <td><%= item.searches %></td>
 </tr>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -39,8 +39,8 @@
     caption: "Unique page views",
     chart_label: "Unique page views chart",
     table_label: "Unique page views table",
-    chart_id: 'pageviews_jan_chart',
-    table_id: 'pageviews_jan_table',
+    chart_id: 'pviews_jan_chart',
+    table_id: 'pviews_jan_table',
     table_direction: 'vertical',
     keys: [*(1..30)],
     rows: [
@@ -54,8 +54,8 @@
   data2 = {
   chart_label: "Time spend on page chart",
   table_label: "Time spent on page table",
-  chart_id: 'pageviews_feb_chart',
-  table_id: 'pageviews_feb_table',
+  chart_id: 'pviews_feb_chart',
+  table_id: 'pviews_feb_table',
   table_direction: 'horizontal',
   keys: ["1st September 2018", "2nd September 2018", "3rd September 2018", "4th September 2018", "5th September 2018", "6th September 2018", "7th September 2018", "8th September 2018", "9th September 2018", "10th September 2018", "11th September 2018", "13th September 2018", "14th September 2018", "15th September 2018", "16th September 2018", "17th September 2018", "18th September 2018", "19th September 2018", "20th September 2018", "21st September 2018", "22nd September 2018", "23rd September 2018", "24th September 2018", "25th September 2018", "26th September 2018", "27th September 2018", "28th September 2018", "29th September 2018", "30th September 2018"],
   rows: [

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -73,7 +73,7 @@
 
 <div class="govuk-grid-row">
   <%= render "glance_metric", metric_name: "upviews" %>
-  <%= render "glance_metric", metric_name: "satisfaction_score" %>
+  <%= render "glance_metric", metric_name: "satisfaction" %>
   <%= render "glance_metric", metric_name: "searches" %>
   <%= render "glance_metric", metric_name: "feedex" %>
 </div>
@@ -94,7 +94,7 @@
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
 
-      <%= render 'metric_section', metric_name: 'satisfaction_score', show_trend: true %>
+      <%= render 'metric_section', metric_name: 'satisfaction', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <%= render 'metric_section', metric_name: 'feedex', show_trend: true %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -74,7 +74,7 @@
 <div class="govuk-grid-row">
   <%= render "glance_metric", metric_name: "upviews" %>
   <%= render "glance_metric", metric_name: "satisfaction_score" %>
-  <%= render "glance_metric", metric_name: "number_of_internal_searches" %>
+  <%= render "glance_metric", metric_name: "searches" %>
   <%= render "glance_metric", metric_name: "feedex_comments" %>
 </div>
 
@@ -89,7 +89,7 @@
       <%= render 'metric_section', metric_name: 'pviews', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'number_of_internal_searches', show_trend: true %>
+      <%= render 'metric_section', metric_name: 'searches', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -86,7 +86,7 @@
       <%= render 'metric_section', metric_name: 'upviews', show_trend: true  %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'pageviews', show_trend: true %>
+      <%= render 'metric_section', metric_name: 'pviews', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <%= render 'metric_section', metric_name: 'number_of_internal_searches', show_trend: true %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -72,7 +72,7 @@
 } %>
 
 <div class="govuk-grid-row">
-  <%= render "glance_metric", metric_name: "unique_pageviews" %>
+  <%= render "glance_metric", metric_name: "upviews" %>
   <%= render "glance_metric", metric_name: "satisfaction_score" %>
   <%= render "glance_metric", metric_name: "number_of_internal_searches" %>
   <%= render "glance_metric", metric_name: "number_of_feedback_comments" %>
@@ -83,7 +83,7 @@
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.performance" %></h2>
 
-      <%= render 'metric_section', metric_name: 'unique_pageviews', show_trend: true  %>
+      <%= render 'metric_section', metric_name: 'upviews', show_trend: true  %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <%= render 'metric_section', metric_name: 'pageviews', show_trend: true %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -111,8 +111,8 @@
     </div>
 
     <div class="govuk-grid-column-one-half">
-      <div class="metric_summary number_of_pdfs">
-        <%= render 'metric_header', metric_name: 'number_of_pdfs', value: @performance_data.number_of_pdfs, show_trend: false %>
+      <div class="metric_summary pdf_count">
+        <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.pdf_count, show_trend: false %>
       </div>
     </div>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -105,8 +105,8 @@
     </div>
 
     <div class="govuk-grid-column-one-half">
-      <div class="metric_summary word_count">
-        <%= render 'metric_header', metric_name: 'word_count', value: @performance_data.word_count, show_trend: false %>
+      <div class="metric_summary words">
+        <%= render 'metric_header', metric_name: 'words', value: @performance_data.words, show_trend: false %>
       </div>
     </div>
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -75,7 +75,7 @@
   <%= render "glance_metric", metric_name: "upviews" %>
   <%= render "glance_metric", metric_name: "satisfaction_score" %>
   <%= render "glance_metric", metric_name: "number_of_internal_searches" %>
-  <%= render "glance_metric", metric_name: "number_of_feedback_comments" %>
+  <%= render "glance_metric", metric_name: "feedex_comments" %>
 </div>
 
 <div class="govuk-grid-row">
@@ -97,7 +97,7 @@
       <%= render 'metric_section', metric_name: 'satisfaction_score', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'number_of_feedback_comments', show_trend: true %>
+      <%= render 'metric_section', metric_name: 'feedex_comments', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.content" %></h2>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -75,7 +75,7 @@
   <%= render "glance_metric", metric_name: "upviews" %>
   <%= render "glance_metric", metric_name: "satisfaction_score" %>
   <%= render "glance_metric", metric_name: "searches" %>
-  <%= render "glance_metric", metric_name: "feedex_comments" %>
+  <%= render "glance_metric", metric_name: "feedex" %>
 </div>
 
 <div class="govuk-grid-row">
@@ -97,7 +97,7 @@
       <%= render 'metric_section', metric_name: 'satisfaction_score', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'feedex_comments', show_trend: true %>
+      <%= render 'metric_section', metric_name: 'feedex', show_trend: true %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.content" %></h2>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -75,7 +75,7 @@ en:
         end of a transaction that started on GOV.UK.
 
         You'll need a Signon account with Feedback Explorer permissions to see the comments.
-    word_count:
+    words:
       title: 'Word count'
       short_title: ''
       summary: 'Number of words on the page'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -16,7 +16,7 @@ en:
         This represents the number of visits in which the page was viewed at least once. 
         For example, if a user visits the same page 5 times during their browsing session,
         it will show up as 1 unique pageview.
-    pageviews:
+    pviews:
       title: 'Pageviews'
       short_title: ''
       summary: 'Number of times the page was viewed'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -61,7 +61,7 @@ en:
         The more users who responded, the more reliable the score is. For a more reliable score
         on a page that doens't have many responses, choose a longer time period. This survey was
         introduced in February 2018 so there are no responses before this date.
-    feedex_comments:
+    feedex:
       title: 'Number of feedback comments'
       short_title: 'Feedback comments'
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -5,7 +5,7 @@ en:
     feedback_explorer: 'Feedback Explorer'
     none: false
   metrics:
-    unique_pageviews:
+    upviews:
       title: 'Unique pageviews'
       short_title: ''
       summary: 'Number of visits during which the page was viewed at least once'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -49,7 +49,7 @@ en:
       about: >
         This is the number of internal site search that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.
-    satisfaction_score:
+    satisfaction:
       title: 'User satisfaction score'
       short_title: ''
       summary: 'Percentage of users who answered ''yes'' to the ''Is this page useful?'' survey'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -86,7 +86,7 @@ en:
         Lots of words on a page can make content difficult for users to read online. The longer the
         page is, the less usable it is likely to be. You could investigate whether this content could
         be shorter. Otherwise, does it have headings and bulletpoint to help users scan?
-    number_of_pdfs:
+    pdf_count:
       title: 'Number of PDFs'
       short_title: ''
       summary: 'Number of .pdf attachements on the page'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -61,7 +61,7 @@ en:
         The more users who responded, the more reliable the score is. For a more reliable score
         on a page that doens't have many responses, choose a longer time period. This survey was
         introduced in February 2018 so there are no responses before this date.
-    number_of_feedback_comments:
+    feedex_comments:
       title: 'Number of feedback comments'
       short_title: 'Feedback comments'
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''
@@ -98,3 +98,4 @@ en:
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
         Serveral PDFs on one page may indicate that too many users needs are being met by them.
         Read more about why to avoid PDFs.
+

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -39,7 +39,7 @@ en:
         shows on average how many times a page was viewed during users' session. If a page has a 
         high ratio (above 1.4), this indicates that users have to come back to that page within 
         their session - investigate the navigation from that page further to identify any issues.
-    number_of_internal_searches:
+    searches:
       title: 'Searches from the page'
       short_title: ''
       summary: 'Number of on-page searches'

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Chart", type: :view do
       caption: "Unique page views",
       chart_label: "Page views chart",
       table_label: "Page views table",
-      chart_id: 'pageviews_jan_chart',
-      table_id: 'pageviews_jan_table',
+      chart_id: 'pviews_jan_chart',
+      table_id: 'pviews_jan_table',
       keys: %w(Jan Feb Mar Apr May Jun Jul Aug Sep Oct Nov Dec),
       rows: [
         {

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe 'date selection', type: :feature do
          { "date" => (from - 2.days).to_s, "value" => 9 },
          { "date" => (to + 1.day).to_s, "value" => 9 }
        ],
-       pageviews: [
+       pviews: [
          { "date" => (from - 1.day).to_s, "value" => 8 },
          { "date" => (from - 2.days).to_s, "value" => 8 },
          { "date" => (to + 1.day).to_s, "value" => 8 }

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'date selection', type: :feature do
                                     to: to,
                                     metrics: metrics,
                                     payload: {
-       unique_pageviews: [
+       upviews: [
          { "date" => (from - 1.day).to_s, "value" => 0 },
          { "date" => (from - 2.days).to_s, "value" => 9 },
          { "date" => (to + 1.day).to_s, "value" => 9 }
@@ -105,8 +105,8 @@ RSpec.describe 'date selection', type: :feature do
     month_and_date_string_for_date1 = (from - 1.day).to_s.last(5)
     month_and_date_string_for_date2 = (from - 2.days).to_s.last(5)
     month_and_date_string_for_date3 = (to + 1.day).to_s.last(5)
-    unique_pageviews_rows = extract_table_content("#unique_pageviews_table")
-    expect(unique_pageviews_rows).to match_array([
+    upviews_rows = extract_table_content("#upviews_table")
+    expect(upviews_rows).to match_array([
       ['', month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
       ['Unique pageviews', "1", "2", "30"]
     ])
@@ -116,8 +116,8 @@ RSpec.describe 'date selection', type: :feature do
     month_and_date_string_for_date1 = (from - 1.day).to_s.last(5)
     month_and_date_string_for_date2 = (from - 2.days).to_s.last(5)
     month_and_date_string_for_date3 = (to + 1.day).to_s.last(5)
-    unique_pageviews_rows = extract_table_content("#unique_pageviews_table")
-    expect(unique_pageviews_rows).to match_array([
+    upviews_rows = extract_table_content("#upviews_table")
+    expect(upviews_rows).to match_array([
       ['', month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
       ['Unique pageviews', "0", "9", "9"]
     ])

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe 'date selection', type: :feature do
          { "date" => (from - 2.days).to_s, "value" => 8 },
          { "date" => (to + 1.day).to_s, "value" => 8 }
        ],
-       number_of_internal_searches: [
+       searches: [
          { "date" => (from - 1.day).to_s, "value" => 8 },
          { "date" => (from - 2.days).to_s, "value" => 8 },
          { "date" => (to + 1.day).to_s, "value" => 8 }

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -82,7 +82,7 @@ RSpec.describe 'date selection', type: :feature do
          { "date" => (from - 2.days).to_s, "value" => 8 },
          { "date" => (to + 1.day).to_s, "value" => 8 }
        ],
-       satisfaction_score: [
+       satisfaction: [
          { "date" => (from - 1.day).to_s, "value" => 100 },
          { "date" => (from - 2.days).to_s, "value" => 90 },
          { "date" => (to + 1.day).to_s, "value" => 80 }

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe '/content' do
         upviews: 233_018,
         document_type: 'news_story',
         satisfaction: 0.81301,
-        satisfaction_score_responses: 250,
+        satisfaction_responses: 250,
         searches: 220
       },
       {
@@ -21,7 +21,7 @@ RSpec.describe '/content' do
         upviews: 100_018,
         document_type: 'guide',
         satisfaction: 0.68,
-        satisfaction_score_responses: 42,
+        satisfaction_responses: 42,
         searches: 12
       }
     ]

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.satisfaction_score', text: '26'
     end
 
-    it 'renders a metric for feedex_comments' do
-      expect(page).to have_selector '.metric_summary.feedex_comments', text: '20'
+    it 'renders a metric for feedex' do
+      expect(page).to have_selector '.metric_summary.feedex', text: '20'
     end
 
     it 'renders a metric for number_of_pdfs' do
@@ -104,7 +104,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metric timeseries for ' do
-      feedback_comment_rows = extract_table_content(".chart.feedex_comments table")
+      feedback_comment_rows = extract_table_content(".chart.feedex table")
 
       expect(feedback_comment_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.upviews', text: '145,000'
     end
 
-    it 'renders the metric for pageviews' do
-      expect(page).to have_selector '.metric_summary.pageviews', text: '200,000'
+    it 'renders the metric for pviews' do
+      expect(page).to have_selector '.metric_summary.pviews', text: '200,000'
     end
 
     it 'renders a metric for satisfaction_score' do
@@ -79,8 +79,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       ])
     end
 
-    it 'renders the metric timeseries for pageviews' do
-      pageviews_rows = extract_table_content(".chart.pageviews table")
+    it 'renders the metric timeseries for pviews' do
+      pageviews_rows = extract_table_content(".chart.pviews table")
       expect(pageviews_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
         %w[Pageviews 10 20 30]

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.pviews', text: '200,000'
     end
 
-    it 'renders a metric for satisfaction_score' do
-      expect(page).to have_selector '.metric_summary.satisfaction_score', text: '26'
+    it 'renders a metric for satisfaction' do
+      expect(page).to have_selector '.metric_summary.satisfaction', text: '26'
     end
 
     it 'renders a metric for feedex' do
@@ -95,9 +95,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
       ])
     end
 
-    it 'renders the metric timeseries for satisfaction_score' do
-      satisfaction_score_rows = extract_table_content(".chart.satisfaction_score table")
-      expect(satisfaction_score_rows).to match_array([
+    it 'renders the metric timeseries for satisfaction' do
+      satisfaction_rows = extract_table_content(".chart.satisfaction table")
+      expect(satisfaction_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
         ["User satisfaction score", "100.000%", "90.000%", "80.000%"]
       ])

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -38,8 +38,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.feedex', text: '20'
     end
 
-    it 'renders a metric for number_of_pdfs' do
-      expect(page).to have_selector '.metric_summary.number_of_pdfs', text: '3'
+    it 'renders a metric for pdf_count' do
+      expect(page).to have_selector '.metric_summary.pdf_count', text: '3'
     end
 
     it 'renders a metric for words' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -42,8 +42,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.number_of_pdfs', text: '3'
     end
 
-    it 'renders a metric for word_count' do
-      expect(page).to have_selector '.metric_summary.word_count', text: '200'
+    it 'renders a metric for words' do
+      expect(page).to have_selector '.metric_summary.words', text: '200'
     end
 
     it 'renders the page title' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders a metric for on page searches' do
-      expect(page).to have_selector '.metric_summary.number_of_internal_searches', text: '250'
+      expect(page).to have_selector '.metric_summary.searches', text: '250'
     end
 
     it 'renders the publishing application' do
@@ -80,15 +80,15 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metric timeseries for pviews' do
-      pageviews_rows = extract_table_content(".chart.pviews table")
-      expect(pageviews_rows).to match_array([
+      pviews_rows = extract_table_content(".chart.pviews table")
+      expect(pviews_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
         %w[Pageviews 10 20 30]
       ])
     end
 
     it 'renders the metric timeseries for on-page searches' do
-      internal_searches_rows = extract_table_content(".chart.number_of_internal_searches table")
+      internal_searches_rows = extract_table_content(".chart.searches table")
       expect(internal_searches_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
         ["Searches from the page", "8", "8", "8"]

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       visit '/metrics/base/path'
     end
 
-    it 'renders the metric for unique_pageviews' do
-      expect(page).to have_selector '.metric_summary.unique_pageviews', text: '145,000'
+    it 'renders the metric for upviews' do
+      expect(page).to have_selector '.metric_summary.upviews', text: '145,000'
     end
 
     it 'renders the metric for pageviews' do
@@ -71,9 +71,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
       ])
     end
 
-    it 'renders the metric timeseries for unique_pageviews' do
-      unique_pageviews_rows = extract_table_content(".chart.unique_pageviews table")
-      expect(unique_pageviews_rows).to match_array([
+    it 'renders the metric timeseries for upviews' do
+      upviews_rows = extract_table_content(".chart.upviews table")
+      expect(upviews_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
         ["Unique pageviews", "1", "2", "30"]
       ])
@@ -137,7 +137,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         to: to.to_s,
         metrics: metrics,
         payload: {
-          unique_pageviews: [],
+          upviews: [],
         })
       visit '/metrics/base/path'
     end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -34,8 +34,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.satisfaction_score', text: '26'
     end
 
-    it 'renders a metric for number_of_feedback_comments' do
-      expect(page).to have_selector '.metric_summary.number_of_feedback_comments', text: '20'
+    it 'renders a metric for feedex_comments' do
+      expect(page).to have_selector '.metric_summary.feedex_comments', text: '20'
     end
 
     it 'renders a metric for number_of_pdfs' do
@@ -91,7 +91,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       internal_searches_rows = extract_table_content(".chart.number_of_internal_searches table")
       expect(internal_searches_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
-        ["Number of internal searches", "8", "8", "8"]
+        ["Searches from the page", "8", "8", "8"]
       ])
     end
 
@@ -99,7 +99,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       satisfaction_score_rows = extract_table_content(".chart.satisfaction_score table")
       expect(satisfaction_score_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
-        ["Satisfaction score", "100.000%", "90.000%", "80.000%"]
+        ["User satisfaction score", "100.000%", "90.000%", "80.000%"]
       ])
     end
 
@@ -108,7 +108,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
       expect(feedback_comment_rows).to match_array([
         ["", month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
-        ["Feedex comments", "20", "21", "22"]
+        ["Number of feedback comments", "20", "21", "22"]
       ])
     end
   end

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe MetricsFormatterHelper do
 
   context 'metric does not need to be rendered as a percentage' do
     it 'displays value as an integer' do
-      value = format_metric_value('pageviews', 90)
+      value = format_metric_value('pviews', 90)
       expect(value).to eq 90
     end
   end

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe MetricsFormatterHelper do
   context 'metric needs to be rendered as a percentage' do
     it 'displays value as a percentage' do
-      value = format_metric_value('satisfaction_score', 0.9000)
+      value = format_metric_value('satisfaction', 0.9000)
       expect(value).to eq '90.000%'
     end
 
     it 'displays value as a percentage whole number for headline figures' do
-      value = format_metric_headline_figure('satisfaction_score', 24.13413)
+      value = format_metric_headline_figure('satisfaction', 24.13413)
       expect(value).to eq '24%'
     end
   end
@@ -21,7 +21,7 @@ RSpec.describe MetricsFormatterHelper do
 
   context 'if figure for percentage metric is not supplied' do
     it 'does not raise an error' do
-      expect { format_metric_value('satisfaction_score', nil) }.to_not raise_error
+      expect { format_metric_value('satisfaction', nil) }.to_not raise_error
     end
   end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe ChartPresenter do
     )
   end
 
+  describe '#human_friendly_metric' do
+    it 'returns `Unique pageviews` for upviews' do
+      presenter = described_class.new(json: {}, metric: :upviews, from: from, to: to)
+      expect(presenter.human_friendly_metric).to eq('Unique pageviews')
+    end
+
+    it 'returns `Pageviews` for pviews' do
+      presenter = described_class.new(json: {}, metric: :pageviews, from: from, to: to)
+      expect(presenter.human_friendly_metric).to eq('Pageviews')
+    end
+  end
+
   it 'returns start date' do
     expect(subject.from).to eq '2018-01-13'
   end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe ChartPresenter do
     ChartPresenter.new(
       json:
         {
-          unique_pageviews: [
+          upviews: [
             { date: '2018-01-13', value: 101 },
             { date: '2018-01-14', value: 202 },
             { date: '2018-01-15', value: 303 }
           ]
         },
-      metric: 'unique_pageviews',
+      metric: :upviews,
       from: from,
       to: to
     )
@@ -33,13 +33,13 @@ RSpec.describe ChartPresenter do
   end
 
   it 'returns formatted hash of chart data' do
-    expect(subject.chart_data).to eq unique_pageviews_chart_data
+    expect(subject.chart_data).to eq upviews_chart_data
   end
 
-  def unique_pageviews_chart_data
+  def upviews_chart_data
     {
       caption: "Unique pageviews from 2018-01-13 to 2018-01-15",
-      chart_id: "unique_pageviews_chart",
+      chart_id: "upviews_chart",
       chart_label: "Unique pageviews",
       keys: [
         "01-13",
@@ -57,7 +57,7 @@ RSpec.describe ChartPresenter do
           ]
         }
       ],
-      table_id: "unique_pageviews_table",
+      table_id: "upviews_table",
       table_direction: "vertical"
     }
   end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ChartPresenter do
     end
 
     it 'returns `Pageviews` for pviews' do
-      presenter = described_class.new(json: {}, metric: :pageviews, from: from, to: to)
+      presenter = described_class.new(json: {}, metric: :pviews, from: from, to: to)
       expect(presenter.human_friendly_metric).to eq('Pageviews')
     end
   end

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ContentRowPresenter do
     expect(subject).to have_attributes(
       base_path: 'some/base_path',
       title: 'a title',
-      unique_pageviews: 200_001
+      upviews: 200_001
     )
   end
 

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ContentRowPresenter do
       title: 'a title',
       upviews: 200_001,
       satisfaction: 0.801001,
-      satisfaction_score_responses: 301,
+      satisfaction_responses: 301,
     }
   end
 
@@ -25,6 +25,6 @@ RSpec.describe ContentRowPresenter do
   end
 
   it 'formats user_satifaction_score correctly' do
-    expect(subject.user_satisfaction_score).to eq('80.1% (301 responses)')
+    expect(subject.user_satisfaction).to eq('80.1% (301 responses)')
   end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SingleContentItemPresenter do
       'public_updated_at' => '2017-10-01T00:00:00.000Z',
       'document_type' => 'news_story',
       'upviews' => 2030,
-      'pageviews' => 3000,
+      'pviews' => 3000,
       'satisfaction_score' => 33.5,
       'number_of_internal_searches' => 120,
       'feedex_comments' => 20,
@@ -58,7 +58,7 @@ RSpec.describe SingleContentItemPresenter do
   it 'returns the aggregated metrics' do
     expect(subject).to have_attributes(
       upviews: 2030,
-      pageviews: 3000,
+      pviews: 3000,
       number_of_internal_searches: 120,
       feedex_comments: 20,
       satisfaction_score: '34%'

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe SingleContentItemPresenter do
       upviews: 2030,
       pageviews: 3000,
       number_of_internal_searches: 120,
-      number_of_feedback_comments: 20,
+      feedex_comments: 20,
       satisfaction_score: '34%'
     )
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SingleContentItemPresenter do
       'pviews' => 3000,
       'satisfaction_score' => 33.5,
       'searches' => 120,
-      'feedex_comments' => 20,
+      'feedex' => 20,
     }
   end
   let(:time_series) { default_timeseries_payload(from.to_date, to.to_date) }
@@ -60,7 +60,7 @@ RSpec.describe SingleContentItemPresenter do
       upviews: 2030,
       pviews: 3000,
       searches: 120,
-      feedex_comments: 20,
+      feedex: 20,
       satisfaction_score: '34%'
     )
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SingleContentItemPresenter do
       'first_published_at' => '2016-09-01T00:00:00.000Z',
       'public_updated_at' => '2017-10-01T00:00:00.000Z',
       'document_type' => 'news_story',
-      'unique_pageviews' => 2030,
+      'upviews' => 2030,
       'pageviews' => 3000,
       'satisfaction_score' => 33.5,
       'number_of_internal_searches' => 120,
@@ -57,7 +57,7 @@ RSpec.describe SingleContentItemPresenter do
 
   it 'returns the aggregated metrics' do
     expect(subject).to have_attributes(
-      unique_pageviews: 2030,
+      upviews: 2030,
       pageviews: 3000,
       number_of_internal_searches: 120,
       number_of_feedback_comments: 20,

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SingleContentItemPresenter do
       'upviews' => 2030,
       'pviews' => 3000,
       'satisfaction_score' => 33.5,
-      'number_of_internal_searches' => 120,
+      'searches' => 120,
       'feedex_comments' => 20,
     }
   end
@@ -59,7 +59,7 @@ RSpec.describe SingleContentItemPresenter do
     expect(subject).to have_attributes(
       upviews: 2030,
       pviews: 3000,
-      number_of_internal_searches: 120,
+      searches: 120,
       feedex_comments: 20,
       satisfaction_score: '34%'
     )

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SingleContentItemPresenter do
       'document_type' => 'news_story',
       'upviews' => 2030,
       'pviews' => 3000,
-      'satisfaction_score' => 33.5,
+      'satisfaction' => 33.5,
       'searches' => 120,
       'feedex' => 20,
     }
@@ -61,7 +61,7 @@ RSpec.describe SingleContentItemPresenter do
       pviews: 3000,
       searches: 120,
       feedex: 20,
-      satisfaction_score: '34%'
+      satisfaction: '34%'
     )
   end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -54,7 +54,7 @@ module GdsApi
           base_path: "/#{base_path}",
           upviews: 145_000,
           pviews: 200_000,
-          satisfaction_score: 25.55,
+          satisfaction: 25.55,
           searches: 250,
           feedex: 20,
           number_of_pdfs: 3,
@@ -90,7 +90,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 21 },
             { "date" => (to + 1.day).to_s, "value" => 22 }
           ],
-          satisfaction_score: [
+          satisfaction: [
             { "date" => (from - 1.day).to_s, "value" => 1.0000 },
             { "date" => (from - 2.days).to_s, "value" => 0.9000 },
             { "date" => (to + 1.day).to_s, "value" => 0.80000 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -58,7 +58,7 @@ module GdsApi
           searches: 250,
           feedex: 20,
           number_of_pdfs: 3,
-          word_count: 200,
+          words: 200,
           title: "Content Title",
           first_published_at: '2018-02-01T00:00:00.000Z',
           public_updated_at: '2018-04-25T00:00:00.000Z',
@@ -95,7 +95,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 0.9000 },
             { "date" => (to + 1.day).to_s, "value" => 0.80000 }
           ],
-          word_count: [
+          words: [
             { "date" => (from - 1.day).to_s, "value" => 200 },
             { "date" => (from - 2.days).to_s, "value" => 200 },
             { "date" => (to + 1.day).to_s, "value" => 200 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -52,7 +52,7 @@ module GdsApi
       def default_metric_payload(base_path)
         {
           base_path: "/#{base_path}",
-          unique_pageviews: 145_000,
+          upviews: 145_000,
           pageviews: 200_000,
           satisfaction_score: 25.55,
           number_of_internal_searches: 250,
@@ -70,7 +70,7 @@ module GdsApi
 
       def default_timeseries_payload(from, to)
         {
-          unique_pageviews: [
+          upviews: [
             { "date" => (from - 1.day).to_s, "value" => 1 },
             { "date" => (from - 2.days).to_s, "value" => 2 },
             { "date" => (to + 1.day).to_s, "value" => 30 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -55,7 +55,7 @@ module GdsApi
           upviews: 145_000,
           pviews: 200_000,
           satisfaction_score: 25.55,
-          number_of_internal_searches: 250,
+          searches: 250,
           feedex_comments: 20,
           number_of_pdfs: 3,
           word_count: 200,
@@ -80,7 +80,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 20 },
             { "date" => (to + 1.day).to_s, "value" => 30 }
           ],
-          number_of_internal_searches: [
+          searches: [
             { "date" => (from - 1.day).to_s, "value" => 8 },
             { "date" => (from - 2.days).to_s, "value" => 8 },
             { "date" => (to + 1.day).to_s, "value" => 8 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -57,7 +57,7 @@ module GdsApi
           satisfaction: 25.55,
           searches: 250,
           feedex: 20,
-          number_of_pdfs: 3,
+          pdf_count: 3,
           words: 200,
           title: "Content Title",
           first_published_at: '2018-02-01T00:00:00.000Z',
@@ -100,7 +100,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 200 },
             { "date" => (to + 1.day).to_s, "value" => 200 }
           ],
-          number_of_pdfs: [
+          pdf_count: [
             { "date" => (from - 1.day).to_s, "value" => 3 },
             { "date" => (from - 2.days).to_s, "value" => 3 },
             { "date" => (to + 1.day).to_s, "value" => 3 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -53,7 +53,7 @@ module GdsApi
         {
           base_path: "/#{base_path}",
           upviews: 145_000,
-          pageviews: 200_000,
+          pviews: 200_000,
           satisfaction_score: 25.55,
           number_of_internal_searches: 250,
           feedex_comments: 20,
@@ -75,7 +75,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 2 },
             { "date" => (to + 1.day).to_s, "value" => 30 }
           ],
-          pageviews: [
+          pviews: [
             { "date" => (from - 1.day).to_s, "value" => 10 },
             { "date" => (from - 2.days).to_s, "value" => 20 },
             { "date" => (to + 1.day).to_s, "value" => 30 }

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -56,7 +56,7 @@ module GdsApi
           pviews: 200_000,
           satisfaction_score: 25.55,
           searches: 250,
-          feedex_comments: 20,
+          feedex: 20,
           number_of_pdfs: 3,
           word_count: 200,
           title: "Content Title",
@@ -85,7 +85,7 @@ module GdsApi
             { "date" => (from - 2.days).to_s, "value" => 8 },
             { "date" => (to + 1.day).to_s, "value" => 8 }
           ],
-          feedex_comments: [
+          feedex: [
             { "date" => (from - 1.day).to_s, "value" => 20 },
             { "date" => (from - 2.days).to_s, "value" => 21 },
             { "date" => (to + 1.day).to_s, "value" => 22 }


### PR DESCRIPTION
It renames the metric names to mimic previous [work in Content Performance Manager][1]

This work raises some alarms because we shouldn't have to change that 
many names after a change in the API. 

I have not added a layer in between to map names because:

1. I would rather use exactly the same names for the time being
2. I think it is better to first clean up the codebase for the frontend and backend before making other design decisions.

[1]: https://github.com/alphagov/content-performance-manager/pull/945/files

