### PR TITLE
Remove placeholder text for unique pageviews

### DIFF
--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -86,7 +86,7 @@
   <%= render "glance_metric",
       metric_name: "upviews",
       total: @performance_data.total_upviews,
-      context: @performance_data.upviews_context %>
+      context: nil %>
 
   <%= render "glance_metric",
       metric_name: "satisfaction",

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -45,10 +45,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector '.glance-metric.upviews', text: '6,000'
       end
 
-      it 'renders glance metric context for unique pageviews' do
-        expect(page).to have_selector '.glance-metric.upviews', text: '2.74%'
-      end
-
       it 'renders trend percentage for unique pageviews' do
         expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: '+500.00%'
       end


### PR DESCRIPTION
#### What
Remove placeholder text in glance metrics for Unique Pageviews.

#### Why
Figures for percentage of value against the whole of an organisation's
is descoped for private beta.

#### Screenshots
##### Before
<img width="222" alt="screenshot at nov 05 4-06-33 pm" src="https://user-images.githubusercontent.com/424772/48010066-c970ab80-e114-11e8-99b8-2e9ef89ec193.png">

##### After
<img width="226" alt="screenshot at nov 05 4-06-15 pm" src="https://user-images.githubusercontent.com/424772/48010083-cd9cc900-e114-11e8-881b-6bbb17168ff9.png">

---
#### Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated feature tests.
* [ ] Added to trello card.
