### PR TITLE
Fix table scroll

### DIFF
--- a/app/assets/stylesheets/components/_chart.scss
+++ b/app/assets/stylesheets/components/_chart.scss
@@ -5,8 +5,11 @@
   margin-bottom: 0;
 }
 
-.app-c-chart__table {
+.app-c-chart__table-wrapper {
   overflow: auto;
+}
+
+.app-c-chart__table {
 
   .govuk-details__summary-text {
     @include govuk-font(16);

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -44,7 +44,7 @@
       <%= render "govuk_publishing_components/components/details", {
               title: t(".table_dropdown", metric_name: chart_label)
             } do %>
-          <div tabindex="0">
+          <div tabindex="0" class="app-c-chart__table-wrapper">
              <table class="govuk-table">
                 <% if table_direction == "vertical" %>
                   <thead class="govuk-table__head">


### PR DESCRIPTION
#### What
Apply the scroll to the table and not the table header
https://trello.com/c/0uFwHlct/782-1-about-this-data-detail-link-disappears-when-user-scrolls-horizontally

#### Why
So that users can access the show/hide mechanism after scrolling without having to scroll back
