### PR TITLE
Add google tag manager component to head of application layout

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,15 @@
   <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
   <%= javascript_include_tag "application" %>
   <%= stylesheet_link_tag "application" %>
-<% end %>
+
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+    } %>
+    <% end %>
+  <% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   environment: Rails.application.config.govuk_environment,


### PR DESCRIPTION
This PR adds the Google Tag Manager component and it needs [Add Google Tag Manager env vars for Content Data Admin](https://github.com/alphagov/govuk-puppet/pull/8193) to get merged in order to render the component. Raised this PR to have it ready.

Trello card (https://trello.com/c/ldax4jWq/631-1-embed-google-tag-manager-code-in-header-and-body-of-each-page-of-the-content-data-app#)