### PR TITLE
Use table component on index page

### DIFF
--- a/app/views/content/_content_row.html.erb
+++ b/app/views/content/_content_row.html.erb
@@ -1,9 +1,0 @@
-<tr>
-  <td><%= link_to item.title, metrics_path(item.base_path, date_range: date_range) %>
-    <span class="base-path">/<%= item.base_path %></span>
-  </td>
-  <td><%= item.document_type %></td>
-  <td><%= number_with_delimiter(item.upviews, delimiter: ',') %></td>
-  <td><%= item.user_satisfaction %></td>
-  <td><%= item.searches %></td>
-</tr>

--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -1,0 +1,3 @@
+<%= link_to item.title, metrics_path(item.base_path, date_range: date_range) %>
+<br>
+<span class="base-path">/<%= item.base_path %></span>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -22,20 +22,58 @@
 
 <% content_for :title, @content.title %>
 <h3>Content data</h3>
-<div class="content-table">
-  <table>
-    <tr>
-      <th>Page title</th>
-      <th>Content type</th>
-      <th>Unique pageviews</th>
-      <th>User satisfaction score</th>
-      <th>Searches from page</th>
-    </tr>
-    <%= render(
-      partial: 'content_row',
-      collection: @content.items,
-      as: :item,
-      locals: { date_range: @content.date_range.time_period }
+
+<%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
+  self,
+  "Showing ... TODO",
+  sortable: true
+) do |t| %>
+  <%= t.head do %>
+    <!-- TODO: Once sorting is supported, fill in the href and sort_direction header arguments with proper values -->
+    <%= t.header(
+      "Page title",
+      href: '#',
+      sort_direction: nil
     ) %>
-  </table>
-</div>
+    <%= t.header(
+      "Content type",
+      href: '#',
+      sort_direction: nil
+    ) %>
+    <%= t.header(
+      "Unique pageviews",
+      href: '#',
+      sort_direction: 'descending'
+    ) %>
+    <%= t.header(
+      "User satisfaction score",
+      href: '#',
+      sort_direction: nil
+    ) %>
+    <%= t.header(
+      "Searches from page",
+      href: '#',
+      sort_direction: nil
+    ) %>
+  <% end %>
+
+  <%= t.body do %>
+    <% @content.items.each do |item| %>
+      <%= t.row do %>
+        <%= t.cell(
+          render(
+            partial: 'page_title',
+            locals: {
+              item: item,
+              date_range: @content.date_range.time_period
+            }
+          )
+        ) %>
+        <%= t.cell item.document_type %>
+        <%= t.cell number_with_delimiter(item.upviews, delimiter: ',') %>
+        <%= t.cell item.user_satisfaction %>
+        <%= t.cell item.searches %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -1,12 +1,21 @@
 <%= form_tag content_path, method: 'get', name: 'organisation-picker' do %>
-  <%= select_tag 'organisation_id', options_for_select(@organisations.map{ |org| [org[:title], org[:organisation_id]] },
-                                                       selected: @organisation_id),
-                                                       class: 'org-picker' %>
-    <%= select_tag 'document_type', options_for_select(@document_types.map{ |dt| [dt.try(:tr, '_', ' ').try(:capitalize), dt] },
-                                                       selected: @document_type || '',
-                                                      ),
-                                                      include_blank: 'All document types',
-                                                      class: 'doc-type-picker' %>
+  <%= select_tag(
+    'organisation_id',
+    options_for_select(
+      @organisations.map{ |org| [org[:title], org[:organisation_id]] },
+      selected: @organisation_id
+    ),
+    class: 'org-picker'
+  ) %>
+  <%= select_tag(
+    'document_type',
+    options_for_select(
+      @document_types.map{ |dt| [dt.try(:tr, '_', ' ').try(:capitalize), dt] },
+      selected: @document_type || '',
+    ),
+    include_blank: 'All document types',
+    class: 'doc-type-picker'
+  ) %>
   <%= hidden_field_tag 'date_range', @content.date_range.time_period %>
   <%= submit_tag "Filter" %>
 <% end %>
@@ -22,6 +31,11 @@
       <th>User satisfaction score</th>
       <th>Searches from page</th>
     </tr>
-    <%= render partial: 'content_row', collection: @content.items, as: :item, locals: { date_range: @content.date_range.time_period } %>
+    <%= render(
+      partial: 'content_row',
+      collection: @content.items,
+      as: :item,
+      locals: { date_range: @content.date_range.time_period }
+    ) %>
   </table>
 </div>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe '/content' do
   end
 
   it 'renders the data in a table' do
-    table_rows = extract_table_content('.content-table table')
+    table_rows = extract_table_content('.govuk-table')
     expect(table_rows).to eq(
       [
         ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
@@ -119,7 +119,7 @@ RSpec.describe '/content' do
     end
 
     it 'renders the filtered results' do
-      table_rows = extract_table_content('.content-table table')
+      table_rows = extract_table_content('.govuk-table')
 
       _header = table_rows.shift
       expect(table_rows).to all(include('News story'))
@@ -129,7 +129,7 @@ RSpec.describe '/content' do
       select 'All document types', from: 'document_type'
       click_on 'Filter'
       expect(page).to have_select('document_type', selected: nil)
-      table_rows = extract_table_content('.content-table table')
+      table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(3)
     end
   end


### PR DESCRIPTION
#### What
Publishing Workflow have built a table component in the gem, we need to implement this. Later we can expand upon it to meet our designs. 

#### Why
Reuse of code, prevents duplication of effort, gives a good starting point for making our tables match the designs.

#### Screenshots
##### Before
![screen shot 2018-10-26 at 13 39 14](https://user-images.githubusercontent.com/1130010/47570004-8ea49180-d924-11e8-965d-47bdbb7ffaf4.png)

##### After
![screen shot 2018-10-26 at 13 36 32](https://user-images.githubusercontent.com/1130010/47570001-8e0bfb00-d924-11e8-84fc-f124fc3c3ce2.png)



---
#### Review Checklist
* [x] Changes in scope.
* [x] Added/updated feature tests.
* [x] Added to trello card.
