### PR TITLE
Add number of responses for satisfaction score

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -36,7 +36,11 @@ class SingleContentItemPresenter
   end
 
   def satisfaction_context
-    I18n.t("metrics.satisfaction.context", total_responses: 700)
+    I18n.t("metrics.satisfaction.context", total_responses: useful_yes_no_total)
+  end
+
+  def satisfaction_short_context
+    I18n.t("metrics.satisfaction.short_context", total_responses: useful_yes_no_total)
   end
 
   def searches_context
@@ -107,6 +111,10 @@ class SingleContentItemPresenter
   end
 
 private
+
+  def useful_yes_no_total
+    @metrics['useful_yes'][:value] + @metrics['useful_no'][:value]
+  end
 
   def on_page_search_rate
     metric_value = self.total_searches

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -5,14 +5,18 @@
   about ||= false
   trend_percentage ||= false
   context ||= false
-  total ||= false
+  short_context ||= false
 %>
 <% if name && figure && context %>
   <div class="app-c-info-metric govuk-body">
     <h3 class="app-c-info-metric__heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
     <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
-    <% if total %><%= total %><% end %>
+    <% if short_context %>
+      <span class="app-c-info-metric__short-context">
+        (<%= short_context %>)
+      </span>
+    <% end %>
     <% if trend_percentage %>
       <span class="app-c-info-metric__trend">
         <% if trend_percentage > 0 %>+<% end %><%= trend_percentage %>%

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -1,6 +1,6 @@
 <%
   show_trend ||= false
-  show_total ||= false
+  short_context ||= false
   data_source = t("metrics.#{metric_name}.data_source")
   time_period = @performance_data.date_range.time_period
   options = {
@@ -18,8 +18,8 @@
     })
   end
 
-  if show_total
-    options.update({ total: t("metrics.#{metric_name}.total") })
+  if short_context
+    options.update({ short_context: short_context })
   end
 %>
 <div class="govuk-grid-row">

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -3,7 +3,7 @@
     metric_name: metric_name,
     value: total,
     show_trend: true,
-    show_total: true
+    short_context: short_context
   }%>
 </div>
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -105,21 +105,21 @@
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.performance" %></h2>
 
-      <%= render 'metric_section', metric_name: 'upviews', total: @performance_data.total_upviews %>
+      <%= render 'metric_section', metric_name: 'upviews', total: @performance_data.total_upviews, short_context: nil %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'pviews', total: @performance_data.total_pviews %>
+      <%= render 'metric_section', metric_name: 'pviews', total: @performance_data.total_pviews, short_context: nil %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'searches', total: @performance_data.total_searches %>
+      <%= render 'metric_section', metric_name: 'searches', total: @performance_data.total_searches, short_context: nil %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
 
-      <%= render 'metric_section', metric_name: 'satisfaction', total: @performance_data.total_satisfaction %>
+      <%= render 'metric_section', metric_name: 'satisfaction', total: @performance_data.total_satisfaction, short_context: @performance_data.satisfaction_short_context %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'feedex', total: @performance_data.total_feedex %>
+      <%= render 'metric_section', metric_name: 'feedex', total: @performance_data.total_feedex, short_context: nil %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
       <h2 class="govuk-heading-l"><%= t ".section_headings.content" %></h2>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -11,10 +11,9 @@ en:
       summary: 'Number of visits during which the page was viewed at least once'
       context: 'This page makes up %{percent_org_views}% of all views.'
       unit: ''
-      total: ''
       data_source: google_analytics
       about: >
-        This represents the number of visits in which the page was viewed at least once. 
+        This represents the number of visits in which the page was viewed at least once.
         For example, if a user visits the same page 5 times during their browsing session,
         it will show up as 1 unique pageview.
     pviews:
@@ -23,7 +22,6 @@ en:
       summary: 'Number of times the page was viewed'
       context: ''
       unit: ''
-      total: ''
       data_source: google_analytics
       about: >
         This is a count of every time the page was viewed. For example, if someone visits page X,
@@ -35,12 +33,11 @@ en:
       summary: 'Number of times per visit the page was viewed'
       context: ''
       unit: ''
-      total: ''
       data_source: calculated_google_analytics
       about: >
-        This figure is calculated by dividing Google Analytic pageviews by unique pageviews. It 
-        shows on average how many times a page was viewed during users' session. If a page has a 
-        high ratio (above 1.4), this indicates that users have to come back to that page within 
+        This figure is calculated by dividing Google Analytic pageviews by unique pageviews. It
+        shows on average how many times a page was viewed during users' session. If a page has a
+        high ratio (above 1.4), this indicates that users have to come back to that page within
         their session - investigate the navigation from that page further to identify any issues.
     searches:
       title: 'Searches from the page'
@@ -48,7 +45,6 @@ en:
       summary: 'Number of on-page searches'
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
-      total: ''
       data_source: none
       about: >
         This is the number of internal site search that were started from the page. When people
@@ -59,7 +55,7 @@ en:
       summary: 'Percentage of users who answered ''yes'' to the ''Is this page useful?'' survey'
       context: 'Users who found this page useful, out of %{total_responses} responses'
       unit: ''
-      total: '%{total_responses} responses'
+      short_context: '%{total_responses} responses'
       data_source: none
       about: >
         Percentage of users who answered 'Yes' rather than 'No' to the 'Is this page useful?' survey.
@@ -72,12 +68,11 @@ en:
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''
       context: ''
       unit: 'comments'
-      total: ''
       data_source: feedback_explorer
       about: >
         You can use Feedback Explorer ('Feedex') to find out what users are saying about your
         content. A high rate of feedback could indicate a problem with the content. The data comes
-        from the 'Is there anything wrong with this page?' form and the satisfaction survey at the 
+        from the 'Is there anything wrong with this page?' form and the satisfaction survey at the
         end of a transaction that started on GOV.UK.
 
         You'll need a Signon account with Feedback Explorer permissions to see the comments.
@@ -87,7 +82,6 @@ en:
       summary: 'Number of words on the page'
       context: ''
       unit: ''
-      total: ''
       data_source: none
       about: >
         Lots of words on a page can make content difficult for users to read online. The longer the
@@ -99,7 +93,6 @@ en:
       summary: 'Number of .pdf attachements on the page'
       context: ''
       unit: ''
-      total: ''
       data_source: none
       about: >
         Compared with HTML content, information published in a PDF is harder to find, use and 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.metric_summary.satisfaction', text: '90.000%'
       end
 
-      xit 'renders the total number of responses as context for satisfaction score' do
-        expect(page).to have_selector '.metric_summary.satisfaction', text: '200 responses'
+      it 'renders the total number of responses as context for satisfaction score' do
+        expect(page).to have_selector '.metric_summary.satisfaction', text: '700 responses'
       end
 
       it 'renders a metric for feedex' do


### PR DESCRIPTION
## Intro
Previous commits added the figure to the glance metrics. This commit uses the recent refactor to enable the the number to be output within the metric header section.

## New changes

Screenshots from a branch deploy on integration:

![screenshot at oct 16 12-03-09 pm](https://user-images.githubusercontent.com/424772/47012210-9cdffa00-d13b-11e8-83f1-0a6e87f1e3b2.png)
![screenshot at oct 16 12-02-25 pm](https://user-images.githubusercontent.com/424772/47012213-9d789080-d13b-11e8-9dcf-3f55c5a9d541.png)
