### PR TITLE
Allow filtering by document type

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -3,6 +3,7 @@ class ContentController < ApplicationController
     get_content
     organisations = FetchOrganisations.call
     @organisations = organisations[:organisations]
+    @document_types = FetchDocumentTypes.call[:document_types]
   end
 
 private
@@ -10,7 +11,8 @@ private
   def get_content
     response = FindContent.call(params)
     @content = ContentItemsPresenter.new(response[:results], date_range)
-    @organisation_id = response[:organisation_id]
+    @organisation_id = params[:organisation_id]
+    @document_type = params[:document_type]
   end
 
   def date_range

--- a/app/services/fetch_document_types.rb
+++ b/app/services/fetch_document_types.rb
@@ -1,0 +1,10 @@
+class FetchDocumentTypes
+  include MetricsCommon
+  def self.call
+    new.call
+  end
+
+  def call
+    api.document_types
+  end
+end

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -10,9 +10,10 @@ class FindContent
     @from = range.from
     @to = range.to
     @organisation = params[:organisation_id]
+    @document_type = params[:document_type]
   end
 
   def call
-    api.content(from: @from, to: @to, organisation_id: @organisation)
+    api.content(from: @from, to: @to, organisation_id: @organisation, document_type: @document_type)
   end
 end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -2,6 +2,11 @@
   <%= select_tag 'organisation_id', options_for_select(@organisations.map{ |org| [org[:title], org[:organisation_id]] },
                                                        selected: @organisation_id),
                                                        class: 'org-picker' %>
+    <%= select_tag 'document_type', options_for_select(@document_types.map{ |dt| [dt.try(:tr, '_', ' ').try(:capitalize), dt] },
+                                                       selected: @document_type || '',
+                                                      ),
+                                                      include_blank: 'All document types',
+                                                      class: 'doc-type-picker' %>
   <%= hidden_field_tag 'date_range', @content.date_range.time_period %>
   <%= submit_tag "Filter" %>
 <% end %>

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -17,8 +17,8 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
-  def content(from:, to:, organisation_id:)
-    url = content_items_url(from, to, organisation_id)
+  def content(from:, to:, organisation_id:, document_type: nil)
+    url = content_items_url(from, to, organisation_id, document_type)
     get_json(url).to_hash.deep_symbolize_keys
   end
 
@@ -29,6 +29,10 @@ class GdsApi::ContentDataApi < GdsApi::Base
 
   def organisations
     get_json(organisations_url).to_hash.deep_symbolize_keys
+  end
+
+  def document_types
+    get_json(document_types_url).to_hash.deep_symbolize_keys
   end
 
 private
@@ -45,8 +49,14 @@ private
     "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
-  def content_items_url(from, to, organisation_id)
-    "#{content_data_api_endpoint}/content#{query_string(from: from, to: to, organisation_id: organisation_id)}"
+  def content_items_url(from, to, organisation_id, document_type)
+    params = {
+      from: from,
+      to: to,
+      organisation_id: organisation_id,
+      document_type: document_type
+ }.reject { |_, v| v.blank? }
+    "#{content_data_api_endpoint}/content#{query_string(params)}"
   end
 
   def single_page_url(base_path, from, to)
@@ -55,5 +65,9 @@ private
 
   def organisations_url
     "#{content_data_api_endpoint}/organisations"
+  end
+
+  def document_types_url
+    "#{content_data_api_endpoint}/document_types"
   end
 end

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -54,8 +54,10 @@ private
       from: from,
       to: to,
       organisation_id: organisation_id,
-      document_type: document_type
- }.reject { |_, v| v.blank? }
+      document_type: document_type,
+    }
+    params.reject! { |_, v| v.blank? }
+
     "#{content_data_api_endpoint}/content#{query_string(params)}"
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -121,11 +121,8 @@ RSpec.describe '/content' do
     it 'renders the filtered results' do
       table_rows = extract_table_content('.content-table table')
 
-      _header = table_rows.first
-      row = table_rows.second
-
-      expect(table_rows.count).to eq(2)
-      expect(row[1]).to eq('News story')
+      _header = table_rows.shift
+      expect(table_rows).to all(include('News story'))
     end
 
     it 'Allows the filter to be cleared' do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -114,10 +114,6 @@ RSpec.describe '/content' do
       click_on 'Filter'
     end
 
-    it 'makes request to api with correct document_type' do
-      expect(page).to have_content('Content data')
-    end
-
     it 'selects the document_type in the dropdown menu' do
       expect(page).to have_select('document_type', selected: 'News story')
     end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe '/content' do
   before do
     stub_metrics_page(base_path: 'path/1', time_period: :last_month)
     content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
-    content_data_has_orgs
     GDS::SSO.test_user = build(:user)
+    content_data_api_has_orgs
+    content_data_api_has_document_types
+
     visit "/content?date_range=last-month&organisation_id=org-id"
   end
 
@@ -87,7 +89,7 @@ RSpec.describe '/content' do
     end
 
     it 'selected organisation is shown in dropdown menu' do
-      expect(page).to have_select('organisation_id', text: 'another org')
+      expect(page).to have_select('organisation_id', selected: 'another org')
     end
 
     it 'respects date range' do
@@ -102,6 +104,40 @@ RSpec.describe '/content' do
       click_on 'Filter'
       click_on 'The title'
       expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.last-year.leading')}")
+    end
+  end
+
+  context 'filter by document_type' do
+    before do
+      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', document_type: 'news_story', items: [items.first])
+      select 'News story', from: 'document_type'
+      click_on 'Filter'
+    end
+
+    it 'makes request to api with correct document_type' do
+      expect(page).to have_content('Content data')
+    end
+
+    it 'selects the document_type in the dropdown menu' do
+      expect(page).to have_select('document_type', selected: 'News story')
+    end
+
+    it 'renders the filtered results' do
+      table_rows = extract_table_content('.content-table table')
+
+      _header = table_rows.first
+      row = table_rows.second
+
+      expect(table_rows.count).to eq(2)
+      expect(row[1]).to eq('News story')
+    end
+
+    it 'Allows the filter to be cleared' do
+      select 'All document types', from: 'document_type'
+      click_on 'Filter'
+      expect(page).to have_select('document_type', selected: nil)
+      table_rows = extract_table_content('.content-table table')
+      expect(table_rows.count).to eq(3)
     end
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -34,8 +34,14 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation_id:, items:)
-        query = query(from: from, to: to, organisation_id: organisation_id)
+      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, items:)
+        params = {
+          from: from,
+          to: to,
+          organisation_id: organisation_id,
+          document_type: document_type
+        }.reject { |_, v| v.blank? }
+        query = query(params)
         url = "#{content_data_api_endpoint}/content#{query}"
         body = { results: items }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
@@ -55,9 +61,15 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
-      def content_data_has_orgs
+      def content_data_api_has_orgs
         url = "#{content_data_api_endpoint}/organisations"
         body = { organisations: default_organisations }.to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
+      def content_data_api_has_document_types
+        url = "#{content_data_api_endpoint}/document_types"
+        body = { document_types: default_document_types }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
@@ -296,6 +308,10 @@ module GdsApi
             organisation_id: 'another-org-id'
           }
         ]
+      end
+
+      def default_document_types
+        %w[case_study guide news_story]
       end
     end
   end


### PR DESCRIPTION
This commit allows filtering by document_type:
It is dependant on [This PR in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/964)

<img width="1036" alt="screen shot 2018-10-19 at 16 34 55" src="https://user-images.githubusercontent.com/511319/47228375-f1de7300-d3bc-11e8-80af-08732498aa12.png">

Url to test : http://content-data-admin.dev.gov.uk/content?utf8=%E2%9C%93&organisation_id=b8a6a8f2-d04f-4346-90c1-d28898565866&document_type=corporate_report&date_range=last-30-days&commit=Filter