### PR TITLE
Feedback explorer link

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -65,6 +65,19 @@ class SingleContentItemPresenter
     I18n.t("metrics.feedex.context")
   end
 
+  def feedback_explorer_href
+    host = Plek.new.external_url_for('support')
+    template = Addressable::Template.new(
+      "#{host}/anonymous_feedback{?from,to,paths}"
+    )
+    query = {
+      paths: base_path,
+      from: @date_range.from,
+      to: @date_range.to
+    }
+    template.expand(query).to_s
+  end
+
   def period
     I18n.t("metrics.show.time_periods.#{@date_range.time_period}.reference")
   end

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -8,7 +8,14 @@
 </div>
 
 <%= render 'chart', series: @performance_data.get_chart(metric_name) %>
-<a href="" class="govuk-link govuk-body-s"><%= t ".download_link", metric_name: t("metrics.#{metric_name}.title") %></a>
-<% if external_link %>
-  <a href="<%= external_link %>" class="govuk-link govuk-body-s"><%= t "metrics.#{metric_name}.external_link" %></a>
-<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <a href="" class="govuk-link govuk-body-s"><%= t ".download_link", metric_name: t("metrics.#{metric_name}.title") %></a>
+  </div>
+  <div class="govuk-grid-column-one-half">
+    <% if external_link %>
+      <a href="<%= external_link %>" class="govuk-link govuk-body-s"><%= t "metrics.#{metric_name}.external_link" %></a>
+    <% end %>
+  </div>
+</div>

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -9,3 +9,6 @@
 
 <%= render 'chart', series: @performance_data.get_chart(metric_name) %>
 <a href="" class="govuk-link govuk-body-s"><%= t ".download_link", metric_name: t("metrics.#{metric_name}.title") %></a>
+<% if external_link %>
+  <a href="<%= external_link %>" class="govuk-link govuk-body-s"><%= t "metrics.#{metric_name}.external_link" %></a>
+<% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -108,21 +108,45 @@
   <div class="govuk-grid-column-full section-performance">
     <h2 class="section-performance__header"><%= t ".section_headings.performance" %></h2>
 
-    <%= render 'metric_section', metric_name: 'upviews', total: @performance_data.total_upviews, short_context: nil %>
+    <%= render 'metric_section', 
+        metric_name: 'upviews', 
+        total: @performance_data.total_upviews, 
+        short_context: nil,
+        external_link: nil %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', metric_name: 'pviews', total: @performance_data.total_pviews, short_context: nil %>
+    <%= render 'metric_section', 
+        metric_name: 'pviews', 
+        total: @performance_data.total_pviews, 
+        short_context: nil,
+        external_link: nil %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', metric_name: 'searches', total: @performance_data.total_searches, short_context: nil %>
+    <%= render 'metric_section', 
+        metric_name: 'searches', 
+        total: @performance_data.total_searches, 
+        short_context: nil,
+        external_link: nil %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
 
-    <%= render 'metric_section', metric_name: 'feedex', total: @performance_data.total_feedex, short_context: nil %>
+    <%= render 'metric_section', 
+        metric_name: 'feedex', 
+        total: @performance_data.total_feedex, 
+        short_context: nil ,
+        external_link: @performance_data.feedback_explorer_href %>
+
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', metric_name: 'satisfaction', total: @performance_data.total_satisfaction, short_context: @performance_data.satisfaction_short_context %>
+    <%= render 'metric_section', 
+        metric_name: 'satisfaction', 
+        total: @performance_data.total_satisfaction, 
+        short_context: @performance_data.satisfaction_short_context,
+        external_link: nil %>
   </div>
 </div>
 

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -12,6 +12,7 @@ en:
       context: 'This page makes up %{percent_org_views}% of all views.'
       unit: ''
       data_source: google_analytics
+      external_link: ''
       about: >
         This represents the number of visits in which the page was viewed at least once.
         For example, if a user visits the same page 5 times during their browsing session,
@@ -23,6 +24,7 @@ en:
       context: ''
       unit: ''
       data_source: google_analytics
+      external_link: ''
       about: >
         This is a count of every time the page was viewed. For example, if someone visits page X,
         then goes to page Y and then page X again, the page X will show having 2 pageviews (and
@@ -34,6 +36,7 @@ en:
       context: ''
       unit: ''
       data_source: calculated_google_analytics
+      external_link: ''
       about: >
         This figure is calculated by dividing Google Analytic pageviews by unique pageviews. It
         shows on average how many times a page was viewed during users' session. If a page has a
@@ -46,6 +49,7 @@ en:
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       data_source: none
+      external_link: ''
       about: >
         This is the number of internal site search that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.
@@ -57,6 +61,7 @@ en:
       unit: ''
       short_context: '%{total_responses} responses'
       data_source: none
+      external_link: ''
       about: >
         Percentage of users who answered 'Yes' rather than 'No' to the 'Is this page useful?' survey.
         The more users who responded, the more reliable the score is. For a more reliable score
@@ -69,6 +74,7 @@ en:
       context: ''
       unit: 'comments'
       data_source: feedback_explorer
+      external_link: 'See comments in Feedback Explorer'
       about: >
         You can use Feedback Explorer ('Feedex') to find out what users are saying about your
         content. A high rate of feedback could indicate a problem with the content. The data comes
@@ -83,6 +89,7 @@ en:
       context: ''
       unit: ''
       data_source: none
+      external_link: ''
       about: >
         Lots of words on a page can make content difficult for users to read online. The longer the
         page is, the less usable it is likely to be. You could investigate whether this content could
@@ -94,6 +101,7 @@ en:
       context: ''
       unit: ''
       data_source: none
+      external_link: ''
       about: >
         Compared with HTML content, information published in a PDF is harder to find, use and 
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
   end
 
+  around do |example|
+    Timecop.freeze Date.new(2018, 12, 25) do
+      example.run
+    end
+  end
+
   context 'successful request' do
     before do
       stub_metrics_page(base_path: 'base/path', time_period: :last_30_days)
@@ -100,6 +106,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
       it 'renders a metric for feedex' do
         expect(page).to have_selector '.metric-summary__feedex', text: '63'
+      end
+
+      it 'renders link to feedback explorer' do
+        expect(page).to have_selector('.govuk-link', text: I18n.t("metrics.feedex.external_link"))
       end
 
       it 'renders a metric for pdf_count' do

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe SingleContentItemPresenter do
   let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-25') }
 
 
+  around do |example|
+    Timecop.freeze Date.new(2018, 6, 1) do
+      example.run
+    end
+  end
+
   subject do
     SingleContentItemPresenter.new(current_period_data, previous_period_data, date_range)
   end
@@ -63,6 +69,14 @@ RSpec.describe SingleContentItemPresenter do
 
     it 'returns the title' do
       expect(subject.title).to eq('Content Title')
+    end
+  end
+
+  describe '#feedback_explorer_href' do
+    it 'returns a URI for the feedback explorer' do
+      host = Plek.new.external_url_for('support')
+      expected_link = "#{host}/anonymous_feedback?from=2018-05-02&to=2018-06-01&paths=%2Fthe%2Fbase%2Fpath"
+      expect(subject.feedback_explorer_href).to eq(expected_link)
     end
   end
 end


### PR DESCRIPTION
Adding a link to the feedback explorer in the feedback comments section. 
![image](https://user-images.githubusercontent.com/11051676/47288836-c8595d80-d5ef-11e8-8b8c-0e73f91dffe7.png)

Note: the spacing is wider than the design due to complexity issues of custom spacing. This was agreed as and should be revisted in a future PR.