### PR TITLE
Allow organisation filtering to respect date range

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -13,6 +13,7 @@ private
   end
 
   def date_range
-    DateRange.new(params[:date_range])
+    time_period = params[:date_range].presence || 'last-30-days'
+    DateRange.new(time_period)
   end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -72,13 +72,33 @@ RSpec.describe '/content' do
   context 'filter by organisation' do
     before do
       content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
-    end
-
-    it 'makes request to api with correct organisation_id' do
       organisation_dropdown = find('.org-picker')
       organisation_dropdown.select('another org')
       click_on 'Filter'
+    end
+
+    it 'makes request to api with correct organisation_id' do
       expect(page).to have_content('Content data')
+    end
+
+    it 'links to the page data page after filtering' do
+      click_on 'The title'
+      expect(page).to have_content('Page data: Last month')
+    end
+
+    it 'respects date range' do
+      from = (Time.zone.today - 1.year).to_s('%F')
+      to = Time.zone.today.to_s('%F')
+      content_data_api_has_single_page(base_path: 'path/1', from: from, to: to)
+      content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
+
+      visit "/content?date_range=last-year&organisation_id=another-org-id"
+
+      organisation_dropdown = find('.org-picker')
+      organisation_dropdown.select('another org')
+      click_on 'Filter'
+      click_on 'The title'
+      expect(page).to have_content('Page data: Past year')
     end
   end
 end


### PR DESCRIPTION
### Why?
[Trello card](https://trello.com/c/nQxldbA2/661-1-index-page-filter-by-organisation)
Currently after filtering if the user clicks on a content item title the page will
not load due to an empty date range param. This bug was discovered after we added
the filter by organisation functionality.

### What?
This PR allows for empty date range params and persists any existing date range params
i.e if in the future we filter the index page to show data from the last 2 years then the page data
page will reflect this.