### PR TITLE
Redirect from / to /content

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  root to: redirect('/content')
+
   get "/healthcheck", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck-f", to: proc {
     GovukError.notify('Sentry works')


### PR DESCRIPTION
This makes the link from Signon more useful, and when combined with
using the users organisation, the content page should work.

Depends on https://github.com/alphagov/content-data-admin/pull/162 so that the index page actually works for most users without fiddling with the query parameters.