### PR TITLE
Remove hash conversion so symbols

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -7,7 +7,7 @@ private
 
   def get_content
     response = FindContent.call(params)
-    @content = ContentItemsPresenter.new(response.deep_symbolize_keys[:results], date_range)
+    @content = ContentItemsPresenter.new(response[:results], date_range)
   end
 
   def date_range


### PR DESCRIPTION
There is no need to symbolize a Hash because of https://github.com/alphagov/content-data-admin/pull/112