### PR TITLE
Fix js issues

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <% content_for :head do %>
   <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
   <%= stylesheet_link_tag "application" %>
+  <%= javascript_include_tag "application" %>
 
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {


### PR DESCRIPTION
In creating the reference index page I removed this call to the js as the gem appears to call it in for us in the admin layout already. However I have now realised that the call needs to be in the head of the page for our charts to work. This will need to be resolved properly later but so I don't leave the charts broken in my absence this is a quick patch. I'm creating a separate ticket in trello to address this fully and to scope the js properly.