### PR TITLE
Add phase banner and update app name

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,12 +18,22 @@
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: Rails.application.config.govuk_environment,
+    product_name: "Content data",
     navigation_items: [
       { text: 'your name here', href: '/link/to/signon' },
       { text: "Log out", href: gds_sign_out_path }
     ]
   }%>
   <div class="govuk-width-container">
+
+    <% banner_message = capture do %>
+      This is a new service - your <a href="">feedback</a> will help us to improve it.
+    <% end %>
+    <%= render "govuk_publishing_components/components/phase_banner", {
+      phase: "beta",
+      message: banner_message
+    } %>
+
     <% if yield(:back_link).present? %>
       <%= render "govuk_publishing_components/components/back_link", href: yield(:back_link) %>
     <% end %>


### PR DESCRIPTION
https://trello.com/c/8DZgZKZn/739-3-add-banner-beta-state-feedback-app-name

Adds the phase (beta) banner, and updates the name in the main banner. Link location is yet to be decided so is currently blank.

![screen shot 2018-10-18 at 11 23 48](https://user-images.githubusercontent.com/31649453/47148441-a21e7f80-d2c8-11e8-8232-417a291520a6.png)
