### PR TITLE
Remove legend from charts

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -8,7 +8,6 @@
   Chartkick.options[:html] = '<div id="%{id}"><noscript><p>Our charts are built using javascript but all the data is also available in the table.</p></noscript></div>'
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
-    legend: { position: 'top', textStyle: {color: '#000', fontName: 'nta', fontSize: '18'}},
     chartArea:{width:'90%',height:'80%'},
     curveType: 'none',
     tooltip: {textStyle: {color: '#000'}, showColorCode: true},


### PR DESCRIPTION
#### What
https://trello.com/c/drqNn996/774-1-hide-legend-on-chart
Remove the legend from the chart

#### Why
To match design - context is clear from headings so legend is unnecessary

#### Screenshots
*If applicable add screenshots otherwise remove this section.*
##### Before
![screen shot 2018-10-29 at 11 46 23](https://user-images.githubusercontent.com/31649453/47647910-5ee9c980-db70-11e8-9198-365ca7a36482.png)
##### After
![screen shot 2018-10-29 at 11 46 42](https://user-images.githubusercontent.com/31649453/47647911-5ee9c980-db70-11e8-823d-bd0f1ed6767f.png)

---
#### Review Checklist
* [x] Added to trello card.
