### PR TITLE
Add on page search rate

### DIFF
--- a/app/presenters/glance_metric_presenter.rb
+++ b/app/presenters/glance_metric_presenter.rb
@@ -1,15 +1,16 @@
 class GlanceMetricPresenter
-  def initialize(metric_name, metric_value, time_period)
+  def initialize(metric_name, metric_value, time_period, secondary_metric_value = nil)
     @metric_name = metric_name
     @metric_value = metric_value
     @time_period = time_period
+    @secondary_metric_value = secondary_metric_value
 
     # Context metrics are variables that can be used in the locales.
     # Dummy values are being used until they are available from API
     @context_metrics = {
       percent_org_views: 2.74,
       total_responses: 505,
-      percent_users_searched: 0.18
+      percent_users_searched: on_page_search_rate
     }
   end
 
@@ -21,6 +22,12 @@ class GlanceMetricPresenter
 
   def value
     @metric_value
+  end
+
+  def on_page_search_rate
+    return unless @metric_name == :searches
+    return 0 if @metric_value.to_i.zero? || @secondary_metric_value.to_i.zero?
+    (@metric_value.to_f / @secondary_metric_value.to_f) * 100
   end
 
   def trend_percentage

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -15,7 +15,13 @@ class SingleContentItemPresenter
               :upviews,
               :upviews_series,
               :pdf_count,
-              :words
+              :words,
+              :searches_glance_metric,
+              :upviews_glance_metric,
+              :satisfaction_glance_metric,
+              :feedex_glance_metric
+
+
 
   def initialize(metrics, time_series, date_range)
     @date_range = date_range
@@ -63,7 +69,7 @@ private
     time_period = @date_range.time_period
     @upviews_glance_metric = GlanceMetricPresenter.new(:upviews, @upviews, time_period)
     @satisfaction_glance_metric = GlanceMetricPresenter.new(:satisfaction, @satisfaction, time_period)
-    @searches_glance_metric = GlanceMetricPresenter.new(:searches, @searches, time_period)
+    @searches_glance_metric = GlanceMetricPresenter.new(:searches, @searches, time_period, @upviews)
     @feedex_glance_metric = GlanceMetricPresenter.new(:feedex, @feedex, time_period)
   end
 

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -2,7 +2,7 @@
   metric = @performance_data.instance_variable_get("@#{metric_name}_glance_metric")
 %>
 <% if metric %>
-  <div class="govuk-grid-column-one-quarter">
+  <div class="govuk-grid-column-one-quarter <%=metric_name%>">
     <%= render "components/glance-metric", {
         name: metric.name,
         figure: metric.value,

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
       expect(page).to have_selector '.metric_summary.searches', text: '250'
     end
 
+    it 'renders a page searches metric as a percentage of views' do
+      expect(page).to have_selector '.govuk-grid-column-one-quarter.searches', text: '250'
+    end
+
     it 'renders the publishing application' do
       expect(page).to have_selector '.related-actions', text: 'Whitehall'
     end

--- a/spec/presenters/glance_metric_presenter_spec.rb
+++ b/spec/presenters/glance_metric_presenter_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe GlanceMetricPresenter do
     expect(subject.period).to eq I18n.t('metrics.show.time_periods.last_30_days.reference')
   end
 
+  context "when metric is searches" do
+    subject do
+      GlanceMetricPresenter.new(
+        :searches, 10, 'last-30-days', 100
+      )
+    end
+
+    it "displays number of internal searches divided by unique pageviews as `on_page_search_rate`" do
+      expect(subject.on_page_search_rate).to eq 10
+    end
+  end
+
   def change_metric_translation(attribute, value)
     en = { metrics: { example_metric: { attribute => value } } }
     I18n.backend.store_translations(:en, en)


### PR DESCRIPTION
### What does this PR do?

Calculates the on page search rate. This is used in _'X% of users searched on this page'_. (See screenshot).

### Why?

To give users some context around the search statistics to help them understand the relevance.

### Technical Note

I considered making changes to the way we handle `@context_metrics` within `GlanceMetricPresenter.rb`.

I'm not sure that `@context_metrics` needs to be a hash, maybe we can simply render `@context_metrics` as a string depending on what the metric name is. In the future I think this will avoid running multiple unnecessary methods.

If the rest of the team thinks this is a good idea then I will address this in a separate PR.

### How it looks
<img width="931" alt="screen shot 2018-10-09 at 10 33 46" src="https://user-images.githubusercontent.com/13124899/46660400-d8fce300-cbae-11e8-8b6a-a92e66e7157b.png">
