### PR TITLE
Remove default legend

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -8,6 +8,7 @@
   Chartkick.options[:html] = '<div id="%{id}"><noscript><p>Our charts are built using javascript but all the data is also available in the table.</p></noscript></div>'
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
+    legend: 'none',
     chartArea:{width:'90%',height:'80%'},
     curveType: 'none',
     tooltip: {textStyle: {color: '#000'}, showColorCode: true},


### PR DESCRIPTION
We previously removed the legend config and lost the legend we intended
to remove from the top of the chart. It had the unexpected effect of
creating a legend label at another position where it didn't fit. This
specifically removes it fully.

https://trello.com/c/s8pyUWgc/785-bug-fix-line-appearing-to-the-right-of-all-charts