### PR TITLE
Round search rate to 2 decimal places

### DIFF
--- a/app/presenters/glance_metric_presenter.rb
+++ b/app/presenters/glance_metric_presenter.rb
@@ -27,7 +27,8 @@ class GlanceMetricPresenter
   def on_page_search_rate
     return unless @metric_name == :searches
     return 0 if @metric_value.to_i.zero? || @secondary_metric_value.to_i.zero?
-    (@metric_value.to_f / @secondary_metric_value.to_f) * 100
+    search_rate = (@metric_value.to_f / @secondary_metric_value.to_f) * 100
+    search_rate.round(2)
   end
 
   def trend_percentage

--- a/spec/presenters/glance_metric_presenter_spec.rb
+++ b/spec/presenters/glance_metric_presenter_spec.rb
@@ -59,12 +59,12 @@ RSpec.describe GlanceMetricPresenter do
   context "when metric is searches" do
     subject do
       GlanceMetricPresenter.new(
-        :searches, 10, 'last-30-days', 100
+        :searches, 107, 'last-30-days', 9794
       )
     end
 
-    it "displays number of internal searches divided by unique pageviews as `on_page_search_rate`" do
-      expect(subject.on_page_search_rate).to eq 10
+    it "displays searches divided by unique pageviews as `on_page_search_rate` to 2 decimal places" do
+      expect(subject.on_page_search_rate).to eq 1.09
     end
   end
 


### PR DESCRIPTION
### What?
Round the search rate metric to 2 decimal places.

### Why?
It is currently showing lots and lots of decimal places which makes it hard to read and messes with the design.

### Before
<img width="908" alt="screen shot 2018-10-10 at 10 15 58" src="https://user-images.githubusercontent.com/13124899/46726167-b2ee4600-cc75-11e8-8b37-fd70fb2a19f6.png">

### After
<img width="906" alt="screen shot 2018-10-10 at 10 15 10" src="https://user-images.githubusercontent.com/13124899/46726185-bc77ae00-cc75-11e8-9f45-8fb9d8ed05c2.png">
