### PR TITLE
Rename table reveal

### DIFF
--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -1,7 +1,7 @@
 en:
   components:
     chart:
-      table_dropdown: 'View %{metric_name} table'
+      table_dropdown: '%{metric_name} table'
     metadata:
       labels:
         status: 'Status'


### PR DESCRIPTION
Removed 'View' from the beginning of the table reveal description to reflect the design.