### PR TITLE
Use symbolized response hash

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -1,9 +1,9 @@
 module MetricsFormatterHelper
   include ActionView::Helpers::NumberHelper
-  METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction).freeze
+  METRICS_MEASURED_AS_PERCENTAGES = %i(satisfaction).freeze
 
   def format_metric_value(metric_name, figure)
-    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s) && figure
+    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name) && figure
       number_to_percentage(figure * 100, precision: 3)
     else
       figure
@@ -11,7 +11,7 @@ module MetricsFormatterHelper
   end
 
   def format_metric_headline_figure(metric_name, figure)
-    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name.to_s) && figure
+    if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name) && figure
       number_to_percentage(figure, precision: 0)
     else
       figure

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -4,7 +4,7 @@ class ChartPresenter
 
   def initialize(json:, metric:, from:, to:)
     @metric = metric
-    @json = json.to_h.with_indifferent_access
+    @json = json.to_h
     @from = from
     @to = to
   end
@@ -41,13 +41,13 @@ class ChartPresenter
   def keys
     return [] unless json[metric]
 
-    dates = json[metric].map { |hash| hash['date'] }
+    dates = json[metric].map { |hash| hash[:date] }
     dates.map { |date| date.last(5) }
   end
 
   def values
     return [] unless json[metric]
 
-    json[metric].map { |hash| format_metric_value(metric, hash['value']) }
+    json[metric].map { |hash| format_metric_value(metric, hash[:value]) }
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -20,13 +20,13 @@ class SingleContentItemPresenter
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
     @metrics = metrics
-    parse_metrics(metrics.with_indifferent_access)
-    parse_time_series(time_series.with_indifferent_access)
+    parse_metrics(metrics)
+    parse_time_series(time_series)
     add_glance_metric_presenters
   end
 
   def publishing_app
-    publishing_app = @metrics['publishing_app']
+    publishing_app = @metrics[:publishing_app]
 
     publishing_app.present? ? publishing_app.capitalize.tr('-', ' ') : 'Unknown'
   end
@@ -34,13 +34,13 @@ class SingleContentItemPresenter
 private
 
   def parse_metrics(metrics)
-    @upviews = format_metric_value('upviews', metrics[:upviews])
-    @pviews = format_metric_value('pviews', metrics[:pviews])
-    @feedex = format_metric_value('feedex', metrics[:feedex])
-    @searches = format_metric_value('searches', metrics[:searches])
-    @pdf_count = format_metric_value('pdf_count', metrics[:pdf_count])
-    @words = format_metric_value('words', metrics[:words])
-    @satisfaction = format_metric_headline_figure('satisfaction', metrics[:satisfaction])
+    @upviews = format_metric_value(:upviews, metrics[:upviews])
+    @pviews = format_metric_value(:pviews, metrics[:pviews])
+    @feedex = format_metric_value(:feedex, metrics[:feedex])
+    @searches = format_metric_value(:searches, metrics[:searches])
+    @pdf_count = format_metric_value(:pdf_count, metrics[:pdf_count])
+    @words = format_metric_value(:words, metrics[:words])
+    @satisfaction = format_metric_headline_figure(:satisfaction, metrics[:satisfaction])
     @title = metrics[:title]
     @metadata = {
       base_path: metrics[:base_path],
@@ -61,10 +61,10 @@ private
 
   def add_glance_metric_presenters
     time_period = @date_range.time_period
-    @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @upviews, time_period)
-    @satisfaction_glance_metric = GlanceMetricPresenter.new('satisfaction', @satisfaction, time_period)
-    @searches_glance_metric = GlanceMetricPresenter.new('searches', @searches, time_period)
-    @feedex_glance_metric = GlanceMetricPresenter.new('feedex', @feedex, time_period)
+    @upviews_glance_metric = GlanceMetricPresenter.new(:upviews, @upviews, time_period)
+    @satisfaction_glance_metric = GlanceMetricPresenter.new(:satisfaction, @satisfaction, time_period)
+    @searches_glance_metric = GlanceMetricPresenter.new(:searches, @searches, time_period)
+    @feedex_glance_metric = GlanceMetricPresenter.new(:feedex, @feedex, time_period)
   end
 
   def get_chart_presenter(time_series, metric)

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -9,17 +9,17 @@ class GdsApi::ContentDataApi < GdsApi::Base
 
   def aggregated_metrics(base_path:, from:, to:, metrics:)
     url = aggregated_metrics_url(base_path, from, to, metrics)
-    get_json(url).to_hash
+    get_json(url).to_hash.deep_symbolize_keys
   end
 
   def time_series(base_path:, from:, to:, metrics:)
     url = time_series_request_url(base_path, from, to, metrics)
-    get_json(url).to_hash
+    get_json(url).to_hash.deep_symbolize_keys
   end
 
   def content(from:, to:, organisation_id:)
     url = content_items_url(from, to, organisation_id)
-    get_json(url).to_hash
+    get_json(url).to_hash.deep_symbolize_keys
   end
 
 private

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe MetricsFormatterHelper do
   context 'metric needs to be rendered as a percentage' do
     it 'displays value as a percentage' do
-      value = format_metric_value('satisfaction', 0.9000)
+      value = format_metric_value(:satisfaction, 0.9000)
       expect(value).to eq '90.000%'
     end
 
     it 'displays value as a percentage whole number for headline figures' do
-      value = format_metric_headline_figure('satisfaction', 24.13413)
+      value = format_metric_headline_figure(:satisfaction, 24.13413)
       expect(value).to eq '24%'
     end
   end
@@ -14,14 +14,14 @@ RSpec.describe MetricsFormatterHelper do
 
   context 'metric does not need to be rendered as a percentage' do
     it 'displays value as an integer' do
-      value = format_metric_value('pviews', 90)
+      value = format_metric_value(:pviews, 90)
       expect(value).to eq 90
     end
   end
 
   context 'if figure for percentage metric is not supplied' do
     it 'does not raise an error' do
-      expect { format_metric_value('satisfaction', nil) }.to_not raise_error
+      expect { format_metric_value(:satisfaction, nil) }.to_not raise_error
     end
   end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -6,17 +6,17 @@ RSpec.describe SingleContentItemPresenter do
 
   let(:metrics) do
     {
-      'title' => 'The title',
-      'base_path' => '/the/base/path',
-      'primary_organisation_title' => 'UK Visas and Immigration',
-      'first_published_at' => '2016-09-01T00:00:00.000Z',
-      'public_updated_at' => '2017-10-01T00:00:00.000Z',
-      'document_type' => 'news_story',
-      'upviews' => 2030,
-      'pviews' => 3000,
-      'satisfaction' => 33.5,
-      'searches' => 120,
-      'feedex' => 20,
+        title: 'The title',
+        base_path: '/the/base/path',
+        primary_organisation_title: 'UK Visas and Immigration',
+        first_published_at: '2016-09-01T00:00:00.000Z',
+        public_updated_at: '2017-10-01T00:00:00.000Z',
+        document_type: 'news_story',
+        upviews: 2030,
+        pviews: 3000,
+        satisfaction: 33.5,
+        searches: 120,
+        feedex: 20,
     }
   end
   let(:time_series) { default_timeseries_payload(from.to_date, to.to_date) }
@@ -31,13 +31,13 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#publishing_app' do
     it 'does not fail if no publishing app' do
-      metrics['publishing_app'] = nil
+      metrics[:publishing_app] = nil
 
       expect(subject.publishing_app).to eq('Unknown')
     end
 
     it 'capitalizes the publishing_app if present' do
-      metrics['publishing_app'] = 'travel-advice'
+      metrics[:publishing_app] = 'travel-advice'
 
       expect(subject.publishing_app).to eq('Travel advice')
     end


### PR DESCRIPTION
Merge after https://github.com/alphagov/content-data-admin/pull/111

Only commit to review:  8976c5a

In our codebase / tests we are not being consistent in using symbols
or string in hashes. Sometimes we even change the code to accommodate
symbols in our Fixtures.

This is not a very good practice, so I have symbolised the response
in origin (right after it is returned by the Adaptor) so that we can
be consistent in our codebase using symbols.