### PR TITLE
Add withdrawn and history mode status

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -141,7 +141,15 @@ class SingleContentItemPresenter
     metadata[:primary_organisation_title]
   end
 
-  def status; end
+  def status
+    if metadata[:withdrawn] && metadata[:historical]
+      I18n.t('components.metadata.statuses.withdrawn_and_historical')
+    elsif metadata[:withdrawn]
+      I18n.t('components.metadata.statuses.withdrawn')
+    elsif metadata[:historical]
+      I18n.t('components.metadata.statuses.historical')
+    end
+  end
 
   def get_chart(metric_name)
     time_series = @metrics[metric_name][:time_series]

--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -10,6 +10,10 @@ en:
         publishing_organisation: 'From'
         document_type: 'Type'
         base_path: 'URL'
+      statuses:
+        withdrawn: 'Withdrawn'
+        historical: 'History mode'
+        withdrawn_and_historical: 'History mode and Withdrawn'
     time-select:
       title: 'Page data: %{time_period}'
       title_compact: 'Showing data from %{time_period}'

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -16,6 +16,35 @@ RSpec.describe SingleContentItemPresenter do
     SingleContentItemPresenter.new(current_period_data, previous_period_data, date_range)
   end
 
+  describe '#status' do
+    context 'when content is published' do
+      it 'displays nothing' do
+        expect(subject.status).to be_nil
+      end
+    end
+    context 'when content is historical' do
+      before { current_period_data[:metadata][:historical] = true }
+      it 'displays history mode' do
+        expect(subject.status).to eq(I18n.t('components.metadata.statuses.historical'))
+      end
+    end
+    context 'when content is withdrawn' do
+      before { current_period_data[:metadata][:withdrawn] = true }
+      it 'displays withdrawn' do
+        expect(subject.status).to eq(I18n.t('components.metadata.statuses.withdrawn'))
+      end
+    end
+    context 'when content is withdrawn and historical' do
+      before {
+        current_period_data[:metadata][:historical] = true
+        current_period_data[:metadata][:withdrawn] = true
+      }
+      it 'displays withdrawn and history mode' do
+        expect(subject.status).to eq(I18n.t('components.metadata.statuses.withdrawn_and_historical'))
+      end
+    end
+  end
+
   describe '#trend_percentage' do
     it 'calculates an increase percentage change' do
       current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -105,7 +105,9 @@ module GdsApi
             public_updated_at:  "2018-07-17T10:35:57.000Z",
             publishing_app:  "whitehall",
             document_type:  "news_story",
-            primary_organisation_title:  "The Ministry"
+            primary_organisation_title:  "The Ministry",
+            historical: false,
+            withdrawn: false
           },
           time_period: {
             to: to,
@@ -193,7 +195,9 @@ module GdsApi
             public_updated_at:  "2018-07-17T10:35:57.000Z",
             publishing_app:  "publisher",
             document_type:  "news_story",
-            primary_organisation_title:  "The Ministry"
+            primary_organisation_title:  "The Ministry",
+            historical: false,
+            withdrawn: false
           },
           time_period: {
             to: to,
@@ -278,7 +282,9 @@ module GdsApi
             public_updated_at:  "2018-07-17T10:35:57.000Z",
             publishing_app:  "publisher",
             document_type:  "news_story",
-            primary_organisation_title:  "The Ministry"
+            primary_organisation_title:  "The Ministry",
+            historical: false,
+            withdrawn: false
           },
           time_period: { to: to, from: from },
           time_series_metrics: [


### PR DESCRIPTION
#### What
Displaying whether a content item Withdraw or in History Mode or both.

#### Why
To allow users to see the status of a piece of content.

#### Screenshots
##### After
<img width="684" alt="image" src="https://user-images.githubusercontent.com/11051676/47728994-502a1200-dc57-11e8-933f-4218d24f8465.png">
<img width="580" alt="image" src="https://user-images.githubusercontent.com/11051676/47729079-6e900d80-dc57-11e8-8ec5-c38817e533d6.png">
<img width="607" alt="image" src="https://user-images.githubusercontent.com/11051676/47729172-97180780-dc57-11e8-87d9-94ae0298d0a8.png">

---
#### Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [ ] Added to trello card.
