### PR TITLE
Re-enable test

### DIFF
--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.glance-metric.searches', text: '24'
       end
 
-      xit 'renders glance metric context for on page searches' do
-        expect(page).to have_selector '.glance-metric.searches', text: '50%'
+      it 'renders glance metric context for on page searches' do
+        expect(page).to have_selector '.glance-metric.searches', text: '4.05%'
       end
 
       it 'renders trend percentage for page searches' do


### PR DESCRIPTION
I must have rebased badly in the past.

#### What
There was a spec disabled among the feature tests. It seems to have been from a WIP commit.

#### Why
We should enable and fix our feature tests to ensure good coverage.
