### PR TITLE
Use single endpoint

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -3,19 +3,12 @@ class MetricsController < ApplicationController
     time_period = params[:date_range] || 'last-30-days'
     date_range = DateRange.new(time_period)
 
-    service_params = {
-      base_path: params[:base_path],
-      date_range: date_range,
-    }
-
-    metrics = FetchAggregatedMetrics.call(service_params)
-    time_series = FetchTimeSeries.call(service_params)
-    FetchSinglePage.call(
+    single_page_data = FetchSinglePage.call(
       base_path: params[:base_path],
       from: date_range.from,
       to: date_range.to
     )
-    @performance_data = SingleContentItemPresenter.new(metrics, time_series, date_range)
+    @performance_data = SingleContentItemPresenter.new(single_page_data, date_range)
   end
 
   rescue_from GdsApi::HTTPNotFound do

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -10,6 +10,11 @@ class MetricsController < ApplicationController
 
     metrics = FetchAggregatedMetrics.call(service_params)
     time_series = FetchTimeSeries.call(service_params)
+    FetchSinglePage.call(
+      base_path: params[:base_path],
+      from: date_range.from,
+      to: date_range.to
+    )
     @performance_data = SingleContentItemPresenter.new(metrics, time_series, date_range)
   end
 

--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -1,6 +1,6 @@
 module MetricsFormatterHelper
   include ActionView::Helpers::NumberHelper
-  METRICS_MEASURED_AS_PERCENTAGES = %i(satisfaction).freeze
+  METRICS_MEASURED_AS_PERCENTAGES = %w(satisfaction).freeze
 
   def format_metric_value(metric_name, figure)
     if METRICS_MEASURED_AS_PERCENTAGES.include?(metric_name) && figure

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -1,16 +1,16 @@
 class ChartPresenter
   include MetricsFormatterHelper
-  attr_reader :json, :metric, :from, :to
+  attr_reader :time_series, :metric, :from, :to
 
   def initialize(json:, metric:, from:, to:)
     @metric = metric
-    @json = json.to_h
+    @time_series = json
     @from = from
     @to = to
   end
 
   def has_values?
-    !json.values.flatten.empty?
+    !time_series.empty?
   end
 
   def human_friendly_metric
@@ -39,15 +39,16 @@ class ChartPresenter
   end
 
   def keys
-    return [] unless json[metric]
+    return [] unless time_series
 
-    dates = json[metric].map { |hash| hash[:date] }
-    dates.map { |date| date.last(5) }
+    time_series.map do |point|
+      point[:date].to_date.strftime("%m-%d")
+    end
   end
 
   def values
-    return [] unless json[metric]
+    return [] unless time_series
 
-    json[metric].map { |hash| format_metric_value(metric, hash[:value]) }
+    time_series.map { |point| format_metric_value(metric, point[:value]) }
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -3,16 +3,11 @@ class SingleContentItemPresenter
 
   attr_reader :date_range,
               :metadata,
-              :feedex,
               :feedex_series,
-              :searches,
               :searches_series,
-              :pviews,
               :pviews_series,
-              :satisfaction,
               :satisfaction_series,
               :title,
-              :upviews,
               :upviews_series,
               :pdf_count,
               :words,
@@ -23,54 +18,75 @@ class SingleContentItemPresenter
 
 
 
-  def initialize(metrics, time_series, date_range)
+  def initialize(single_page_data, date_range)
+    @single_page_data = single_page_data
     @date_range = date_range
-    @metrics = metrics
-    parse_metrics(metrics)
-    parse_time_series(time_series)
+    @metrics = {}
+
+    get_metadata
+    parse_metrics
+    parse_time_series
     add_glance_metric_presenters
   end
 
   def publishing_app
-    publishing_app = @metrics[:publishing_app]
+    publishing_app = @single_page_data[:metadata][:publishing_app]
 
     publishing_app.present? ? publishing_app.capitalize.tr('-', ' ') : 'Unknown'
   end
 
 private
 
-  def parse_metrics(metrics)
-    @upviews = format_metric_value(:upviews, metrics[:upviews])
-    @pviews = format_metric_value(:pviews, metrics[:pviews])
-    @feedex = format_metric_value(:feedex, metrics[:feedex])
-    @searches = format_metric_value(:searches, metrics[:searches])
-    @pdf_count = format_metric_value(:pdf_count, metrics[:pdf_count])
-    @words = format_metric_value(:words, metrics[:words])
-    @satisfaction = format_metric_headline_figure(:satisfaction, metrics[:satisfaction])
-    @title = metrics[:title]
+  def get_metadata
+    metadata = @single_page_data[:metadata]
+    @title = metadata[:title]
     @metadata = {
-      base_path: metrics[:base_path],
-      document_type: metrics[:document_type].tr('_', ' ').capitalize,
-      published_at: format_date(metrics[:first_published_at]),
-      last_updated: format_date(metrics[:public_updated_at]),
-      publishing_organisation: metrics[:primary_organisation_title],
+      base_path: metadata[:base_path],
+      document_type: metadata[:document_type].tr('_', ' ').capitalize,
+      published_at: format_date(metadata[:first_published_at]),
+      last_updated: format_date(metadata[:public_updated_at]),
+      publishing_organisation: metadata[:primary_organisation_title],
     }
   end
 
-  def parse_time_series(time_series)
-    @upviews_series = get_chart_presenter(time_series, :upviews)
-    @pviews_series = get_chart_presenter(time_series, :pviews)
-    @searches_series = get_chart_presenter(time_series, :searches)
-    @feedex_series = get_chart_presenter(time_series, :feedex)
-    @satisfaction_series = get_chart_presenter(time_series, :satisfaction)
+  def parse_metrics
+    @single_page_data[:time_series_metrics].each do |metric|
+      @metrics[metric[:name]] = {
+        'value': format_metric_value(metric[:name], metric[:total]),
+        'time_series': metric[:time_series]
+      }
+    end
+
+    @single_page_data[:edition_metrics].each do |metric|
+      @metrics[metric[:name]] = {
+        'value': format_metric_value(metric[:name], metric[:value]),
+        'time_series': nil
+      }
+    end
+
+    @pdf_count = @metrics['pdf_count'][:value]
+    @words = @metrics['words'][:value]
+    @upviews = format_metric_value('upviews', @metrics['upviews'][:value])
+    @pviews = format_metric_value('pviews', @metrics['pviews'][:value])
+    @feedex = format_metric_value('feedex', @metrics['feedex'][:value])
+    @searches = format_metric_value('searches', @metrics['searches'][:value])
+    @satisfaction = format_metric_value('satisfaction', @metrics['satisfaction'][:value])
+  end
+
+  def parse_time_series
+    @upviews_series = get_chart_presenter(@metrics['upviews'][:time_series], 'upviews')
+    @pviews_series = get_chart_presenter(@metrics['pviews'][:time_series], 'pviews')
+    @searches_series = get_chart_presenter(@metrics['searches'][:time_series], 'searches')
+    @feedex_series = get_chart_presenter(@metrics['feedex'][:time_series], 'feedex')
+    @satisfaction_series = get_chart_presenter(@metrics['satisfaction'][:time_series], 'satisfaction')
   end
 
   def add_glance_metric_presenters
     time_period = @date_range.time_period
-    @upviews_glance_metric = GlanceMetricPresenter.new(:upviews, @upviews, time_period)
-    @satisfaction_glance_metric = GlanceMetricPresenter.new(:satisfaction, @satisfaction, time_period)
-    @searches_glance_metric = GlanceMetricPresenter.new(:searches, @searches, time_period, @upviews)
-    @feedex_glance_metric = GlanceMetricPresenter.new(:feedex, @feedex, time_period)
+    @upviews_glance_metric = GlanceMetricPresenter.new('upviews', @metrics['upviews'][:value], time_period)
+    @satisfaction_glance_metric = GlanceMetricPresenter.new('satisfaction', @metrics['satisfaction'][:value], time_period)
+    @searches_glance_metric = GlanceMetricPresenter.new('searches', @metrics['searches'][:value], time_period)
+    @feedex_glance_metric = GlanceMetricPresenter.new('feedex', @metrics['feedex'][:value], time_period)
   end
 
   def get_chart_presenter(time_series, metric)

--- a/app/services/fetch_single_page.rb
+++ b/app/services/fetch_single_page.rb
@@ -4,7 +4,7 @@ class FetchSinglePage
     new(args).call
   end
 
-  def initialize(base_path, to, from)
+  def initialize(base_path:, to:, from:)
     @base_path = base_path
     @from = from
     @to = to

--- a/app/services/fetch_single_page.rb
+++ b/app/services/fetch_single_page.rb
@@ -1,0 +1,16 @@
+class FetchSinglePage
+  include MetricsCommon
+  def self.call(args)
+    new(args).call
+  end
+
+  def initialize(base_path, to, from)
+    @base_path = base_path
+    @from = from
+    @to = to
+  end
+
+  def call
+    api.single_page(base_path: @base_path, from: @from, to: @to)
+  end
+end

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -1,6 +1,6 @@
 <div class="metric_summary <%= metric_name %>">
   <%= render 'metric_header', {
-    metric_name: metric_name, 
+    metric_name: metric_name,
     value: @performance_data.instance_variable_get("@#{metric_name}"), 
     show_trend: show_trend 
   }%>

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -1,7 +1,7 @@
 <div class="metric_summary <%= metric_name %>">
   <%= render 'metric_header', {
     metric_name: metric_name,
-    value: @performance_data.instance_variable_get("@#{metric_name}"), 
+    value: @performance_data.metrics[metric_name][:value], 
     show_trend: show_trend 
   }%>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -106,13 +106,13 @@
 
     <div class="govuk-grid-column-one-half">
       <div class="metric_summary words">
-        <%= render 'metric_header', metric_name: 'words', value: @performance_data.words, show_trend: false %>
+        <%= render 'metric_header', metric_name: 'words', value: @performance_data.metrics['words'][:value], show_trend: false %>
       </div>
     </div>
 
     <div class="govuk-grid-column-one-half">
       <div class="metric_summary pdf_count">
-        <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.pdf_count, show_trend: false %>
+        <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.metrics['pdf_count'][:value], show_trend: false %>
       </div>
     </div>
 </div>

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -22,6 +22,11 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
+  def single_page(base_path:, from:, to:)
+    url = single_page_url(base_path, from, to)
+    get_json(url).to_hash.deep_symbolize_keys
+  end
+
 private
 
   def content_data_api_endpoint
@@ -38,5 +43,9 @@ private
 
   def content_items_url(from, to, organisation_id)
     "#{content_data_api_endpoint}/content#{query_string(from: from, to: to, organisation_id: organisation_id)}"
+  end
+
+  def single_page_url(base_path, from, to)
+    "#{content_data_api_endpoint}/single_page/#{base_path}#{query_string(from: from, to: to)}"
   end
 end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'date selection', type: :feature do
     upviews_rows = extract_table_content("#upviews_table")
     expect(upviews_rows).to match_array([
       ['', month_and_date_string_for_date1.to_s, month_and_date_string_for_date2.to_s, month_and_date_string_for_date3.to_s],
-      ['Unique pageviews', "0", "9", "9"]
+      ['Unique pageviews', "1", "2", "30"]
     ])
   end
 

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -58,6 +58,9 @@ RSpec.describe 'date selection', type: :feature do
   def initial_page_stub
     from = Time.zone.today - 30.days
     to = Time.zone.today
+    content_data_api_has_single_page(base_path: 'base/path',
+                                     from: from.to_s,
+                                     to: to.to_s)
     content_data_api_has_metric(base_path: 'base/path',
                                 from: from,
                                 to: to,
@@ -99,6 +102,9 @@ RSpec.describe 'date selection', type: :feature do
       from: from,
       to: to,
       metrics: metrics)
+    content_data_api_has_single_page(base_path: 'base/path',
+      from: from.to_s,
+      to: to.to_s)
   end
 
   def expect_metrics_for_each_date_to_be_correct(from, to)

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -61,47 +61,9 @@ RSpec.describe 'date selection', type: :feature do
     content_data_api_has_single_page(base_path: 'base/path',
                                      from: from.to_s,
                                      to: to.to_s)
-    content_data_api_has_metric(base_path: 'base/path',
-                                from: from,
-                                to: to,
-                                metrics: metrics)
-    content_data_api_has_timeseries(base_path: 'base/path',
-                                    from: from,
-                                    to: to,
-                                    metrics: metrics,
-                                    payload: {
-       upviews: [
-         { "date" => (from - 1.day).to_s, "value" => 0 },
-         { "date" => (from - 2.days).to_s, "value" => 9 },
-         { "date" => (to + 1.day).to_s, "value" => 9 }
-       ],
-       pviews: [
-         { "date" => (from - 1.day).to_s, "value" => 8 },
-         { "date" => (from - 2.days).to_s, "value" => 8 },
-         { "date" => (to + 1.day).to_s, "value" => 8 }
-       ],
-       searches: [
-         { "date" => (from - 1.day).to_s, "value" => 8 },
-         { "date" => (from - 2.days).to_s, "value" => 8 },
-         { "date" => (to + 1.day).to_s, "value" => 8 }
-       ],
-       satisfaction: [
-         { "date" => (from - 1.day).to_s, "value" => 100 },
-         { "date" => (from - 2.days).to_s, "value" => 90 },
-         { "date" => (to + 1.day).to_s, "value" => 80 }
-       ]
-     })
   end
 
   def stub_response_for_date_range(from, to)
-    content_data_api_has_metric(base_path: 'base/path',
-      from: from,
-      to: to,
-      metrics: metrics)
-    content_data_api_has_timeseries(base_path: 'base/path',
-      from: from,
-      to: to,
-      metrics: metrics)
     content_data_api_has_single_page(base_path: 'base/path',
       from: from.to_s,
       to: to.to_s)

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -28,6 +28,7 @@ RSpec.describe '/content' do
   end
 
   before do
+    content_data_api_has_single_page(base_path: 'path/1', from: from, to: to)
     content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
     visit "/content?date_range=last-month&organisation_id=org-id"
   end
@@ -59,6 +60,7 @@ RSpec.describe '/content' do
     it 'respects the date filter' do
       from = (Time.zone.today - 1.year).to_s('%F')
       to = Time.zone.today.to_s('%F')
+      content_data_api_has_single_page(base_path: 'path/1', from: from, to: to)
       content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
       content_data_api_has_metric(base_path: 'path/1', from: from, to: to, metrics: metrics)
       content_data_api_has_timeseries(base_path: 'path/1', from: from, to: to, metrics: metrics)

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -51,8 +51,6 @@ RSpec.describe '/content' do
 
   context 'click title of an item' do
     it 'takes you to single content item page' do
-      content_data_api_has_metric(base_path: 'path/1', from: from, to: to, metrics: metrics)
-      content_data_api_has_timeseries(base_path: 'path/1', from: from, to: to, metrics: metrics)
       click_link 'The title'
       expect(current_path).to eq '/metrics/path/1'
     end
@@ -62,8 +60,6 @@ RSpec.describe '/content' do
       to = Time.zone.today.to_s('%F')
       content_data_api_has_single_page(base_path: 'path/1', from: from, to: to)
       content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
-      content_data_api_has_metric(base_path: 'path/1', from: from, to: to, metrics: metrics)
-      content_data_api_has_timeseries(base_path: 'path/1', from: from, to: to, metrics: metrics)
 
       visit "/content?date_range=last-year&organisation_id=org-id"
       click_link 'The title'

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -19,6 +19,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
         from: from.to_s,
         to: to.to_s,
         metrics: metrics)
+
+      content_data_api_has_single_page(base_path: 'base/path', from: from.to_s, to: to.to_s)
+
       visit '/metrics/base/path'
     end
 
@@ -143,6 +146,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
         payload: {
           upviews: [],
         })
+
+      content_data_api_has_single_page(base_path: 'base/path', from: from.to_s, to: to.to_s)
+
       visit '/metrics/base/path'
     end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -10,16 +10,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
   context 'successful request' do
     before do
-      content_data_api_has_metric(base_path: 'base/path',
-        from: from.to_s,
-        to: to.to_s,
-        metrics: metrics)
-
-      content_data_api_has_timeseries(base_path: 'base/path',
-        from: from.to_s,
-        to: to.to_s,
-        metrics: metrics)
-
       content_data_api_has_single_page(base_path: 'base/path', from: from.to_s, to: to.to_s)
 
       visit '/metrics/base/path'
@@ -58,7 +48,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders a page searches metric as a percentage of views' do
-      expect(page).to have_selector '.govuk-grid-column-one-quarter.searches', text: '250'
+      expect(page).to have_selector '.govuk-grid-column-one-quarter.searches', text: '24'
     end
 
     it 'renders the publishing application' do
@@ -133,19 +123,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
   context 'no time series from the data-api' do
     before do
-      content_data_api_has_metric(base_path: 'base/path',
-        from: from.to_s,
-        to: to.to_s,
-        metrics: metrics)
-
-      content_data_api_has_timeseries(base_path: 'base/path',
-        from: from.to_s,
-        to: to.to_s,
-        metrics: metrics,
-        payload: {
-          upviews: [],
-        })
-
       content_data_api_has_single_page_missing_data(base_path: 'base/path', from: from.to_s, to: to.to_s)
 
       visit '/metrics/base/path'

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -26,19 +26,19 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the metric for upviews' do
-      expect(page).to have_selector '.metric_summary.upviews', text: '145,000'
+      expect(page).to have_selector '.metric_summary.upviews', text: '33'
     end
 
     it 'renders the metric for pviews' do
-      expect(page).to have_selector '.metric_summary.pviews', text: '200,000'
+      expect(page).to have_selector '.metric_summary.pviews', text: '60'
     end
 
     it 'renders a metric for satisfaction' do
-      expect(page).to have_selector '.metric_summary.satisfaction', text: '26'
+      expect(page).to have_selector '.metric_summary.satisfaction', text: '90'
     end
 
     it 'renders a metric for feedex' do
-      expect(page).to have_selector '.metric_summary.feedex', text: '20'
+      expect(page).to have_selector '.metric_summary.feedex', text: '63'
     end
 
     it 'renders a metric for pdf_count' do
@@ -54,7 +54,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders a metric for on page searches' do
-      expect(page).to have_selector '.metric_summary.searches', text: '250'
+      expect(page).to have_selector '.metric_summary.searches', text: '24'
     end
 
     it 'renders a page searches metric as a percentage of views' do
@@ -62,7 +62,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     it 'renders the publishing application' do
-      expect(page).to have_selector '.related-actions', text: 'Whitehall'
+      expect(page).to have_selector '.related-actions', text: 'Publisher'
     end
 
     it 'renders the metadata' do
@@ -70,9 +70,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
         el.all('dt,dd').map(&:text)
       end
       expect(metadata).to eq([
-        [I18n.t("components.metadata.labels.published_at"), '1 February 2018',
-         I18n.t("components.metadata.labels.last_updated"), '25 April 2018'],
-        [I18n.t("components.metadata.labels.publishing_organisation"), 'The ministry',
+        [I18n.t("components.metadata.labels.published_at"), '17 July 2018',
+         I18n.t("components.metadata.labels.last_updated"), '17 July 2018'],
+        [I18n.t("components.metadata.labels.publishing_organisation"), 'The Ministry',
          I18n.t("components.metadata.labels.document_type"), 'News story',
          I18n.t("components.metadata.labels.base_path"), '/.../path']
       ])
@@ -124,8 +124,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     it 'returns a 404 for a Gds::NotFound' do
       content_data_api_does_not_have_base_path(base_path: 'base/path',
         from: from.to_s,
-        to: to.to_s,
-        metrics: metrics)
+        to: to.to_s)
       visit '/metrics/base/path'
       expect(page.status_code).to eq(404)
       expect(page).to have_content "The page you were looking for doesn't exist."
@@ -147,7 +146,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
           upviews: [],
         })
 
-      content_data_api_has_single_page(base_path: 'base/path', from: from.to_s, to: to.to_s)
+      content_data_api_has_single_page_missing_data(base_path: 'base/path', from: from.to_s, to: to.to_s)
 
       visit '/metrics/base/path'
     end

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,12 +1,12 @@
 RSpec.describe MetricsFormatterHelper do
   context 'metric needs to be rendered as a percentage' do
     it 'displays value as a percentage' do
-      value = format_metric_value(:satisfaction, 0.9000)
+      value = format_metric_value('satisfaction', 0.9000)
       expect(value).to eq '90.000%'
     end
 
     it 'displays value as a percentage whole number for headline figures' do
-      value = format_metric_headline_figure(:satisfaction, 24.13413)
+      value = format_metric_headline_figure('satisfaction', 24.13413)
       expect(value).to eq '24%'
     end
   end
@@ -14,14 +14,14 @@ RSpec.describe MetricsFormatterHelper do
 
   context 'metric does not need to be rendered as a percentage' do
     it 'displays value as an integer' do
-      value = format_metric_value(:pviews, 90)
+      value = format_metric_value('pviews', 90)
       expect(value).to eq 90
     end
   end
 
   context 'if figure for percentage metric is not supplied' do
     it 'does not raise an error' do
-      expect { format_metric_value(:satisfaction, nil) }.to_not raise_error
+      expect { format_metric_value('satisfaction', nil) }.to_not raise_error
     end
   end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -4,13 +4,11 @@ RSpec.describe ChartPresenter do
   subject do
     ChartPresenter.new(
       json:
-        {
-          upviews: [
-            { date: '2018-01-13', value: 101 },
-            { date: '2018-01-14', value: 202 },
-            { date: '2018-01-15', value: 303 }
-          ]
-        },
+        [
+          { date: '2018-01-13', value: 101 },
+          { date: '2018-01-14', value: 202 },
+          { date: '2018-01-15', value: 303 }
+        ],
       metric: :upviews,
       from: from,
       to: to

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -55,15 +55,16 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
-  it 'returns the aggregated metrics' do
-    expect(subject).to have_attributes(
-      upviews: 2030,
-      pviews: 3000,
-      searches: 120,
-      feedex: 20,
-      satisfaction: '34%'
-    )
-  end
+
+  # it 'returns the aggregated metrics' do
+  #   expect(subject).to have_attributes(
+  #     upviews: 2030,
+  #     pviews: 3000,
+  #     searches: 120,
+  #     feedex: 20,
+  #     satisfaction: '34%'
+  #   )
+  # end
 
   it 'returns the title' do
     expect(subject.title).to eq('The title')

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe SingleContentItemPresenter do
     SingleContentItemPresenter.new(single_page_data, date_range)
   end
 
-
   describe '#publishing_app' do
     it 'does not fail if no publishing app' do
       single_page_data[:metadata][:publishing_app] = nil
@@ -37,5 +36,28 @@ RSpec.describe SingleContentItemPresenter do
 
   it 'returns the title' do
     expect(subject.title).to eq('Content Title')
+  end
+
+  describe '#metrics' do
+    glance_metrics = %w[upviews satisfaction searches feedex]
+    chart_metrics = %w[upviews pviews satisfaction searches feedex]
+    page_content_metrics = %w[words pdf_count]
+
+    it 'contains all required metrics' do
+      all_metrics = glance_metrics | chart_metrics | page_content_metrics
+      expect(subject.metrics.keys).to contain_exactly(*all_metrics)
+    end
+
+    it 'contains values for all metrics' do
+      expect(subject.metrics.values).to all(a_hash_including(value: anything))
+    end
+
+    chart_metrics.each do |chart_metric|
+      it "contains time series for #{chart_metric}" do
+        expect(subject.metrics[chart_metric][:time_series]).to all(
+          include('date' => anything, 'value' => anything)
+        )
+      end
+    end
   end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -3,43 +3,23 @@ RSpec.describe SingleContentItemPresenter do
 
   let(:from) { '2018-01-01' }
   let(:to) { '2018-06-01' }
-
-  let(:metrics) do
-    {
-        title: 'The title',
-        base_path: '/the/base/path',
-        primary_organisation_title: 'UK Visas and Immigration',
-        first_published_at: '2016-09-01T00:00:00.000Z',
-        public_updated_at: '2017-10-01T00:00:00.000Z',
-        document_type: 'news_story',
-        upviews: 2030,
-        pviews: 3000,
-        satisfaction: 33.5,
-        searches: 120,
-        feedex: 20,
-    }
-  end
-  let(:time_series) { default_timeseries_payload(from.to_date, to.to_date) }
+  let(:single_page_data) { default_single_page_payload('the/base/path', from, to) }
   let(:date_range) { build(:date_range, :last_30_days) }
 
   subject do
-    SingleContentItemPresenter.new(metrics,
-      time_series,
-      date_range)
+    SingleContentItemPresenter.new(single_page_data, date_range)
   end
 
 
   describe '#publishing_app' do
     it 'does not fail if no publishing app' do
-      metrics[:publishing_app] = nil
+      single_page_data[:metadata][:publishing_app] = nil
 
       expect(subject.publishing_app).to eq('Unknown')
     end
 
     it 'capitalizes the publishing_app if present' do
-      metrics[:publishing_app] = 'travel-advice'
-
-      expect(subject.publishing_app).to eq('Travel advice')
+      expect(subject.publishing_app).to eq('Publisher')
     end
   end
 
@@ -47,26 +27,15 @@ RSpec.describe SingleContentItemPresenter do
     it 'returns a hash with the metadata' do
       expect(subject.metadata).to eq(
         base_path: '/the/base/path',
-        published_at: "1 September 2016",
-        last_updated: "1 October 2017",
-        publishing_organisation: 'UK Visas and Immigration',
-        document_type: "News story",
+        published_at:  "17 July 2018",
+        last_updated:  "17 July 2018",
+        document_type:  "News story",
+        publishing_organisation:  "The Ministry"
       )
     end
   end
 
-
-  # it 'returns the aggregated metrics' do
-  #   expect(subject).to have_attributes(
-  #     upviews: 2030,
-  #     pviews: 3000,
-  #     searches: 120,
-  #     feedex: 20,
-  #     satisfaction: '34%'
-  #   )
-  # end
-
   it 'returns the title' do
-    expect(subject.title).to eq('The title')
+    expect(subject.title).to eq('Content Title')
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -30,6 +30,13 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
+      def content_data_api_has_single_page(base_path:, from:, to:)
+        query = query(from: from, to: to)
+        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        body = default_single_page_payload(base_path, from, to).to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_endpoint
         Plek.current.find('content-performance-manager').to_s
       end
@@ -104,6 +111,81 @@ module GdsApi
             { "date" => (from - 1.day).to_s, "value" => 3 },
             { "date" => (from - 2.days).to_s, "value" => 3 },
             { "date" => (to + 1.day).to_s, "value" => 3 }
+          ]
+        }
+      end
+
+      def default_single_page_payload(base_path, from, to)
+        {
+          metadata: {
+            title:  "Content Title",
+            base_path:  "/#{base_path}",
+            first_published_at:  "2018-07-17T10:35:59.000Z",
+            public_updated_at:  "2018-07-17T10:35:57.000Z",
+            publishing_app:  "publisher",
+            document_type:  "news_story",
+            primary_organisation_title:  "The Ministry"
+          },
+          time_period: {
+            to: to.to_s,
+            from: from.to_s
+          },
+          time_series_metrics: [
+            {
+              name: "upviews",
+              total: 33,
+              time_series: [
+                { "date" => (from - 1.day).to_s, "value" => 1 },
+                { "date" => (from - 2.days).to_s, "value" => 2 },
+                { "date" => (to + 1.day).to_s, "value" => 30 }
+              ]
+            },
+            {
+              name: "pviews",
+              total: 60,
+              time_series: [
+                { "date" => (from - 1.day).to_s, "value" => 10 },
+                { "date" => (from - 2.days).to_s, "value" => 20 },
+                { "date" => (to + 1.day).to_s, "value" => 30 }
+              ]
+            },
+            {
+              name: "searches",
+              total: 24,
+              time_series: [
+                { "date" => (from - 1.day).to_s, "value" => 8 },
+                { "date" => (from - 2.days).to_s, "value" => 8 },
+                { "date" => (to + 1.day).to_s, "value" => 8 }
+              ]
+            },
+            {
+              name: "feedex",
+              total: 63,
+              time_series: [
+                { "date" => (from - 1.day).to_s, "value" => 20 },
+                { "date" => (from - 2.days).to_s, "value" => 21 },
+                { "date" => (to + 1.day).to_s, "value" => 22 }
+              ]
+            },
+            {
+              name: "satisfaction",
+              total: 0.9000,
+              time_series: [
+                { "date" => (from - 1.day).to_s, "value" => 1.0000 },
+                { "date" => (from - 2.days).to_s, "value" => 0.9000 },
+                { "date" => (to + 1.day).to_s, "value" => 0.80000 }
+              ]
+            }
+          ],
+          edition_metrics: [
+            {
+              name: "words",
+              value: 200
+            },
+            {
+              name: "pdf_count",
+              value: 3
+            }
           ]
         }
       end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -116,6 +116,8 @@ module GdsApi
       end
 
       def default_single_page_payload(base_path, from, to)
+        from_date = Time.zone.parse(from)
+        to_date = Time.zone.parse(to)
         {
           metadata: {
             title:  "Content Title",
@@ -127,53 +129,53 @@ module GdsApi
             primary_organisation_title:  "The Ministry"
           },
           time_period: {
-            to: to.to_s,
-            from: from.to_s
+            to: to,
+            from: from
           },
           time_series_metrics: [
             {
               name: "upviews",
               total: 33,
               time_series: [
-                { "date" => (from - 1.day).to_s, "value" => 1 },
-                { "date" => (from - 2.days).to_s, "value" => 2 },
-                { "date" => (to + 1.day).to_s, "value" => 30 }
+                { "date" => (from_date - 1.day).to_s, "value" => 1 },
+                { "date" => (from_date - 2.days).to_s, "value" => 2 },
+                { "date" => (to_date + 1.day).to_s, "value" => 30 }
               ]
             },
             {
               name: "pviews",
               total: 60,
               time_series: [
-                { "date" => (from - 1.day).to_s, "value" => 10 },
-                { "date" => (from - 2.days).to_s, "value" => 20 },
-                { "date" => (to + 1.day).to_s, "value" => 30 }
+                { "date" => (from_date - 1.day).to_s, "value" => 10 },
+                { "date" => (from_date - 2.days).to_s, "value" => 20 },
+                { "date" => (to_date + 1.day).to_s, "value" => 30 }
               ]
             },
             {
               name: "searches",
               total: 24,
               time_series: [
-                { "date" => (from - 1.day).to_s, "value" => 8 },
-                { "date" => (from - 2.days).to_s, "value" => 8 },
-                { "date" => (to + 1.day).to_s, "value" => 8 }
+                { "date" => (from_date - 1.day).to_s, "value" => 8 },
+                { "date" => (from_date - 2.days).to_s, "value" => 8 },
+                { "date" => (to_date + 1.day).to_s, "value" => 8 }
               ]
             },
             {
               name: "feedex",
               total: 63,
               time_series: [
-                { "date" => (from - 1.day).to_s, "value" => 20 },
-                { "date" => (from - 2.days).to_s, "value" => 21 },
-                { "date" => (to + 1.day).to_s, "value" => 22 }
+                { "date" => (from_date - 1.day).to_s, "value" => 20 },
+                { "date" => (from_date - 2.days).to_s, "value" => 21 },
+                { "date" => (to_date + 1.day).to_s, "value" => 22 }
               ]
             },
             {
               name: "satisfaction",
               total: 0.9000,
               time_series: [
-                { "date" => (from - 1.day).to_s, "value" => 1.0000 },
-                { "date" => (from - 2.days).to_s, "value" => 0.9000 },
-                { "date" => (to + 1.day).to_s, "value" => 0.80000 }
+                { "date" => (from_date - 1.day).to_s, "value" => 1.0000 },
+                { "date" => (from_date - 2.days).to_s, "value" => 0.9000 },
+                { "date" => (to_date + 1.day).to_s, "value" => 0.80000 }
               ]
             }
           ],

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -3,24 +3,10 @@ require 'gds_api/content_data_api'
 module GdsApi
   module TestHelpers
     module ContentDataApi
-      def content_data_api_has_metric(base_path:, from:, to:, metrics:)
-        query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}#{query}"
-        body = default_metric_payload(base_path)
-        stub_request(:get, url).to_return(status: 200, body: body.to_json)
-      end
-
       def content_data_api_does_not_have_base_path(base_path:, from:, to:)
         query = query(from: from, to: to)
         url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
-      end
-
-      def content_data_api_has_timeseries(base_path:, from:, to:, metrics:, payload: nil)
-        query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query}"
-        body = payload.nil? ? default_timeseries_payload(from.to_date, to.to_date) : payload
-        stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_has_content_items(from:, to:, organisation_id:, items:)
@@ -61,65 +47,6 @@ module GdsApi
         }.flatten
 
         "?#{param_pairs.join('&')}"
-      end
-
-      def default_metric_payload(base_path)
-        {
-          base_path: "/#{base_path}",
-          upviews: 145_000,
-          pviews: 200_000,
-          satisfaction: 25.55,
-          searches: 250,
-          feedex: 20,
-          pdf_count: 3,
-          words: 200,
-          title: "Content Title",
-          first_published_at: '2018-02-01T00:00:00.000Z',
-          public_updated_at: '2018-04-25T00:00:00.000Z',
-          primary_organisation_title: 'The ministry',
-          document_type: "news_story",
-          publishing_app: 'whitehall',
-        }
-      end
-
-      def default_timeseries_payload(from, to)
-        {
-          upviews: [
-            { "date" => (from - 1.day).to_s, "value" => 1 },
-            { "date" => (from - 2.days).to_s, "value" => 2 },
-            { "date" => (to + 1.day).to_s, "value" => 30 }
-          ],
-          pviews: [
-            { "date" => (from - 1.day).to_s, "value" => 10 },
-            { "date" => (from - 2.days).to_s, "value" => 20 },
-            { "date" => (to + 1.day).to_s, "value" => 30 }
-          ],
-          searches: [
-            { "date" => (from - 1.day).to_s, "value" => 8 },
-            { "date" => (from - 2.days).to_s, "value" => 8 },
-            { "date" => (to + 1.day).to_s, "value" => 8 }
-          ],
-          feedex: [
-            { "date" => (from - 1.day).to_s, "value" => 20 },
-            { "date" => (from - 2.days).to_s, "value" => 21 },
-            { "date" => (to + 1.day).to_s, "value" => 22 }
-          ],
-          satisfaction: [
-            { "date" => (from - 1.day).to_s, "value" => 1.0000 },
-            { "date" => (from - 2.days).to_s, "value" => 0.9000 },
-            { "date" => (to + 1.day).to_s, "value" => 0.80000 }
-          ],
-          words: [
-            { "date" => (from - 1.day).to_s, "value" => 200 },
-            { "date" => (from - 2.days).to_s, "value" => 200 },
-            { "date" => (to + 1.day).to_s, "value" => 200 }
-          ],
-          pdf_count: [
-            { "date" => (from - 1.day).to_s, "value" => 3 },
-            { "date" => (from - 2.days).to_s, "value" => 3 },
-            { "date" => (to + 1.day).to_s, "value" => 3 }
-          ]
-        }
       end
 
       def default_single_page_payload(base_path, from, to)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -10,9 +10,9 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
-      def content_data_api_does_not_have_base_path(base_path:, from:, to:, metrics:)
-        query = query(from: from, to: to, metrics: metrics)
-        url = "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}#{query}"
+      def content_data_api_does_not_have_base_path(base_path:, from:, to:)
+        query = query(from: from, to: to)
+        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
@@ -34,6 +34,13 @@ module GdsApi
         query = query(from: from, to: to)
         url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
         body = default_single_page_payload(base_path, from, to).to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
+      def content_data_api_has_single_page_missing_data(base_path:, from:, to:)
+        query = query(from: from, to: to)
+        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        body = no_data_single_page_payload(base_path, from, to).to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
@@ -116,8 +123,11 @@ module GdsApi
       end
 
       def default_single_page_payload(base_path, from, to)
-        from_date = Time.zone.parse(from)
-        to_date = Time.zone.parse(to)
+        from_date = Date.parse(from)
+        to_date = Date.parse(to)
+        day1 = (from_date - 1.day).to_s
+        day2 = (from_date - 2.days).to_s
+        day3 = (to_date + 1.day).to_s
         {
           metadata: {
             title:  "Content Title",
@@ -137,45 +147,45 @@ module GdsApi
               name: "upviews",
               total: 33,
               time_series: [
-                { "date" => (from_date - 1.day).to_s, "value" => 1 },
-                { "date" => (from_date - 2.days).to_s, "value" => 2 },
-                { "date" => (to_date + 1.day).to_s, "value" => 30 }
+                { "date" => day1, "value" => 1 },
+                { "date" => day2, "value" => 2 },
+                { "date" => day3, "value" => 30 }
               ]
             },
             {
               name: "pviews",
               total: 60,
               time_series: [
-                { "date" => (from_date - 1.day).to_s, "value" => 10 },
-                { "date" => (from_date - 2.days).to_s, "value" => 20 },
-                { "date" => (to_date + 1.day).to_s, "value" => 30 }
+                { "date" => day1, "value" => 10 },
+                { "date" => day2, "value" => 20 },
+                { "date" => day3, "value" => 30 }
               ]
             },
             {
               name: "searches",
               total: 24,
               time_series: [
-                { "date" => (from_date - 1.day).to_s, "value" => 8 },
-                { "date" => (from_date - 2.days).to_s, "value" => 8 },
-                { "date" => (to_date + 1.day).to_s, "value" => 8 }
+                { "date" => day1, "value" => 8 },
+                { "date" => day2, "value" => 8 },
+                { "date" => day3, "value" => 8 }
               ]
             },
             {
               name: "feedex",
               total: 63,
               time_series: [
-                { "date" => (from_date - 1.day).to_s, "value" => 20 },
-                { "date" => (from_date - 2.days).to_s, "value" => 21 },
-                { "date" => (to_date + 1.day).to_s, "value" => 22 }
+                { "date" => day1, "value" => 20 },
+                { "date" => day2, "value" => 21 },
+                { "date" => day3, "value" => 22 }
               ]
             },
             {
               name: "satisfaction",
-              total: 0.9000,
+              total: 0.9,
               time_series: [
-                { "date" => (from_date - 1.day).to_s, "value" => 1.0000 },
-                { "date" => (from_date - 2.days).to_s, "value" => 0.9000 },
-                { "date" => (to_date + 1.day).to_s, "value" => 0.80000 }
+                { "date" => day1, "value" => 1.0000 },
+                { "date" => day2, "value" => 0.9000 },
+                { "date" => day3, "value" => 0.80000 }
               ]
             }
           ],
@@ -188,6 +198,32 @@ module GdsApi
               name: "pdf_count",
               value: 3
             }
+          ]
+        }
+      end
+
+      def no_data_single_page_payload(base_path, from, to)
+        {
+          metadata: {
+            title:  "Content Title",
+            base_path:  "/#{base_path}",
+            first_published_at:  "2018-07-17T10:35:59.000Z",
+            public_updated_at:  "2018-07-17T10:35:57.000Z",
+            publishing_app:  "publisher",
+            document_type:  "news_story",
+            primary_organisation_title:  "The Ministry"
+          },
+          time_period: { to: to, from: from },
+          time_series_metrics: [
+            { name: "upviews", total: 0, time_series: [] },
+            { name: "pviews", total: 0, time_series: [] },
+            { name: "searches", total: 0, time_series: [] },
+            { name: "feedex", total: 0, time_series: [] },
+            { name: "satisfaction", total: 0.0, time_series: [] }
+          ],
+          edition_metrics: [
+            { name: "words", value: 0 },
+            { name: "pdf_count", value: 0 }
           ]
         }
       end


### PR DESCRIPTION
Updating the single page presenter to use the new `/single_page` endpoint from content performance manager. Removed old request test stubs for access in the previous endpoints.  