### PR TITLE
Use unique pageviews for search rate

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -151,10 +151,11 @@ private
 
   def on_page_search_rate
     searches = @metrics['searches'][:value].to_f
-    pviews = @metrics['pviews'][:value].to_f
+    upviews = @metrics['upviews'][:value].to_f
 
-    return 0 if searches.zero? || pviews.zero?
-    search_rate = (searches / pviews) * 100
+    return 0 if searches.zero? || upviews.zero?
+    search_rate = (searches / upviews) * 100
+    search_rate = 100 if search_rate > 100
     search_rate.round(2)
   end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     describe 'glance metrics section' do
       it 'renders glance metrics unique page views' do
-        expect(page).to have_selector '.glance-metric.upviews', text: '33'
+        expect(page).to have_selector '.glance-metric.upviews', text: '6,000'
       end
 
       it 'renders glance metric context for unique pageviews' do
@@ -50,7 +50,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders trend percentage for unique pageviews' do
-        expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: '+230.00%'
+        expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: '-40.00%'
       end
 
       it 'renders glance metric for satisfaction score' do
@@ -74,7 +74,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders trend percentage for page searches' do
-        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '400.00%'
+        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '406.25%'
       end
 
       it 'renders glance metric for feedex comments' do
@@ -86,7 +86,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders context for page searches' do
-        expect(page).to have_selector '.searches .app-c-glance-metric__context', text: '0.4%'
+        expect(page).to have_selector '.searches .app-c-glance-metric__context', text: '4.05%'
       end
     end
 
@@ -94,7 +94,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       let(:expected_table_dates) { ['', '11-25', '11-26', '12-25'] }
 
       it 'renders the metric for upviews' do
-        expect(page).to have_selector '.metric-summary__upviews', text: '33'
+        expect(page).to have_selector '.metric-summary__upviews', text: '6,000'
       end
 
       it 'renders about label for upviews' do
@@ -171,7 +171,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         upviews_rows = extract_table_content(".chart.upviews table")
         expect(upviews_rows).to match_array([
           expected_table_dates,
-          ["Unique pageviews", "1", "2", "30"]
+          ["Unique pageviews", "1000", "2000", "3000"]
         ])
       end
 
@@ -187,7 +187,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         internal_searches_rows = extract_table_content(".chart.searches table")
         expect(internal_searches_rows).to match_array([
           expected_table_dates,
-          ["Searches from the page", "80", "80", "80"]
+          ["Searches from the page", "80", "80", "83"]
         ])
       end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -46,6 +46,33 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
+  describe '#searches_context' do
+    it 'shows the percentage of users who searched the page' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 10 }]
+      expect(subject.searches_context).to eq "10.0% of users searched from the page"
+    end
+
+    it 'return 0 if there are no unique pageviews' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'searches', total: 10 }]
+      expect(subject.searches_context).to eq "0% of users searched from the page"
+    end
+
+    it 'returns 0 if there have been no searches' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 10 }, { name: 'searches', total: 0 }]
+      expect(subject.searches_context).to eq "0% of users searched from the page"
+    end
+
+    it 'rounds to 2 decimal places' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 8777 }, { name: 'searches', total: 1753 }]
+      expect(subject.searches_context).to eq "19.97% of users searched from the page"
+    end
+
+    it 'caps to a maximum of 100%' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 900 }]
+      expect(subject.searches_context).to eq "100% of users searched from the page"
+    end
+  end
+
   describe '#metadata' do
     it 'returns a hash with the metadata' do
       expect(subject.base_path).to eq('/the/base/path')

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -114,11 +114,11 @@ module GdsApi
           time_series_metrics: [
             {
               name: "upviews",
-              total: 33,
+              total: 6000,
               time_series: [
-                { "date" => day1, "value" => 1 },
-                { "date" => day2, "value" => 2 },
-                { "date" => day3, "value" => 30 }
+                { "date" => day1, "value" => 1000 },
+                { "date" => day2, "value" => 2000 },
+                { "date" => day3, "value" => 3000 }
               ]
             },
             {
@@ -132,11 +132,11 @@ module GdsApi
             },
             {
               name: "searches",
-              total: 240,
+              total: 243,
               time_series: [
                 { "date" => day1, "value" => 80 },
                 { "date" => day2, "value" => 80 },
-                { "date" => day3, "value" => 80 }
+                { "date" => day3, "value" => 83 }
               ]
             },
             {
@@ -202,11 +202,11 @@ module GdsApi
           time_series_metrics: [
             {
               name: "upviews",
-              total: 10,
+              total: 10000,
               time_series: [
-                { "date" => day1, "value" => 1 },
-                { "date" => day2, "value" => 2 },
-                { "date" => day3, "value" => 7 }
+                { "date" => day1, "value" => 1000 },
+                { "date" => day2, "value" => 2000 },
+                { "date" => day3, "value" => 7000 }
               ]
             },
             {


### PR DESCRIPTION
#### What
[Trello card](https://trello.com/c/TdGevWTq/764-1-page-data-fix-of-users-searched-the-page-in-the-at-a-glance-metrics)
We currently use pageviews to calculate search rate, this PR changes it so that
we will use unique pageviews.

Some changes to the test data.

#### Why
Unique pageviews more accurately represents the idea of 'How many users searched per page'.

Changing the test data was necessary to make it closer to the kind of data that we will see in production.

---
#### Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to trello card.
