### PR TITLE
Handle no comparison data

### DIFF
--- a/app/models/calculator/pageviews_per_visit.rb
+++ b/app/models/calculator/pageviews_per_visit.rb
@@ -1,0 +1,39 @@
+class Calculator::PageviewsPerVisit
+  attr_reader :metrics
+  def initialize(metrics)
+    @metrics = metrics
+  end
+
+  def current_period
+    return 0 if zero_pageviews? || zero_unique_pageviews?
+    calculate
+  end
+
+  def previous_period
+    return nil if no_pageviews_data? || no_unique_pageviews_data?
+    return 0 if zero_pageviews? || zero_unique_pageviews?
+    calculate
+  end
+
+private
+
+  def zero_pageviews?
+    metrics['pviews'][:value].to_f.zero?
+  end
+
+  def zero_unique_pageviews?
+    metrics['upviews'][:value].to_f.zero?
+  end
+
+  def no_pageviews_data?
+    metrics['pviews'][:value].blank?
+  end
+
+  def no_unique_pageviews_data?
+    metrics['upviews'][:value].blank?
+  end
+
+  def calculate
+    (metrics['pviews'][:value].to_f / metrics['upviews'][:value].to_f).round(2)
+  end
+end

--- a/app/models/calculator/trend_percentage.rb
+++ b/app/models/calculator/trend_percentage.rb
@@ -1,0 +1,17 @@
+class Calculator::TrendPercentage
+  attr_reader :current_value, :previous_value
+
+  def initialize(current_value, previous_value)
+    @current_value = current_value
+    @previous_value = previous_value
+  end
+
+  def run
+    return 0 if previous_value <= 0
+    trend
+  end
+
+  def trend
+    ((current_value.to_f / previous_value.to_f) - 1) * 100
+  end
+end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -224,8 +224,8 @@ private
   end
 
   def calculate_trend_percentage(current_value, previous_value, metric_name)
-    return 'no comparison data' if incomplete_previous_data?(current_value, previous_value, metric_name)
-    
+    return if incomplete_previous_data?(current_value, previous_value, metric_name)
+
     previous_value[:value] <= 0 ? 0 : ((current_value[:value].to_f / previous_value[:value].to_f) - 1) * 100
   end
 

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -212,7 +212,7 @@ private
   def calculate_trend_percentage(current_value, previous_value, metric_name)
     return if incomplete_previous_data?(current_value, previous_value, metric_name)
 
-    previous_value[:value] <= 0 ? 0 : ((current_value[:value].to_f / previous_value[:value].to_f) - 1) * 100
+    Calculator::TrendPercentage.new(current_value[:value], previous_value[:value]).run
   end
 
   def incomplete_previous_data?(current_value, previous_value, metric_name)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -213,16 +213,19 @@ private
   end
 
   def calculate_previous_pageviews_per_visit
-    previous = if @previous_metrics['pviews'][:value].to_f.zero? || @previous_metrics['upviews'][:value].to_f.zero?
+    previous = if @previous_metrics['pviews'][:value].blank? || @previous_metrics['upviews'][:value].blank?
+                 nil
+               elsif @previous_metrics['pviews'][:value].to_f.zero? || @previous_metrics['upviews'][:value].to_f.zero?
                  0
                else
-                 @previous_metrics['pviews'][:value].to_f / @previous_metrics['upviews'][:value].to_f
+                 (@previous_metrics['pviews'][:value].to_f / @previous_metrics['upviews'][:value].to_f).round(2)
                end
-    @previous_metrics['pageviews_per_visit'] = { value: previous.round(2) }
+    @previous_metrics['pageviews_per_visit'] = { value: previous }
   end
 
   def calculate_trend_percentage(current_value, previous_value)
-    previous_value.to_f <= 0 ? 0 : ((current_value.to_f / previous_value.to_f) - 1) * 100
+    return 'no comparison data' if previous_value.nil?
+    previous_value <= 0 ? 0 : ((current_value.to_f / previous_value.to_f) - 1) * 100
   end
 
   def format_date(date_str)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -225,16 +225,22 @@ private
 
   def calculate_trend_percentage(current_value, previous_value, metric_name)
     return 'no comparison data' if incomplete_previous_data?(current_value, previous_value, metric_name)
+    
     previous_value[:value] <= 0 ? 0 : ((current_value[:value].to_f / previous_value[:value].to_f) - 1) * 100
   end
 
   def incomplete_previous_data?(current_value, previous_value, metric_name)
     return incomplete_previous_pageviews_per_visit_data? if metric_name == 'pageviews_per_visit'
-    return true if previous_value[:time_series].blank?
+    return true if no_previous_timeseries?(previous_value)
 
     current_timeseries_length = calculate_length_of_timeseries(current_value[:time_series])
     previous_time_series_length = calculate_length_of_timeseries(previous_value[:time_series])
+
     current_timeseries_length != previous_time_series_length
+  end
+
+  def no_previous_timeseries?(previous_value)
+    previous_value[:time_series].blank?
   end
 
   def incomplete_previous_pageviews_per_visit_data?

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -13,23 +13,29 @@
     <span class="app-c-glance-metric__figure"><%= figure %><span class="app-c-glance-metric__measurement" <% if measurement_explicit_label %>aria-label="<%= measurement_explicit_label %>"<% end %>><%= measurement_display_label %></span></span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">
-      <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
+      <% if trend_percentage == "no comparison data" %>
+        no comparison data
+      <% else %>
+        <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
+      <% end %>
     </span>
-    <% if trend_percentage > 0 %>
-      <span class="app-c-glance-metric__trend--up">
-        <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9650;</span>
-        <span class="app-c-glance-metric__trend-text">Upward trend</span>
-      <span>
-    <% elsif trend_percentage < 0 %>
-      <span class="app-c-glance-metric__trend--down">
-        <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9660;</span>
-        <span class="app-c-glance-metric__trend-text">Downward trend</span>
-      <span>
-    <% else %>
-      <span class="app-c-glance-metric__trend--no-change">
-        <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9679;</span>
-        <span class="app-c-glance-metric__trend-text">No change</span>
-      <span>
+    <% unless trend_percentage == "no comparison data" %>
+      <% if trend_percentage > 0 %>
+        <span class="app-c-glance-metric__trend--up">
+          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9650;</span>
+          <span class="app-c-glance-metric__trend-text">Upward trend</span>
+        <span>
+      <% elsif trend_percentage < 0 %>
+        <span class="app-c-glance-metric__trend--down">
+          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9660;</span>
+          <span class="app-c-glance-metric__trend-text">Downward trend</span>
+        <span>
+      <% else %>
+        <span class="app-c-glance-metric__trend--no-change">
+          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9679;</span>
+          <span class="app-c-glance-metric__trend-text">No change</span>
+        <span>
+      <% end %>
     <% end %>
     <p class="app-c-glance-metric__period govuk-body-xs"><%= period %></p>
   </div>

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -13,13 +13,13 @@
     <span class="app-c-glance-metric__figure"><%= figure %><span class="app-c-glance-metric__measurement" <% if measurement_explicit_label %>aria-label="<%= measurement_explicit_label %>"<% end %>><%= measurement_display_label %></span></span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">
-      <% if trend_percentage == "no comparison data" %>
+      <% if trend_percentage.blank? %>
         no comparison data
       <% else %>
         <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
       <% end %>
     </span>
-    <% unless trend_percentage == "no comparison data" %>
+    <% unless trend_percentage.blank? %>
       <% if trend_percentage > 0 %>
         <span class="app-c-glance-metric__trend--up">
           <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9650;</span>

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -30,7 +30,7 @@
         (<%= short_context %>)
       </span>
     <% end %>
-    <% if trend_percentage && trend_percentage != 'no comparison data' %>
+    <% if trend_percentage %>
       <span class="app-c-info-metric__trend">
         <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
       </span>
@@ -51,7 +51,7 @@
         <span>
       <% end %>
     <% end %>
-    <% if period && trend_percentage != 'no comparison data' %>
+    <% if period && trend_percentage %>
       <span class="app-c-info-metric__period"><%= period %></span>
     <% end %>
   </div>

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -30,7 +30,7 @@
         (<%= short_context %>)
       </span>
     <% end %>
-    <% if trend_percentage %>
+    <% if trend_percentage && trend_percentage != 'no comparison data' %>
       <span class="app-c-info-metric__trend">
         <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
       </span>
@@ -51,7 +51,7 @@
         <span>
       <% end %>
     <% end %>
-    <% if period %>
+    <% if period && trend_percentage != 'no comparison data' %>
       <span class="app-c-info-metric__period"><%= period %></span>
     <% end %>
   </div>

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "Glance Metric", type: :view do
   end
 
   it 'displays no trend direction if no comparison data available' do
-    data[:trend_percentage] = 'no comparison data'
+    data[:trend_percentage] = nil
     render_component(data)
     assert_select ".app-c-glance-metric__trend-text", count: 0
     assert_select ".app-c-glance-metric__trend-icon", count: 0

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric__trend--no-change .app-c-glance-metric__trend-text", text: "No change"
   end
 
+  it 'displays no trend direction if no comparison data available' do
+    data[:trend_percentage] = 'no comparison data'
+    render_component(data)
+    assert_select ".app-c-glance-metric__trend-text", count: 0
+    assert_select ".app-c-glance-metric__trend-icon", count: 0
+  end
+
   def render_component(locals)
     render partial: "components/glance-metric", locals: locals
   end

--- a/spec/components/info_metric_spec.rb
+++ b/spec/components/info_metric_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe "Info Metric", type: :view do
   end
 
   it 'does not display a trend direction if there is no comparison data' do
-    data[:trend_percentage] = 'no comparison data'
+    data[:trend_percentage] = nil
     render_component(data)
     assert_select ".app-c-info-metric__trend", count: 0
     assert_select ".app-c-info-metric__trend-text", count: 0

--- a/spec/components/info_metric_spec.rb
+++ b/spec/components/info_metric_spec.rb
@@ -52,6 +52,13 @@ RSpec.describe "Info Metric", type: :view do
     assert_select ".app-c-info-metric__trend--no-change .app-c-info-metric__trend-text", text: "No change"
   end
 
+  it 'does not display a trend direction if there is no comparison data' do
+    data[:trend_percentage] = 'no comparison data'
+    render_component(data)
+    assert_select ".app-c-info-metric__trend", count: 0
+    assert_select ".app-c-info-metric__trend-text", count: 0
+  end
+
   it "does not render the detail link when no about data is supplied" do
     data[:about] = false
     render_component(data)

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -210,6 +210,20 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
     end
 
+    context 'when the data-api has no comparison data' do
+      it 'returns trend as `no comparison data`' do
+        content_data_api_has_single_page(base_path: 'base/path',
+                                         from: from.to_s,
+                                         to: to.to_s)
+        content_data_api_has_single_page_with_nil_values(base_path: 'base/path',
+                                                         from: prev_from.to_s,
+                                                         to: from.to_s)
+        visit '/metrics/base/path'
+        expect(page.status_code).to eq(200)
+        expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: 'no comparison data'
+      end
+    end
+
     context 'when the data-api has an error' do
       it 'returns a 404 for a Gds::NotFound' do
         content_data_api_does_not_have_base_path(base_path: 'base/path',

--- a/spec/models/calculator/pageviews_per_visit_calculator.rb
+++ b/spec/models/calculator/pageviews_per_visit_calculator.rb
@@ -1,0 +1,67 @@
+RSpec.describe Calculator::PageviewsPerVisit do
+  let(:subject) { Calculator::PageviewsPerVisit }
+  context '#current' do
+    it 'returns 0 if there are 0 pageviews' do
+      metrics = build_metrics(pviews: 0)
+      expect(subject.new(metrics).current_period).to eq 0
+    end
+
+    it 'returns 0 if there are 0 unique pageviews' do
+      metrics = build_metrics(upviews: 0)
+      expect(subject.new(metrics).current_period).to eq 0
+    end
+
+    it 'returns 0 if there are nil pageviews' do
+      metrics = build_metrics(pviews: nil)
+      expect(subject.new(metrics).current_period).to eq 0
+    end
+
+    it 'returns 0 if there are nil unique pageviews' do
+      metrics = build_metrics(upviews: nil)
+      expect(subject.new(metrics).current_period).to eq 0
+    end
+
+    it 'returns pageviews per visit if there are pageviews and unique pageviews' do
+      metrics = build_metrics(pviews: 100, upviews: 10)
+      expect(subject.new(metrics).current_period).to eq 10
+    end
+  end
+
+  context '#previous' do
+    it 'returns 0 if there are 0 pageviews' do
+      metrics = build_metrics(pviews: 0)
+      expect(subject.new(metrics).previous_period).to eq 0
+    end
+
+    it 'returns 0 if there are 0 unique pageviews' do
+      metrics = build_metrics(upviews: 0)
+      expect(subject.new(metrics).previous_period).to eq 0
+    end
+
+    it 'returns nil if there are nil pageviews' do
+      metrics = build_metrics(pviews: nil)
+      expect(subject.new(metrics).previous_period).to eq nil
+    end
+
+    it 'returns nil if there are nil unique pageviews' do
+      metrics = build_metrics(upviews: nil)
+      expect(subject.new(metrics).previous_period).to eq nil
+    end
+
+    it 'returns pageviews per visit if there are pageviews and unique pageviews' do
+      metrics = build_metrics(pviews: 100, upviews: 10)
+      expect(subject.new(metrics).previous_period).to eq 10
+    end
+  end
+
+  def build_metrics(pviews: 10, upviews: 10)
+    {
+      'pviews' => {
+        value: pviews
+      },
+      'upviews' => {
+        value: upviews
+      }
+    }
+  end
+end

--- a/spec/models/calculator/trend_percentage_spec.rb
+++ b/spec/models/calculator/trend_percentage_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Calculator::TrendPercentage do
+  subject { Calculator::TrendPercentage }
+  it 'returns 0 if previous value <= 0' do
+    expect(subject.new(1, 0).run).to eq 0
+  end
+
+  it 'returns trend percentage if previous value > 0' do
+    expect(subject.new(2, 1).run).to eq 100
+  end
+end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -47,29 +47,197 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#trend_percentage' do
     it 'calculates an increase percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }, { name: 'pviews', total: 100 }]
+      current_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      previous_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 50,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        }
+      ]
 
       expect(subject.trend_percentage('upviews')).to eq(100.0)
     end
 
     it 'calculates an decrease percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 50 }, { name: 'pviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
+      current_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 50,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      previous_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        }
+      ]
 
       expect(subject.trend_percentage('upviews')).to eq(-50.0)
     end
 
     it 'calculates an no percentage change' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
+      current_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      previous_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        }
+      ]
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
 
     it 'calculates an infinite percent increase (0 to non-zero)' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: 100 }, { name: 'pviews', total: 100 }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: 0 }, { name: 'pviews', total: 100 }]
+      current_period_data[:time_series_metrics] = current_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      previous_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 0,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        }
+      ]
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
@@ -79,6 +247,58 @@ RSpec.describe SingleContentItemPresenter do
       previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: nil }]
 
       expect(subject.trend_percentage('upviews')).to eq("no comparison data")
+    end
+
+    it 'returns `no comparison data` if there is incomplete comparison data' do
+      current_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            },
+            {
+              date: '2018-11-26',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-11-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      previous_period_data[:time_series_metrics] = [
+        {
+          name: 'upviews',
+          total: 50,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        },
+        {
+          name: 'pviews',
+          total: 100,
+          time_series: [
+            {
+              date: '2018-10-25',
+              value: 100
+            }
+          ]
+        }
+      ]
+      expect(subject.trend_percentage('upviews')).to eq('no comparison data')
     end
   end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe SingleContentItemPresenter do
       current_period_data[:time_series_metrics] = time_series_metrics(100)
       previous_period_data[:time_series_metrics] = time_series_metrics(nil, nil)
 
-      expect(subject.trend_percentage('upviews')).to eq("no comparison data")
+      expect(subject.trend_percentage('upviews')).to eq(nil)
     end
 
     it 'returns `no comparison data` if there is incomplete comparison data' do
@@ -112,7 +112,7 @@ RSpec.describe SingleContentItemPresenter do
       current_period_data[:time_series_metrics] = time_series_metrics(100, current_time_series)
       previous_period_data[:time_series_metrics] = time_series_metrics(100, previous_time_series)
 
-      expect(subject.trend_percentage('upviews')).to eq('no comparison data')
+      expect(subject.trend_percentage('upviews')).to eq(nil)
     end
   end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -4,6 +4,30 @@ RSpec.describe SingleContentItemPresenter do
   let(:date_range) { build(:date_range, :last_30_days) }
   let(:current_period_data) { default_single_page_payload('the/base/path', '2018-11-25', '2018-12-25') }
   let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-25') }
+  let(:default_timeseries_metrics) {
+    [
+      {
+        name: 'upviews',
+        total: 100,
+        time_series: [
+          {
+            date: '2018-11-25',
+            value: 100
+          }
+        ]
+      },
+      {
+        name: 'pviews',
+        total: 100,
+        time_series: [
+          {
+            date: '2018-11-25',
+            value: 100
+          }
+        ]
+      }
+    ]
+  }
 
 
   around do |example|
@@ -47,257 +71,47 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#trend_percentage' do
     it 'calculates an increase percentage change' do
-      current_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        }
-      ]
-      previous_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 50,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        }
-      ]
+      current_period_data[:time_series_metrics] = time_series_metrics(100)
+      previous_period_data[:time_series_metrics] = time_series_metrics(50)
 
       expect(subject.trend_percentage('upviews')).to eq(100.0)
     end
 
     it 'calculates an decrease percentage change' do
-      current_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 50,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        }
-      ]
-      previous_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        }
-      ]
+      current_period_data[:time_series_metrics] = time_series_metrics(50)
+      previous_period_data[:time_series_metrics] = time_series_metrics(100)
 
       expect(subject.trend_percentage('upviews')).to eq(-50.0)
     end
 
     it 'calculates an no percentage change' do
-      current_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        }
-      ]
-      previous_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        }
-      ]
+      current_period_data[:time_series_metrics] = time_series_metrics(100)
+      previous_period_data[:time_series_metrics] = time_series_metrics(100)
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
 
     it 'calculates an infinite percent increase (0 to non-zero)' do
-      current_period_data[:time_series_metrics] = current_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        }
-      ]
-      previous_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 0,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        }
-      ]
+      current_period_data[:time_series_metrics] = time_series_metrics(100)
+      previous_period_data[:time_series_metrics] = time_series_metrics(0)
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
 
     it 'returns `no comparison data` if there is no comparison data' do
-      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: nil }]
-      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: nil }]
+      current_period_data[:time_series_metrics] = time_series_metrics(100)
+      previous_period_data[:time_series_metrics] = time_series_metrics(nil, nil)
 
       expect(subject.trend_percentage('upviews')).to eq("no comparison data")
     end
 
     it 'returns `no comparison data` if there is incomplete comparison data' do
-      current_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            },
-            {
-              date: '2018-11-26',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-11-25',
-              value: 100
-            }
-          ]
-        }
-      ]
-      previous_period_data[:time_series_metrics] = [
-        {
-          name: 'upviews',
-          total: 50,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        },
-        {
-          name: 'pviews',
-          total: 100,
-          time_series: [
-            {
-              date: '2018-10-25',
-              value: 100
-            }
-          ]
-        }
-      ]
+      current_time_series = [{ date: '2018-11-25', value: 100 }, { date: '2018-11-26', value: 100 }]
+      previous_time_series = [{ date: '2018-11-25', value: 100 }]
+
+      current_period_data[:time_series_metrics] = time_series_metrics(100, current_time_series)
+      previous_period_data[:time_series_metrics] = time_series_metrics(100, previous_time_series)
+
       expect(subject.trend_percentage('upviews')).to eq('no comparison data')
     end
   end
@@ -416,5 +230,25 @@ RSpec.describe SingleContentItemPresenter do
     it 'returns the downcased translation of the metric name' do
       expect(subject.link_text('upviews')).to eq('unique pageviews')
     end
+  end
+
+  def time_series_metrics(upviews_total = 100, upviews_timeseries = [{ date: '2018-11-25', value: 100 }])
+    [
+      {
+        name: 'upviews',
+        total: upviews_total,
+        time_series: upviews_timeseries
+      },
+      {
+        name: 'pviews',
+        total: 100,
+        time_series: [
+          {
+            date: '2018-11-25',
+            value: 100
+          }
+        ]
+      }
+    ]
   end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -73,6 +73,13 @@ RSpec.describe SingleContentItemPresenter do
 
       expect(subject.trend_percentage('upviews')).to eq(0.0)
     end
+
+    it 'returns `no comparison data` if there is no comparison data' do
+      current_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: nil }]
+      previous_period_data[:time_series_metrics] = [{ name: 'upviews', total: nil }, { name: 'pviews', total: nil }]
+
+      expect(subject.trend_percentage('upviews')).to eq("no comparison data")
+    end
   end
 
   describe '#searches_context' do

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -62,6 +62,13 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
+      def content_data_api_has_single_page_with_nil_values(base_path:, from:, to:)
+        query = query(from: from, to: to)
+        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        body = nil_values_in_single_page_payload(base_path, from, to).to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_has_orgs
         url = "#{content_data_api_endpoint}/organisations"
         body = { organisations: default_organisations }.to_json
@@ -300,6 +307,36 @@ module GdsApi
           edition_metrics: [
             { name: "words", value: 0 },
             { name: "pdf_count", value: 0 }
+          ]
+        }
+      end
+
+      def nil_values_in_single_page_payload(base_path, from, to)
+        {
+          metadata: {
+            title:  "Content Title",
+            base_path:  "/#{base_path}",
+            first_published_at:  "2018-07-17T10:35:59.000Z",
+            public_updated_at:  "2018-07-17T10:35:57.000Z",
+            publishing_app:  "publisher",
+            document_type:  "news_story",
+            primary_organisation_title:  "The Ministry",
+            historical: false,
+            withdrawn: false
+          },
+          time_period: { to: to, from: from },
+          time_series_metrics: [
+            { name: "upviews", total: nil, time_series: [] },
+            { name: "pviews", total: nil, time_series: [] },
+            { name: "searches", total: nil, time_series: [] },
+            { name: "feedex", total: nil, time_series: [] },
+            { name: "satisfaction", total: nil, time_series: [] },
+            { name: "useful_yes", total: nil, time_series: [] },
+            { name: "useful_no", total: nil, time_series: [] }
+          ],
+          edition_metrics: [
+            { name: "words", value: nil },
+            { name: "pdf_count", value: nil }
           ]
         }
       end


### PR DESCRIPTION
#### What
[Trello card](https://trello.com/c/a34qyfIg/786-2-page-data-display-no-data-when-there-isnt-comparison-data-available-for-a-previous-time-period)
Display 'no comparison data' when we have no previous data with which to compare current data.

Currently we display a trend percentage of 0% if we have no previous data.

#### Why
Displaying a 0% change for both an actual 0% change as well as an unknown change is incorrect and is likely to be confusing for end users who do not know which of the two scenarios that the 0% change would relate to.

#### Screenshots
### Before
<img width="1263" alt="screen shot 2018-11-05 at 12 13 43" src="https://user-images.githubusercontent.com/13124899/47997594-48a1b780-e0f4-11e8-945f-ac23364a9423.png">

### After
<img width="1193" alt="screen shot 2018-11-05 at 12 12 06" src="https://user-images.githubusercontent.com/13124899/47997611-522b1f80-e0f4-11e8-86e4-dee6b789c34e.png">

---
#### Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to trello card.
