### PR TITLE
Add metric name in about metric label

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -86,6 +86,11 @@ class SingleContentItemPresenter
     I18n.t("metrics.#{metric_name}.short_title")
   end
 
+  def metric_about_label(metric_name)
+    short_title = metric_short_title(metric_name).downcase
+    I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
+  end
+
   def trend_percentage(metric_name)
     current_value = @metrics[metric_name][:value]
     previous_value = @previous_metrics[metric_name][:value]

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -6,6 +6,7 @@
   trend_percentage ||= false
   context ||= false
   short_context ||= false
+  about_label ||= "About this data"
 %>
 <% if name && figure && context %>
   <div class="app-c-info-metric govuk-body">
@@ -14,7 +15,7 @@
     <% if about %>
       <div class="app-c-info-metric__about govuk-body-s">
         <%= render "govuk_publishing_components/components/details", {
-          title: t(".about_dropdown")
+          title: about_label
         } do %>
           <p class="govuk-body govuk-body-s"><%= raw about %></p>
           <% if data_source %>

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -8,7 +8,8 @@
     figure: number_with_delimiter(value, delimiter: ','),
     context: t("metrics.#{metric_name}.summary"),
     data_source: t("data_sources.#{data_source}"),
-    about: t("metrics.#{metric_name}.about")
+    about: t("metrics.#{metric_name}.about"),
+    about_label: t("components.info-metric.about_dropdown")
   }
 
   if show_trend

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -9,7 +9,7 @@
     context: t("metrics.#{metric_name}.summary"),
     data_source: t("data_sources.#{data_source}"),
     about: t("metrics.#{metric_name}.about"),
-    about_label: t("components.info-metric.about_dropdown")
+    about_label: @performance_data.metric_about_label(metric_name)
   }
 
   if show_trend

--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -15,6 +15,6 @@ en:
       change_dropdown: 'Change time period'
       submit_button: 'Change dates'
     info-metric:
-      about_dropdown: 'About this data'
+      about_dropdown: "About %{metric_short_title}"
       data_source: 'Source: %{source}'
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -93,12 +93,27 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.metric-summary__upviews', text: '33'
       end
 
+      it 'renders about label for upviews' do
+        label = expected_metric_label('upviews')
+        expect(page).to have_selector(".metric-summary__upviews .govuk-details__summary-text", text: label)
+      end
+
       it 'renders the metric for pviews' do
         expect(page).to have_selector '.metric-summary__pviews', text: '60'
       end
 
+      it 'renders about label for pviews' do
+        label = expected_metric_label('pviews')
+        expect(page).to have_selector(".metric-summary__pviews .govuk-details__summary-text", text: label)
+      end
+
       it 'renders a metric for satisfaction' do
         expect(page).to have_selector '.metric-summary__satisfaction', text: '90%'
+      end
+
+      it 'renders about label for satisfaction' do
+        label = expected_metric_label('satisfaction')
+        expect(page).to have_selector(".metric-summary__satisfaction .govuk-details__summary-text", text: label)
       end
 
       it 'renders the total number of responses as context for satisfaction score' do
@@ -109,6 +124,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.metric-summary__feedex', text: '63'
       end
 
+      it 'renders about label for feedex' do
+        label = expected_metric_label('feedex')
+        expect(page).to have_selector(".metric-summary__feedex .govuk-details__summary-text", text: label)
+      end
+
       it 'renders link to feedback explorer' do
         expect(page).to have_selector('.govuk-link', text: I18n.t("metrics.feedex.external_link"))
       end
@@ -117,8 +137,18 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.metric-summary__pdf-count', text: '3'
       end
 
-      it 'renders a metric for words' do
+      it 'renders about label for pdf count' do
+        label = expected_metric_label('pdf_count')
+        expect(page).to have_selector(".metric-summary__pdf-count .govuk-details__summary-text", text: label)
+      end
+
+      it 'renders a metric for words count' do
         expect(page).to have_selector '.metric-summary__words', text: '200'
+      end
+
+      it 'renders about label for  words count' do
+        label = expected_metric_label('words')
+        expect(page).to have_selector(".metric-summary__words .govuk-details__summary-text", text: label)
       end
 
       it 'renders the page title' do
@@ -206,4 +236,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
     end
   end
+end
+
+def expected_metric_label(metric_name)
+  short_title = I18n.t("metrics.#{metric_name}.short_title").downcase
+  I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
 end


### PR DESCRIPTION
This enables the use of the short metric title in the about label within the locales. 