### PR TITLE
Add styling for mobile views, tweak desktop view to match design.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@ $govuk-global-styles: true;
 // gem components
 @import 'govuk_publishing_components/all_components';
 
+
 // local components
 @import "components/chart";
 @import "components/glance-metric";
@@ -10,3 +11,9 @@ $govuk-global-styles: true;
 @import "components/metadata";
 @import "components/time-select";
 @import "components/related-actions";
+
+// local views
+@import "metrics/show";
+
+//overrides must be imported last
+@import "govuk-frontend/overrides/all";

--- a/app/assets/stylesheets/components/_chart.scss
+++ b/app/assets/stylesheets/components/_chart.scss
@@ -1,6 +1,10 @@
 // Include our GOV.UK components
 @import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
 
+.gem-c-details {
+  margin-bottom: 0;
+}
+
 .app-c-chart__table {
   overflow: auto;
 
@@ -11,9 +15,11 @@
 
 .app-c-chart__table {
   max-height: 350px;
+  margin-top: govuk-spacing(3);
 
   @include media(mobile) {
     max-height: 250px;
+
   }
 }
 

--- a/app/assets/stylesheets/components/_glance-metric.scss
+++ b/app/assets/stylesheets/components/_glance-metric.scss
@@ -13,6 +13,8 @@
 .app-c-glance-metric__heading {
   @include govuk-responsive-margin(3, "top");
   @include govuk-responsive-margin(2, "bottom");
+  min-height: 2.6em;
+
 
   @include media-down(tablet) {
     min-height: 4em;
@@ -25,15 +27,27 @@
 
 .app-c-glance-metric__figure {
   @include govuk-font($size: 36, $weight: bold);
+
+  @include media-down(mobile) {
+    @include govuk-font($size: 48, $weight: bold);
+  }
 }
 
 .app-c-glance-metric__context {
   min-height: 5em;
   border-bottom: 1px solid $govuk-border-colour;
 
-  @include media(mobile) {
+  @include media-down(mobile) {
+    @include govuk-font(16);
     min-height: 0;
     border-bottom: 0;
+  }
+}
+
+.app-c-glance-metric__trend {
+
+  @include media-down(mobile) {
+    @include govuk-font(24);
   }
 }
 
@@ -43,4 +57,15 @@
 
 .app-c-glance-metric__trend-icon {
   color: $grey-1;
+
+  @include media-down(mobile) {
+    @include govuk-font(19);
+  }
+}
+
+.app-c-glance-metric__period {
+
+  @include media-down(mobile) {
+    @include govuk-font(16);
+  }
 }

--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -13,6 +13,10 @@
   @include govuk-visually-hidden;
 }
 
+.app-c-info-metric__context {
+  margin-bottom: 0;
+}
+
 .app-c-info-metric__trend-icon {
   color: $grey-1;
 }
@@ -22,10 +26,10 @@
 }
 
 .app-c-info-metric__about {
-  @include govuk-responsive-margin(2, "top");
+  @include govuk-responsive-margin(1, "top");
 }
 
-.app-c-info-metric__about {
+.app-c-info-metric {
 
   .govuk-details__summary-text {
     @include govuk-font(16);

--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,20 +1,36 @@
+.app-c-metadata__list {
+
+  @include media-down(mobile) {
+    @include govuk-clearfix;
+    margin-bottom: govuk-spacing(3);
+  }
+}
+
 .app-c-metadata__title {
   @include grid-column( 1 / 5);
   padding: 0;
   margin: 0;
 
   @include media-down(mobile) {
-    @include grid-column( 1 / 4, mobile );
+    @include grid-column( 1 / 3, mobile );
+    @include govuk-font(16);
     padding: 0;
     margin: 0;
+    margin-bottom: govuk-spacing(1);
   }
+}
+
+.app-c-metadata__title--wrappable {
+  height: 2.5em;
 }
 
 .app-c-metadata__description {
 
   @include media-down(mobile) {
-    @include grid-column( 3 / 4, mobile );
+    @include grid-column( 2 / 3, mobile );
+    @include govuk-font(16);
     padding: 0;
     margin: 0;
+    margin-bottom: govuk-spacing(1);
   }
 }

--- a/app/assets/stylesheets/components/_related-actions.scss
+++ b/app/assets/stylesheets/components/_related-actions.scss
@@ -1,12 +1,34 @@
 @import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
 
 .app-c-related-actions {
-  border-top: 1px solid $govuk-border-colour;
+  border-top: 2px solid $govuk-border-colour;
+  @include govuk-responsive-margin(3, "bottom");
+
+  @include media-down(mobile-down) {
+    border-bottom: 2px solid $govuk-border-colour;
+  }
+}
+
+.app-c-related-actions__header {
+
+  @include media-down(mobile) {
+    @include govuk-font(19);
+    @include govuk-clearfix;
+    @include govuk-responsive-margin(5, "top");
+  }
+
 }
 
 .app-c-related-actions__link {
-  margin-left: 0;
+  @include govuk-responsive-margin(0, "left");
   @include govuk-responsive-margin(3, "bottom");
+
+  @include media-down(mobile) {
+    @include govuk-font(19);
+    @include govuk-responsive-margin(1, "top");
+
+  }
+
 }
 
 .app-c-related-actions__accessibility-message {

--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -1,1 +1,5 @@
-// All required styles are inherited
+.app-c-time-select {
+  @include govuk-responsive-padding(3, "top");
+  @include govuk-responsive-padding(3, "bottom");
+  border-top: 2px solid $govuk-border-colour;
+}

--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -1,0 +1,40 @@
+.section-performance {
+
+  @include media-down(mobile) {
+    border-top: 2px solid $govuk-border-colour;
+  }
+}
+
+.section-performance__header {
+  @include govuk-font($size: 36, $weight: bold);
+  margin: 0;
+
+  @include media-down(mobile) {
+    @include govuk-responsive-margin(3, "top");
+  }
+}
+
+.section-content {
+  padding: 0;
+}
+
+.section-content__header {
+  @include govuk-font($size: 36, $weight: bold);
+  margin: 0;
+}
+
+.govuk-section-break--visible {
+  border-width: 2px;
+}
+
+.metric-summary__words {
+  padding: 0 !important;
+
+  @include media-down(mobile) {
+    border-bottom: 2px solid $govuk-border-colour;
+  }
+}
+
+.metric-summary__pdf-count {
+  padding: 0 !important;
+}

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -12,7 +12,7 @@
     chartArea:{width:'90%',height:'80%'},
     curveType: 'none',
     tooltip: {textStyle: {color: '#000'}, showColorCode: true},
-    hAxis: {showTextEvery: 3, textStyle: {color: '#000', fontName: 'nta', fontSize: '12'}},
+    hAxis: { textStyle: {color: '#000', fontName: 'nta', fontSize: '12'}},
     vAxis: {format:'#,###,###.###', textStyle: {color: '#000', fontName: 'nta', fontSize: '12'}},
     pointSize: 0,
     series: {

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -9,7 +9,7 @@
 %>
 <% if name && figure && period %>
   <div class="app-c-glance-metric govuk-body">
-    <h3 class="app-c-glance-metric__heading govuk-heading-s"><%= name %></h3>
+    <h3 class="app-c-glance-metric__heading"><%= name %></h3>
     <span class="app-c-glance-metric__figure"><%= figure %><span class="app-c-glance-metric__measurement" <% if measurement_explicit_label %>aria-label="<%= measurement_explicit_label %>"<% end %>><%= measurement_display_label %></span></span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -11,6 +11,18 @@
   <div class="app-c-info-metric govuk-body">
     <h3 class="app-c-info-metric__heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
+    <% if about %>
+      <div class="app-c-info-metric__about govuk-body-s">
+        <%= render "govuk_publishing_components/components/details", {
+          title: t(".about_dropdown")
+        } do %>
+          <p class="govuk-body govuk-body-s"><%= about %></p>
+          <% if data_source %>
+            <p><%=t("components.info-metric.data_source", source: data_source)%></p>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
     <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
     <% if short_context %>
       <span class="app-c-info-metric__short-context">
@@ -40,18 +52,6 @@
     <% end %>
     <% if period %>
       <span class="app-c-info-metric__period"><%= period %></span>
-    <% end %>
-    <% if about %>
-      <div class="app-c-info-metric__about govuk-body-s">
-        <%= render "govuk_publishing_components/components/details", {
-          title: t(".about_dropdown")
-        } do %>
-          <p><%= about %></p>
-          <% if data_source %>
-            <p><%=t("components.info-metric.data_source", source: data_source)%></p>
-          <% end %>
-        <% end %>
-      </div>
     <% end %>
   </div>
 <% end %>

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -25,7 +25,7 @@
     <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>
     <dt class="app-c-metadata__title"><%= t ".labels.document_type" %></dt>
     <dd class="app-c-metadata__description"><%= document_type %></dd>
-    <dt class="app-c-metadata__title"><%= t ".labels.base_path" %></dt>
-    <dd class="app-c-metadata__description"><% if base_path != "" %>/.../<%= base_path.split("/")[-1] %><% end %></dd>
+    <dt class="app-c-metadata__title app-c-metadata__title--wrappable"><%= t ".labels.base_path" %></dt>
+    <dd class="app-c-metadata__description"><% if base_path != "" %>gov.uk<%= base_path %><% end %></dd>
   </dl>
 </div>

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -22,8 +22,5 @@
     options.update({ short_context: short_context })
   end
 %>
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <%= render "components/info-metric", options %>
-  </div>
-</div>
+<%= render "components/info-metric", options %>
+

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -1,4 +1,4 @@
-<div class="metric_summary <%= metric_name %>">
+<div class="metric-summary__<%= metric_name %>">
   <%= render 'metric_header', {
     metric_name: metric_name,
     value: total,
@@ -8,4 +8,4 @@
 </div>
 
 <%= render 'chart', series: @performance_data.get_chart(metric_name) %>
-<a href="" class="govuk-link"><%= t ".download_link", metric_name: t("metrics.#{metric_name}.title") %></a>
+<a href="" class="govuk-link govuk-body-s"><%= t ".download_link", metric_name: t("metrics.#{metric_name}.title") %></a>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -40,7 +40,8 @@
       } %>
   </div>
 </div>
-<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+
 
 <%= form_for('date', :url => "/metrics#{@performance_data.base_path}", :method => :get) do %>
   <%= render "components/time-select", {
@@ -104,40 +105,37 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <div class="govuk-grid-column-full section-performance">
+    <h2 class="section-performance__header"><%= t ".section_headings.performance" %></h2>
 
-      <h2 class="govuk-heading-l"><%= t ".section_headings.performance" %></h2>
+    <%= render 'metric_section', metric_name: 'upviews', total: @performance_data.total_upviews, short_context: nil %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'upviews', total: @performance_data.total_upviews, short_context: nil %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <%= render 'metric_section', metric_name: 'pviews', total: @performance_data.total_pviews, short_context: nil %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'pviews', total: @performance_data.total_pviews, short_context: nil %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <%= render 'metric_section', metric_name: 'searches', total: @performance_data.total_searches, short_context: nil %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <%= render 'metric_section', metric_name: 'searches', total: @performance_data.total_searches, short_context: nil %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <%= render 'metric_section', metric_name: 'satisfaction', total: @performance_data.total_satisfaction, short_context: @performance_data.satisfaction_short_context %>
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
+    <h2 class="govuk-heading-l"><%= t ".section_headings.content" %></h2>
 
-      <%= render 'metric_section', metric_name: 'satisfaction', total: @performance_data.total_satisfaction, short_context: @performance_data.satisfaction_short_context %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+    <%= render 'metric_section', metric_name: 'feedex', total: @performance_data.total_feedex, short_context: nil %>
+  </div>
+</div>
 
-      <%= render 'metric_section', metric_name: 'feedex', total: @performance_data.total_feedex, short_context: nil %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-      <h2 class="govuk-heading-l"><%= t ".section_headings.content" %></h2>
-
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full section-content">
+    <h2 class="section-content__header"><%= t ".section_headings.content" %></h2>
+    <div class="govuk-grid-column-one-half metric-summary metric-summary__words">
+      <%= render 'metric_header', metric_name: 'words', value: @performance_data.total_words, show_trend: false %>
     </div>
-
-    <div class="govuk-grid-column-one-half">
-      <div class="metric_summary words">
-        <%= render 'metric_header', metric_name: 'words', value: @performance_data.total_words, show_trend: false %>
-      </div>
+    <div class="govuk-grid-column-one-half metric-summary metric-summary__pdf-count">
+      <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.total_pdf_count, show_trend: false %>
     </div>
-
-    <div class="govuk-grid-column-one-half">
-      <div class="metric_summary pdf_count">
-        <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.total_pdf_count, show_trend: false %>
-      </div>
-    </div>
+  </div>
 </div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "content-data-admin",
-  "private": true,
-  "dependencies": {}
-}

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Metadata", type: :view do
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.document_type")
     assert_select ".app-c-metadata__description", text: "Guidance"
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.base_path")
-    assert_select ".app-c-metadata__description", text: "/.../visitor-visa-guide-to-supporting-documents"
+    assert_select ".app-c-metadata__description", text: "gov.uk/government/publications/visitor-visa-guide-to-supporting-documents"
   end
 
   it "renders blank values for expected fields when data items aren't provided" do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
                                   I18n.t("components.metadata.labels.last_updated"), '17 July 2018'],
                                  [I18n.t("components.metadata.labels.publishing_organisation"), 'The Ministry',
                                   I18n.t("components.metadata.labels.document_type"), 'News story',
-                                  I18n.t("components.metadata.labels.base_path"), '/.../path']
+                                  I18n.t("components.metadata.labels.base_path"), 'gov.uk/base/path']
                                ])
       end
     end
@@ -62,31 +62,31 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     describe 'page metric section' do
       it 'renders the metric for upviews' do
-        expect(page).to have_selector '.metric_summary.upviews', text: '33'
+        expect(page).to have_selector '.metric-summary__upviews', text: '33'
       end
 
       it 'renders the metric for pviews' do
-        expect(page).to have_selector '.metric_summary.pviews', text: '60'
+        expect(page).to have_selector '.metric-summary__pviews', text: '60'
       end
 
       it 'renders a metric for satisfaction' do
-        expect(page).to have_selector '.metric_summary.satisfaction', text: '90.000%'
+        expect(page).to have_selector '.metric-summary__satisfaction', text: '90.000%'
       end
 
       it 'renders the total number of responses as context for satisfaction score' do
-        expect(page).to have_selector '.metric_summary.satisfaction', text: '700 responses'
+        expect(page).to have_selector '.metric-summary__satisfaction .app-c-info-metric__short-context', text: '700 responses'
       end
 
       it 'renders a metric for feedex' do
-        expect(page).to have_selector '.metric_summary.feedex', text: '63'
+        expect(page).to have_selector '.metric-summary__feedex', text: '63'
       end
 
       it 'renders a metric for pdf_count' do
-        expect(page).to have_selector '.metric_summary.pdf_count', text: '3'
+        expect(page).to have_selector '.metric-summary__pdf-count', text: '3'
       end
 
       it 'renders a metric for words' do
-        expect(page).to have_selector '.metric_summary.words', text: '200'
+        expect(page).to have_selector '.metric-summary__words', text: '200'
       end
 
       it 'renders the page title' do
@@ -94,7 +94,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders a metric for on page searches' do
-        expect(page).to have_selector '.metric_summary.searches', text: '24'
+        expect(page).to have_selector '.metric-summary__searches', text: '24'
       end
 
       it 'renders a page searches metric as a percentage of views' do


### PR DESCRIPTION
https://trello.com/c/csZsWZNy/736-3-page-data-make-layout-work-at-mobile-and-tablet-breakpoints

Matching styles against designs for desktop and mobile:

https://drive.google.com/open?id=194icCuUprUsYYtakbUHGZbDQySoLnCSe
https://drive.google.com/open?id=1IHYvkjQm_ZAU9Er-cIdAapNLZ7qEDOns

Some changes to CSS classes, building on top of recent changes in the gem.