### PR TITLE
Use users organisation on index page

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,6 +1,8 @@
 class ContentController < ApplicationController
   def index
-    get_content
+    @content = get_content
+    @organisation_id = content_params[:organisation_id]
+    @document_type = content_params[:document_type]
     organisations = FetchOrganisations.call
     @organisations = organisations[:organisations]
     @document_types = FetchDocumentTypes.call[:document_types]
@@ -10,12 +12,10 @@ private
 
   def get_content
     response = FindContent.call(content_params)
-    @content = ContentItemsPresenter.new(
+    ContentItemsPresenter.new(
       response[:results],
       DateRange.new(content_params[:date_range])
     )
-    @organisation_id = content_params[:organisation_id]
-    @document_type = content_params[:document_type]
   end
 
   def content_params

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -9,14 +9,28 @@ class ContentController < ApplicationController
 private
 
   def get_content
-    response = FindContent.call(params)
-    @content = ContentItemsPresenter.new(response[:results], date_range)
-    @organisation_id = params[:organisation_id]
-    @document_type = params[:document_type]
+    response = FindContent.call(content_params)
+    @content = ContentItemsPresenter.new(
+      response[:results],
+      DateRange.new(content_params[:date_range])
+    )
+    @organisation_id = content_params[:organisation_id]
+    @document_type = content_params[:document_type]
   end
 
-  def date_range
-    time_period = params[:date_range].presence || 'last-30-days'
-    DateRange.new(time_period)
+  def content_params
+    @content_params ||= begin
+      defaults = {
+        date_range: 'last-30-days'
+      }
+
+      defaults.merge(
+        params.permit(
+          :date_range,
+          :organisation_id,
+          :document_type
+        ).to_h.symbolize_keys
+      )
+    end
   end
 end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -21,7 +21,8 @@ private
   def content_params
     @content_params ||= begin
       defaults = {
-        date_range: 'last-30-days'
+        date_range: 'last-30-days',
+        organisation_id: current_user.organisation_content_id,
       }
 
       defaults.merge(

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe '/content' do
   before do
     stub_metrics_page(base_path: 'path/1', time_period: :last_month)
     content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
-    GDS::SSO.test_user = build(:user)
+    GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
     content_data_api_has_orgs
     content_data_api_has_document_types
 
@@ -104,6 +104,26 @@ RSpec.describe '/content' do
       click_on 'Filter'
       click_on 'The title'
       expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.last-year.leading')}")
+    end
+
+    context 'with users organisation' do
+      before do
+        content_data_api_has_content_items(
+          from: from,
+          to: to,
+          organisation_id: 'users-org-id',
+          items: [
+            items[0].merge(title: 'Content from users-org-id')
+          ]
+        )
+
+        visit "/content?date_range=last-month"
+      end
+
+      it 'uses the users organisation by default' do
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content('Content from users-org-id')
+      end
     end
   end
 


### PR DESCRIPTION
#### What
By default, pre-populate filters and data with the user's organisation.

#### Why
The most common scenario is for users to search/edit content for their organisation.

---
#### Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [ ] Added to trello card.
