### PR TITLE
Update time select component to allow it to be embedded in another form.

### DIFF
--- a/app/views/components/_time-select.html.erb
+++ b/app/views/components/_time-select.html.erb
@@ -1,6 +1,7 @@
 <%
   base_path ||= false
   current_selection ||= false
+  render_button ||= false
   submit_button_text = t ".submit_button"
 
   if dates.length > 1
@@ -12,19 +13,20 @@
     selectable[:checked] = true
   end
 %>
-<% if base_path && dates.length > 1 && current_selection %>
+<% if dates.length > 1 && current_selection %>
   <div class="app-c-time-select">
     <h2 class="govuk-heading-l"><%= t '.title', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
     <%= render "govuk_publishing_components/components/details", {
       title: t('.change_dropdown')
     } do %>
-      <%= form_for('date', :url => "#{base_path}", :method => :get) do %>
+
         <%= render "govuk_publishing_components/components/radio", {
           name: "date_range",
           items: dates
         } %>
-        <%= render "govuk_publishing_components/components/button", {text: submit_button_text} %>
-      <% end %>
+        <% if render_button != false %>
+          <%= render "govuk_publishing_components/components/button", {text: submit_button_text} %>
+        <% end %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -41,42 +41,45 @@
   </div>
 </div>
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-<%= render "components/time-select", {
-  base_path: "/metrics#{@performance_data.base_path}",
-  current_selection: current_selection,
-  dates: [
-    {
-      value: "last-30-days",
-      text: t(".time_periods.last-30-days.leading"),
-      hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
-    },
-    {
-      value: "last-month",
-      text: t(".time_periods.last-month.leading"),
-      hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
-    },
-    {
-      value: "last-3-months",
-      text: t(".time_periods.last-3-months.leading"),
-      hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
-    },
-    {
-      value: "last-6-months",
-      text: t(".time_periods.last-6-months.leading"),
-      hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
-    },
-    {
-      value: "last-year",
-      text: t(".time_periods.last-year.leading"),
-      hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
-    },
-    {
-      value: "last-2-years",
-      text: t(".time_periods.last-2-years.leading"),
-      hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
-    }
-  ]
-} %>
+
+<%= form_for('date', :url => "/metrics#{@performance_data.base_path}", :method => :get) do %>
+  <%= render "components/time-select", {
+    render_button: true,
+    current_selection: current_selection,
+    dates: [
+      {
+        value: "last-30-days",
+        text: t(".time_periods.last-30-days.leading"),
+        hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+      },
+      {
+        value: "last-month",
+        text: t(".time_periods.last-month.leading"),
+        hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
+      },
+      {
+        value: "last-3-months",
+        text: t(".time_periods.last-3-months.leading"),
+        hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+      },
+      {
+        value: "last-6-months",
+        text: t(".time_periods.last-6-months.leading"),
+        hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+      },
+      {
+        value: "last-year",
+        text: t(".time_periods.last-year.leading"),
+        hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+      },
+      {
+        value: "last-2-years",
+        text: t(".time_periods.last-2-years.leading"),
+        hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+      }
+    ]
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <%= render "glance_metric",

--- a/spec/components/time_select_spec.rb
+++ b/spec/components/time_select_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Time Select", type: :view do
   let(:data) {
     {
-    base_path: "/metrics",
+    render_button: true,
     current_selection: 'last-30-days',
       dates: [
         {
@@ -37,11 +37,6 @@ RSpec.describe "Time Select", type: :view do
     assert_empty render_component(data)
   end
 
-  it "does not render when base_path is not supplied" do
-    data[:base_path] = false
-    assert_empty render_component(data)
-  end
-
   it "renders correctly when given valid data" do
     render_component(data)
     assert_select ".app-c-time-select", 1
@@ -52,10 +47,22 @@ RSpec.describe "Time Select", type: :view do
     assert_select "input[type=radio][value=last-30-days][checked=checked]"
   end
 
-  it "preselects the radio button based on the current_selection parameter" do
+  it "preselects the radio input based on the current_selection parameter" do
     data[:current_selection] = "last-3-months"
     render_component(data)
     assert_select "input[type=radio][value=last-3-months][checked=checked]"
+  end
+
+  it "ommits the submit button when render_button is false" do
+    data[:render_button] = false
+    render_component(data)
+    assert_select ".gem-c-button.govuk-button", 0
+  end
+
+  it "renders the submit button when render_button is true" do
+    data[:render_button] = true
+    render_component(data)
+    assert_select ".gem-c-button.govuk-button"
   end
 
   def render_component(locals)


### PR DESCRIPTION
https://trello.com/c/MC1QwkUL/738-3-index-page-update-date-select-component-so-it-becomes-part-of-another-form

We want to use this form section within the form on the index page, since it was a standalone form originally this wouldn't have been possible so in this PR we move the form tags into the view template leaving the component as a form partial. In the original view the component also rendered the submit button and because it is hidden in the reveal, I have had to preserve that ability. Since we don't want it on the index page, though, it is now parameterised. Visually there are no changes.

![screen shot 2018-10-16 at 14 13 08](https://user-images.githubusercontent.com/31649453/47018884-aeca9880-d14d-11e8-8bf7-a15dd8192a61.png)


