### PR TITLE
Fix search rate bug

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -146,11 +146,11 @@ private
   end
 
   def on_page_search_rate
-    metric_value = self.total_searches
-    secondary_metric_value = self.total_pviews
+    metric_value_as_float = self.total_searches.delete(',').to_f
+    secondary_metric_value_as_float = self.total_pviews.delete(',').to_f
 
-    return 0 if metric_value.to_i.zero? || secondary_metric_value.to_i.zero?
-    search_rate = (metric_value.to_f / secondary_metric_value.to_f) * 100
+    return 0 if metric_value_as_float.zero? || secondary_metric_value_as_float.zero?
+    search_rate = (metric_value_as_float / secondary_metric_value_as_float) * 100
     search_rate.round(2)
   end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders trend percentage for page searches' do
-        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '-50.00%'
+        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '400.00%'
       end
 
       it 'renders glance metric for feedex comments' do
@@ -83,6 +83,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
       it 'renders trend percentage for feedex comments' do
         expect(page).to have_selector '.feedex .app-c-glance-metric__trend', text: '+5.00%'
+      end
+
+      it 'renders context for page searches' do
+        expect(page).to have_selector '.searches .app-c-glance-metric__context', text: '0.4%'
       end
     end
 
@@ -145,7 +149,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         pviews_rows = extract_table_content(".chart.pviews table")
         expect(pviews_rows).to match_array([
           expected_table_dates,
-          %w[Pageviews 10 20 30]
+          %w[Pageviews 10000 20000 30000]
         ])
       end
 
@@ -153,7 +157,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         internal_searches_rows = extract_table_content(".chart.searches table")
         expect(internal_searches_rows).to match_array([
           expected_table_dates,
-          ["Searches from the page", "8", "8", "8"]
+          ["Searches from the page", "80", "80", "80"]
         ])
       end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -111,20 +111,20 @@ module GdsApi
             },
             {
               name: "pviews",
-              total: 60,
+              total: 60000,
               time_series: [
-                { "date" => day1, "value" => 10 },
-                { "date" => day2, "value" => 20 },
-                { "date" => day3, "value" => 30 }
+                { "date" => day1, "value" => 10000 },
+                { "date" => day2, "value" => 20000 },
+                { "date" => day3, "value" => 30000 }
               ]
             },
             {
               name: "searches",
-              total: 24,
+              total: 240,
               time_series: [
-                { "date" => day1, "value" => 8 },
-                { "date" => day2, "value" => 8 },
-                { "date" => day3, "value" => 8 }
+                { "date" => day1, "value" => 80 },
+                { "date" => day2, "value" => 80 },
+                { "date" => day3, "value" => 80 }
               ]
             },
             {


### PR DESCRIPTION
### What?

[Trello card](https://trello.com/c/TdGevWTq/764-1-page-data-fix-of-users-searched-the-page-in-the-at-a-glance-metrics)

This PR is to fix a bug (see trello card) which has crept into the code base resulting in `search_rate` for a content item being calculated incorrectly.

Search rates were being calculated incorrectly due to our use of the method
`number_with_delimiter` which, for example, returns '10,000' when passed 10000.

Calling `to_f` on '10,000' returns 10 and this is the cause of our current incorrect
calculation for search_rate on some pages.

### How?

This is solved by formatting the `total_searches` and `total_pviews` into
a float before using them to calculate `on_page_search_rate`.

This PR adds a test for this functionality and makes changes to default data in order
to test that this bug is not longer a problem.