### PR TITLE
Fix searches_per_visit_bug

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -196,7 +196,7 @@ private
   end
 
   def calculate_current_pageviews_per_visit
-    current = if @metrics['pviews'][:value].zero? || @metrics['upviews'][:value].zero?
+    current = if @metrics['pviews'][:value].to_f.zero? || @metrics['upviews'][:value].to_f.zero?
                 0
               else
                 @metrics['pviews'][:value].to_f / @metrics['upviews'][:value].to_f
@@ -205,7 +205,7 @@ private
   end
 
   def calculate_previous_pageviews_per_visit
-    previous = if @previous_metrics['pviews'][:value].zero? || @previous_metrics['upviews'][:value].zero?
+    previous = if @previous_metrics['pviews'][:value].to_f.zero? || @previous_metrics['upviews'][:value].to_f.zero?
                  0
                else
                  @previous_metrics['pviews'][:value].to_f / @previous_metrics['upviews'][:value].to_f

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -89,6 +89,16 @@ RSpec.describe SingleContentItemPresenter do
       expect(subject.pageviews_per_visit).to eq('0')
     end
 
+    it 'return 0 if unique pageviews are nil' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: 0 }]
+      expect(subject.pageviews_per_visit).to eq('0')
+    end
+
+    it 'return 0 if pageviews are nil' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'pviews', total: nil }]
+      expect(subject.pageviews_per_visit).to eq('0')
+    end
+
     it 'rounds to 2 decimal places' do
       current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 4 }, { name: 'pviews', total: 13 }]
       expect(subject.pageviews_per_visit).to eq('3.25')


### PR DESCRIPTION
### What?
We currently have a bug which raises an error when calculating searches per page
if we do not have any data for either pviews or upviews for a certain period. It was introduced in [this PR](https://github.com/alphagov/content-data-admin/pull/159)

This bug has raised it's head when we set the date range to a period longer than we
have data for. This is because we will not have any data for the previous period, which
we use to calculate trends and so we get the error which is raised by this bug:

'`NoMethodError: undefined method `zero?' for nil:NilClass'

### How?
This PR calls `.to_f` on the value field of pviews and upviews. This will convert nil to 0
which will stop the error being raised if we receive a nil value.

### Notes

If we do not have any value for a set period then we will set pageviews per visit to `0`. This is not strictly true but is currently the strategy we are using in other areas. This is something the product team are aware of and are considering.

---
#### Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to trello card.
