### PR TITLE
Add dropdown menu to filter by organisation

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,6 +1,8 @@
 class ContentController < ApplicationController
   def index
     @content = get_content
+    organisations = FetchOrganisations.call
+    @organisations = organisations[:organisations]
   end
 
 private

--- a/app/services/fetch_organisations.rb
+++ b/app/services/fetch_organisations.rb
@@ -1,0 +1,11 @@
+class FetchOrganisations
+  include MetricsCommon
+
+  def self.call
+    new.call
+  end
+
+  def call
+    api.organisations
+  end
+end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -1,3 +1,9 @@
+<%= form_tag content_path, method: 'get', name: 'organisation-picker' do %>
+  <%= select_tag 'organisation_id', options_for_select(@organisations.map{ |org| [org[:title], org[:organisation_id]] }), class: 'org-picker' %>
+  <%= hidden_field_tag 'date_range', @content.date_range.time_period %>
+  <%= submit_tag "Filter" %>
+<% end %>
+
 <% content_for :title, @content.title %>
 <h3>Content data</h3>
 <div class="content-table">

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -27,6 +27,10 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
+  def organisations
+    get_json(organisations_url).to_hash.deep_symbolize_keys
+  end
+
 private
 
   def content_data_api_endpoint
@@ -47,5 +51,9 @@ private
 
   def single_page_url(base_path, from, to)
     "#{content_data_api_endpoint}/single_page/#{base_path}#{query_string(from: from, to: to)}"
+  end
+
+  def organisations_url
+    "#{content_data_api_endpoint}/organisations"
   end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe '/content' do
   before do
     content_data_api_has_single_page(base_path: 'path/1', from: from, to: to)
     content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
+    content_data_has_orgs
     visit "/content?date_range=last-month&organisation_id=org-id"
   end
 
@@ -65,6 +66,19 @@ RSpec.describe '/content' do
       click_link 'The title'
       expect(current_path).to eq '/metrics/path/1'
       expect(page).to have_content('Page data: Past year')
+    end
+  end
+
+  context 'filter by organisation' do
+    before do
+      content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
+    end
+
+    it 'makes request to api with correct organisation_id' do
+      organisation_dropdown = find('.org-picker')
+      organisation_dropdown.select('another org')
+      click_on 'Filter'
+      expect(page).to have_content('Content data')
     end
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -30,6 +30,12 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
+      def content_data_has_orgs
+        url = "#{content_data_api_endpoint}/organisations"
+        body = { organisations: default_organisations }.to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_endpoint
         Plek.current.find('content-performance-manager').to_s
       end
@@ -153,6 +159,19 @@ module GdsApi
             { name: "pdf_count", value: 0 }
           ]
         }
+      end
+
+      def default_organisations
+        [
+          {
+            title: 'org',
+            organisation_id: 'org-id'
+          },
+          {
+            title: 'another org',
+            organisation_id: 'another-org-id'
+          }
+        ]
       end
     end
   end


### PR DESCRIPTION
### What?

A dropdown to display all the organisations and allow the user to choose to filter content by chosen organisation i.e to only display content that belongs to the selected organisation.

[Trello card](https://trello.com/c/nQxldbA2/661-1-index-page-filter-by-organisation#)

### Why?

To allow the user to filter down to the content that is most important to them.

### Notes

The dropdown menu is not the final design, this PR sets up the logic and in future we will use a govuk component for the dropdown.

<img width="1059" alt="screen shot 2018-10-11 at 14 04 19" src="https://user-images.githubusercontent.com/13124899/46806071-937f1800-cd5e-11e8-9e6e-c3c9151812dd.png">

<img width="1147" alt="screen shot 2018-10-11 at 14 04 04" src="https://user-images.githubusercontent.com/13124899/46806058-89f5b000-cd5e-11e8-8d14-3aed35741ab3.png">