### PR TITLE
Pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "gds-api-adapters", "~> 54"
 gem "gds-sso", "~> 13"
 gem "govuk_app_config", "~> 1"
 gem "govuk_publishing_components", "~> 12.3"
+gem 'kaminari'
 gem 'logstasher'
 gem "pg", "~> 1"
 gem "plek", "~> 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,18 @@ GEM
     jaro_winkler (1.5.1)
     json (2.1.0)
     jwt (1.5.6)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     kgio (2.11.2)
     kramdown (1.15.0)
     link_header (0.0.8)
@@ -356,6 +368,7 @@ DEPENDENCIES
   govuk-lint (~> 3)
   govuk_app_config (~> 1)
   govuk_publishing_components (~> 12.3)
+  kaminari
   listen (~> 3)
   logstasher
   pg (~> 1)
@@ -372,4 +385,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.4
+   1.16.6

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -14,7 +14,9 @@ private
     response = FindContent.call(content_params)
     ContentItemsPresenter.new(
       response[:results],
-      DateRange.new(content_params[:date_range])
+        DateRange.new(content_params[:date_range]),
+        response[:total_results],
+        params[:page]
     )
   end
 
@@ -29,7 +31,8 @@ private
         params.permit(
           :date_range,
           :organisation_id,
-          :document_type
+          :document_type,
+          :page
         ).to_h.symbolize_keys
       )
     end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,4 +1,6 @@
 class ContentController < ApplicationController
+  include PaginationHelper
+
   def index
     @content = get_content
     @organisation_id = content_params[:organisation_id]
@@ -16,7 +18,8 @@ private
       response[:results],
         DateRange.new(content_params[:date_range]),
         response[:total_results],
-        params[:page]
+        response[:total_pages],
+        response[:page]
     )
   end
 

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -14,13 +14,7 @@ private
 
   def get_content
     response = FindContent.call(content_params)
-    ContentItemsPresenter.new(
-      response[:results],
-        DateRange.new(content_params[:date_range]),
-        response[:total_results],
-        response[:total_pages],
-        response[:page]
-    )
+    ContentItemsPresenter.new(response, DateRange.new(content_params[:date_range]))
   end
 
   def content_params

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -1,0 +1,28 @@
+module PaginationHelper
+  include Kaminari::Helpers::HelperMethods
+  attr_accessor :content
+
+  def navigation_links
+    result = {}
+    if content.prev_link?
+      result = result.merge(
+        previous_page:  {
+          url: path_to_prev_page(content.items),
+          title: 'Previous',
+          label: "#{content.page - 1} of #{content.total_pages}"
+        }
+      )
+    end
+
+    if content.next_link?
+      result = result.merge(
+        next_page: {
+          url: path_to_next_page(content.items),
+          title: 'Next',
+          label: "#{content.page + 1} of #{content.total_pages}"
+        }
+      )
+    end
+    result
+  end
+end

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,11 +1,22 @@
 class ContentItemsPresenter
-  attr_reader :items, :title, :date_range
-  def initialize(content_items, date_range, total_results, page)
+  include Kaminari::Helpers::HelperMethods
+  attr_reader :items, :title, :date_range, :page, :total_pages
+
+  def initialize(content_items, date_range, total_results, total_pages, page)
     @title = 'Content Items'
     @date_range = date_range
     @total_results = total_results
-    @page = page
+    @total_pages = total_pages
+    @page = page || 1
     @items = paginate(content_items.map { |ci| ContentRowPresenter.new(ci) })
+  end
+
+  def prev_link?
+    @page > 1
+  end
+
+  def next_link?
+    @page < @total_pages
   end
 
 private

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,8 +1,17 @@
 class ContentItemsPresenter
   attr_reader :items, :title, :date_range
-  def initialize(content_items, date_range)
-    @items = content_items.map { |ci| ContentRowPresenter.new(ci) }
+  def initialize(content_items, date_range, total_results, page)
     @title = 'Content Items'
     @date_range = date_range
+    @total_results = total_results
+    @page = page
+    @items = paginate(content_items.map { |ci| ContentRowPresenter.new(ci) })
+  end
+
+private
+
+  def paginate(items)
+    Kaminari.paginate_array(items, total_count: @total_results)
+      .page(@page).per(100)
   end
 end

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -2,13 +2,13 @@ class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
   attr_reader :items, :title, :date_range, :page, :total_pages
 
-  def initialize(content_items, date_range, total_results, total_pages, page)
+  def initialize(response, date_range)
     @title = 'Content Items'
     @date_range = date_range
-    @total_results = total_results
-    @total_pages = total_pages
-    @page = page || 1
-    @items = paginate(content_items.map { |ci| ContentRowPresenter.new(ci) })
+    @total_results = response[:total_results]
+    @total_pages = response[:total_pages]
+    @page = response[:page] || 1
+    @items = paginate(response[:results].map { |ci| ContentRowPresenter.new(ci) })
   end
 
   def prev_link?

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -11,9 +11,10 @@ class FindContent
     @to = range.to
     @organisation = params[:organisation_id]
     @document_type = params[:document_type]
+    @page = params[:page]
   end
 
   def call
-    api.content(from: @from, to: @to, organisation_id: @organisation, document_type: @document_type)
+    api.content(from: @from, to: @to, organisation_id: @organisation, document_type: @document_type, page: @page)
   end
 end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -2,7 +2,7 @@
   <%= select_tag(
     'organisation_id',
     options_for_select(
-      @organisations.map{ |org| [org[:title], org[:organisation_id]] },
+      @organisations.map { |org| [org[:title], org[:organisation_id]] },
       selected: @organisation_id
     ),
     class: 'org-picker'
@@ -10,7 +10,7 @@
   <%= select_tag(
     'document_type',
     options_for_select(
-      @document_types.map{ |dt| [dt.try(:tr, '_', ' ').try(:capitalize), dt] },
+      @document_types.map { |dt| [dt.try(:tr, '_', ' ').try(:capitalize), dt] },
       selected: @document_type || '',
     ),
     include_blank: 'All document types',
@@ -76,4 +76,4 @@
     <% end %>
   <% end %>
 <% end %>
-<%= paginate @content.items %>
+<%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -22,7 +22,6 @@
 
 <% content_for :title, @content.title %>
 <h3>Content data</h3>
-
 <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
   self,
   "Showing ... TODO",
@@ -77,3 +76,4 @@
     <% end %>
   <% end %>
 <% end %>
+<%= paginate @content.items %>

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -17,8 +17,8 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
-  def content(from:, to:, organisation_id:, document_type: nil)
-    url = content_items_url(from, to, organisation_id, document_type)
+  def content(from:, to:, organisation_id:, document_type: nil, page: nil)
+    url = content_items_url(from, to, organisation_id, document_type, page)
     get_json(url).to_hash.deep_symbolize_keys
   end
 
@@ -49,12 +49,13 @@ private
     "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
-  def content_items_url(from, to, organisation_id, document_type)
+  def content_items_url(from, to, organisation_id, document_type, page)
     params = {
       from: from,
       to: to,
       organisation_id: organisation_id,
       document_type: document_type,
+      page: page,
     }
     params.reject! { |_, v| v.blank? }
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -153,4 +153,45 @@ RSpec.describe '/content' do
       expect(table_rows.count).to eq(3)
     end
   end
+
+  context 'pagination' do
+    let(:other_page_items) do
+      [
+        {
+          base_path: '/path/3',
+          title: 'third title',
+          upviews: 233_018,
+          document_type: 'press_release',
+          satisfaction: 0.81301,
+          satisfaction_responses: 250,
+          searches: 220
+        },
+        {
+          base_path: '/path/4',
+          title: 'forth title',
+          upviews: 100_018,
+          document_type: 'news_story',
+          satisfaction: 0.68,
+          satisfaction_responses: 42,
+          searches: 12
+        }
+      ]
+    end
+
+    before do
+      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', page: 2, items: other_page_items)
+    end
+
+    it 'shows the second page of data' do
+      click_on '2'
+      table_rows = extract_table_content('.govuk-table')
+      expect(table_rows).to eq(
+        [
+          ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
+          ['third title /path/3', 'Press release', '233,018', '81.3% (250 responses)', '220'],
+          ['forth title /path/4', 'News story', '100,018', '68.0% (42 responses)', '12'],
+        ]
+                            )
+    end
+  end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -183,7 +183,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows the second page of data' do
-      click_on '2'
+      click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
         [
@@ -191,7 +191,7 @@ RSpec.describe '/content' do
           ['third title /path/3', 'Press release', '233,018', '81.3% (250 responses)', '220'],
           ['forth title /path/4', 'News story', '100,018', '68.0% (42 responses)', '12'],
         ]
-                            )
+      )
     end
   end
 end

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -1,5 +1,14 @@
 RSpec.describe PaginationHelper do
   let(:date_range) { DateRange.new('last-30-days') }
+  let(:response) do
+    {
+      results: [],
+      total_results: 300,
+      total_pages: 3,
+      page: 1
+    }
+  end
+
   before do
     controller.params[:action] = 'index'
     controller.params[:controller] = 'content'
@@ -8,7 +17,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when on the first page' do
-    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 1) }
+    let(:content) { ContentItemsPresenter.new(response, date_range) }
     it 'only returns the `Next` link' do
       expect(navigation_links).to eq(next_page: { url: "/content?organisation_id=org-1&page=2",
                                                                   title: 'Next',
@@ -17,7 +26,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when on the last page' do
-    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 3) }
+    let(:content) { ContentItemsPresenter.new(response.merge(page: 3), date_range) }
 
     it 'only returns the `Previous` link' do
       expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1&page=2",
@@ -27,7 +36,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when in the middle somewhere' do
-    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 2) }
+    let(:content) { ContentItemsPresenter.new(response.merge(page: 2), date_range) }
 
     it 'returns `Previous` and `Next` links' do
       expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1",

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe PaginationHelper do
+  let(:date_range) { DateRange.new('last-30-days') }
+  before do
+    controller.params[:action] = 'index'
+    controller.params[:controller] = 'content'
+    controller.params[:organisation_id] = 'org-1'
+    assign :content, content
+  end
+
+  context 'when on the first page' do
+    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 1) }
+    it 'only returns the `Next` link' do
+      expect(navigation_links).to eq(next_page: { url: "/content?organisation_id=org-1&page=2",
+                                                                  title: 'Next',
+                                                                  label: '2 of 3' })
+    end
+  end
+
+  context 'when on the last page' do
+    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 3) }
+
+    it 'only returns the `Previous` link' do
+      expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1&page=2",
+                                                  title: 'Previous',
+                                                  label: '2 of 3' })
+    end
+  end
+
+  context 'when in the middle somewhere' do
+    let(:content) { ContentItemsPresenter.new([], date_range, 300, 3, 2) }
+
+    it 'returns `Previous` and `Next` links' do
+      expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1",
+                                                      title: 'Previous',
+                                                      label: '1 of 3' },
+                                     next_page: { url: "/content?organisation_id=org-1&page=3",
+                                                  title: 'Next',
+                                                  label: '3 of 3' })
+    end
+  end
+end

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -1,0 +1,26 @@
+RSpec.describe ContentItemsPresenter do
+  let(:date_range) { DateRange.new('last-30-days') }
+  describe '#prev_link?' do
+    it 'returns false if on first page' do
+      presenter = described_class.new([], date_range, 300, 3, 1)
+      expect(presenter.prev_link?).to eq(false)
+    end
+
+    it 'returns true if on another page' do
+      presenter = described_class.new([], date_range, 300, 3, 2)
+      expect(presenter.prev_link?).to eq(true)
+    end
+  end
+
+  describe '#next_link?' do
+    it 'returns false when on the last page' do
+      presenter = described_class.new([], date_range, 300, 3, 3)
+      expect(presenter.next_link?).to eq(false)
+    end
+
+    it 'returns true when on the another page' do
+      presenter = described_class.new([], date_range, 300, 3, 2)
+      expect(presenter.next_link?).to eq(true)
+    end
+  end
+end

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -1,25 +1,33 @@
 RSpec.describe ContentItemsPresenter do
   let(:date_range) { DateRange.new('last-30-days') }
+  let(:response) do
+    {
+      results: [],
+      total_results: 300,
+      total_pages: 3,
+      page: 1
+    }
+  end
   describe '#prev_link?' do
     it 'returns false if on first page' do
-      presenter = described_class.new([], date_range, 300, 3, 1)
+      presenter = described_class.new(response, date_range)
       expect(presenter.prev_link?).to eq(false)
     end
 
     it 'returns true if on another page' do
-      presenter = described_class.new([], date_range, 300, 3, 2)
+      presenter = described_class.new(response.merge(page: 2), date_range)
       expect(presenter.prev_link?).to eq(true)
     end
   end
 
   describe '#next_link?' do
     it 'returns false when on the last page' do
-      presenter = described_class.new([], date_range, 300, 3, 3)
+      presenter = described_class.new(response.merge(page: 3), date_range)
       expect(presenter.next_link?).to eq(false)
     end
 
     it 'returns true when on the another page' do
-      presenter = described_class.new([], date_range, 300, 3, 2)
+      presenter = described_class.new(response, date_range)
       expect(presenter.next_link?).to eq(true)
     end
   end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -34,16 +34,17 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, items:)
+      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, page: nil, items:)
         params = {
           from: from,
           to: to,
           organisation_id: organisation_id,
-          document_type: document_type
+          document_type: document_type,
+          page: page,
         }.reject { |_, v| v.blank? }
         query = query(params)
         url = "#{content_data_api_endpoint}/content#{query}"
-        body = { results: items }.to_json
+        body = { results: items, total_results: 200 }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -44,7 +44,7 @@ module GdsApi
         }.reject { |_, v| v.blank? }
         query = query(params)
         url = "#{content_data_api_endpoint}/content#{query}"
-        body = { results: items, total_results: 200 }.to_json
+        body = { results: items, total_results: 200, total_pages: 2 }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 


### PR DESCRIPTION
#### What
Add pagination to the index page

#### Why
So the user can view more than the first page.

There is a related [PR in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/974)

Url to test: http://localhost:3230/content?date_range=last-month&document_type=&organisation_id=c36bd301-d0c5-4492-86ad-ee7843b8383b&page=4

#### Screenshots

##### Before
<img width="1132" alt="screen shot 2018-10-30 at 12 44 53" src="https://user-images.githubusercontent.com/511319/47719010-c1f76100-dc41-11e8-9794-85424f2a0381.png">

##### After

![screen shot 2018-11-01 at 11 41 04](https://user-images.githubusercontent.com/511319/47849874-20038000-ddcb-11e8-88a7-8af1f2cb3890.png)

