### PR TITLE
Use rails polling file checker

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,5 +49,9 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  # This not used as evented file updates are not supported via VM
+  # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Using polling file checker, requires VM time to be in sync with host
+  config.file_watcher = ActiveSupport::FileUpdateChecker
 end


### PR DESCRIPTION
Changed file checker to use polling rather than system events to allow automatic code reload within the development environment in the VM. This is due to system events not being passed to the VM.