### PR TITLE
Add pageviews_per_visit metric

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -16,6 +16,7 @@ class SingleContentItemPresenter
       previous_period_data[:time_series_metrics],
       previous_period_data[:edition_metrics]
     )
+    calculate_secondary_metrics
   end
 
   def total_upviews
@@ -44,6 +45,10 @@ class SingleContentItemPresenter
 
   def total_pdf_count
     number_with_delimiter @metrics['pdf_count'][:value]
+  end
+
+  def pageviews_per_visit
+    number_with_delimiter @metrics['pageviews_per_visit'][:value]
   end
 
   def upviews_context
@@ -179,6 +184,33 @@ private
       }
     end
     metrics
+  end
+
+  def calculate_secondary_metrics
+    calculate_pageviews_per_visit
+  end
+
+  def calculate_pageviews_per_visit
+    calculate_current_pageviews_per_visit
+    calculate_previous_pageviews_per_visit
+  end
+
+  def calculate_current_pageviews_per_visit
+    current = if @metrics['pviews'][:value].zero? || @metrics['upviews'][:value].zero?
+                0
+              else
+                @metrics['pviews'][:value].to_f / @metrics['upviews'][:value].to_f
+              end
+    @metrics['pageviews_per_visit'] = { value: current.round(2) }
+  end
+
+  def calculate_previous_pageviews_per_visit
+    previous = if @previous_metrics['pviews'][:value].zero? || @previous_metrics['upviews'][:value].zero?
+                 0
+               else
+                 @previous_metrics['pviews'][:value].to_f / @previous_metrics['upviews'][:value].to_f
+               end
+    @previous_metrics['pageviews_per_visit'] = { value: previous.round(2) }
   end
 
   def calculate_trend_percentage(current_value, previous_value)

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -108,25 +108,25 @@
   <div class="govuk-grid-column-full section-performance">
     <h2 class="section-performance__header"><%= t ".section_headings.performance" %></h2>
 
-    <%= render 'metric_section', 
+    <%= render 'metric_section',
         metric_name: 'upviews',
-        total: @performance_data.total_upviews, 
+        total: @performance_data.total_upviews,
         short_context: nil,
         external_link: nil %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', 
-        metric_name: 'pviews', 
-        total: @performance_data.total_pviews, 
+    <%= render 'metric_section',
+        metric_name: 'pviews',
+        total: @performance_data.total_pviews,
         short_context: nil,
         external_link: nil %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', 
-        metric_name: 'searches', 
-        total: @performance_data.total_searches, 
+    <%= render 'metric_section',
+        metric_name: 'searches',
+        total: @performance_data.total_searches,
         short_context: nil,
         external_link: nil %>
 
@@ -134,17 +134,17 @@
 
     <h2 class="govuk-heading-l"><%= t ".section_headings.feedback" %></h2>
 
-    <%= render 'metric_section', 
-        metric_name: 'feedex', 
-        total: @performance_data.total_feedex, 
+    <%= render 'metric_section',
+        metric_name: 'feedex',
+        total: @performance_data.total_feedex,
         short_context: nil ,
         external_link: @performance_data.feedback_explorer_href %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section', 
-        metric_name: 'satisfaction', 
-        total: @performance_data.total_satisfaction, 
+    <%= render 'metric_section',
+        metric_name: 'satisfaction',
+        total: @performance_data.total_satisfaction,
         short_context: @performance_data.satisfaction_short_context,
         external_link: nil %>
   </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -124,6 +124,17 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
+    <div class="metric-summary__pageviews_per_visit">
+      <%= render 'metric_header', {
+        metric_name: 'pageviews_per_visit',
+        value: @performance_data.pageviews_per_visit,
+        show_trend: true,
+        short_context: nil
+      }%>
+    </div>
+
+    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
     <%= render 'metric_section',
         metric_name: 'searches',
         total: @performance_data.total_searches,

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -107,6 +107,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.metric-summary__pviews', text: '60,000'
       end
 
+      it 'renders the metric for pagviews per visit' do
+        expect(page).to have_selector '.metric-summary__pageviews_per_visit', text: '10.0'
+      end
+
       it 'renders about label for pviews' do
         label = expected_metric_label('pviews')
         expect(page).to have_selector(".metric-summary__pviews .govuk-details__summary-text", text: label)

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders trend percentage for unique pageviews' do
-        expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: '-40.00%'
+        expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: '+500.00%'
       end
 
       it 'renders glance metric for satisfaction score' do
@@ -100,10 +100,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders about label for upviews' do
         label = expected_metric_label('upviews')
         expect(page).to have_selector(".metric-summary__upviews .govuk-details__summary-text", text: label)
+        expect(page).to have_selector '.metric-summary__upviews', text: '6,000'
       end
 
       it 'renders the metric for pviews' do
-        expect(page).to have_selector '.metric-summary__pviews', text: '60'
+        expect(page).to have_selector '.metric-summary__pviews', text: '60,000'
       end
 
       it 'renders about label for pviews' do

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -18,29 +18,29 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#trend_percentage' do
     it 'calculates an increase percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
+      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }, { name: 'pviews', total: 100 }]
 
       expect(subject.trend_percentage('upviews')).to eq(100.0)
     end
 
     it 'calculates an decrease percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }, { name: 'pviews', total: 100 }]
+      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
 
       expect(subject.trend_percentage('upviews')).to eq(-50.0)
     end
 
     it 'calculates an no percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
+      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
 
     it 'calculates an infinite percent increase (0 to non-zero)' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
+      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'pviews', total: 100 }]
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
@@ -48,28 +48,50 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#searches_context' do
     it 'shows the percentage of users who searched the page' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 10 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 10 }, { name: 'pviews', total: 100 }]
       expect(subject.searches_context).to eq "10.0% of users searched from the page"
     end
 
     it 'return 0 if there are no unique pageviews' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'searches', total: 10 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'searches', total: 10 }, { name: 'pviews', total: 100 }]
       expect(subject.searches_context).to eq "0% of users searched from the page"
     end
 
     it 'returns 0 if there have been no searches' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 10 }, { name: 'searches', total: 0 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 10 }, { name: 'searches', total: 0 }, { name: 'pviews', total: 100 }]
       expect(subject.searches_context).to eq "0% of users searched from the page"
     end
 
     it 'rounds to 2 decimal places' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 8777 }, { name: 'searches', total: 1753 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 8777 }, { name: 'searches', total: 1753 }, { name: 'pviews', total: 100 }]
       expect(subject.searches_context).to eq "19.97% of users searched from the page"
     end
 
     it 'caps to a maximum of 100%' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 900 }]
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'searches', total: 900 }, { name: 'pviews', total: 100 }]
       expect(subject.searches_context).to eq "100% of users searched from the page"
+    end
+  end
+
+  describe '#pageviews_per_visit' do
+    it 'calculates number of times the page was viewed in one visit' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }, { name: 'pviews', total: 100 }]
+      expect(subject.pageviews_per_visit).to eq('2.0')
+    end
+
+    it 'return 0 if there are no pageviews' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 0 }]
+      expect(subject.pageviews_per_visit).to eq('0')
+    end
+
+    it 'return 0 if there are no unique pageviews' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'pviews', total: 100 }]
+      expect(subject.pageviews_per_visit).to eq('0')
+    end
+
+    it 'rounds to 2 decimal places' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 4 }, { name: 'pviews', total: 13 }]
+      expect(subject.pageviews_per_visit).to eq('3.25')
     end
   end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -202,7 +202,7 @@ module GdsApi
           time_series_metrics: [
             {
               name: "upviews",
-              total: 10000,
+              total: 1000,
               time_series: [
                 { "date" => day1, "value" => 1000 },
                 { "date" => day2, "value" => 2000 },
@@ -211,7 +211,7 @@ module GdsApi
             },
             {
               name: "pviews",
-              total: 30,
+              total: 30000,
               time_series: [
                 { "date" => day1, "value" => 5 },
                 { "date" => day2, "value" => 5 },


### PR DESCRIPTION
#### What
[Trello card](https://trello.com/c/174c4iAe/758-2-page-data-add-pageviews-per-visit-metric)
Add pageviews per visit metric to single content item page

#### Why
So that users can measure how many times the page is viewed by an individual user in order to judge the performance of the page.

#### Screenshots
<img width="1211" alt="screen shot 2018-10-26 at 16 50 59" src="https://user-images.githubusercontent.com/13124899/47577693-6aa27980-d93f-11e8-97ae-ac6c776e6518.png">

---
#### Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to trello card.
