### PR TITLE
Add formatting to table values

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -61,7 +61,7 @@
                       <tr class="govuk-table__row">
                         <th class="govuk-table__header" scope="row"><%= r[:label]  %></th>
                         <% r[:values].each do |v| %>
-                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= v %></td>
+                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter v %></td>
                         <% end %>
                       </tr>
                     <% end %>
@@ -80,7 +80,7 @@
                       <tr>
                         <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= k %></th>
                         <% rows.each do |r| %>
-                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= r[:values][i] %></td>
+                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter r[:values][i] %></td>
                         <% end %>
                       </tr>
                     <% end %>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         upviews_rows = extract_table_content(".chart.upviews table")
         expect(upviews_rows).to match_array([
           expected_table_dates,
-          ["Unique pageviews", "1000", "2000", "3000"]
+          ["Unique pageviews", "1,000", "2,000", "3,000"]
         ])
       end
 
@@ -184,7 +184,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         pviews_rows = extract_table_content(".chart.pviews table")
         expect(pviews_rows).to match_array([
           expected_table_dates,
-          %w[Pageviews 10000 20000 30000]
+          %w[Pageviews 10,000 20,000 30,000]
         ])
       end
 


### PR DESCRIPTION
The values should use a delimiter for large numbers to be more readable.

#### What
This change formats the numbers to use locale based format delimiters.

#### Why
Number in tables do not display with delimiter. 

#### Screenshots
##### Before
![screenshot at nov 05 2-01-12 pm](https://user-images.githubusercontent.com/424772/48002379-4f83f680-e103-11e8-92e1-9f0f3bcb7728.png)

##### After
![screenshot at nov 05 2-00-34 pm](https://user-images.githubusercontent.com/424772/48002368-4abf4280-e103-11e8-99a1-866f8411aa27.png)



---
#### Review Checklist
* [x] Changes in scope.
* [x] Added/updated feature tests.
* [x] Added to trello card.
