### PR TITLE
Remove placeholder download links on single page

### DIFF
--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -11,9 +11,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
-    <a href="" class="govuk-link govuk-body-s"><%= t ".download_link", metric_name: @performance_data.link_text(metric_name) %></a>
-  </div>
-  <div class="govuk-grid-column-one-half">
     <% if external_link %>
       <a href="<%= external_link %>" class="govuk-link govuk-body-s"><%= t "metrics.#{metric_name}.external_link" %></a>
     <% end %>


### PR DESCRIPTION
## What
Remove the placeholder Download links for each metric on the single page performance page.

## Why
Deprioritising for private beta, as we are no longer sure this feature
is appropriate.

## Screenshots
### Before
![screenshot at nov 05 4-53-55 pm](https://user-images.githubusercontent.com/424772/48013063-68000b00-e11b-11e8-955a-8404b0cc7456.png)


### After
![screenshot at nov 05 4-53-28 pm](https://user-images.githubusercontent.com/424772/48013081-70584600-e11b-11e8-96c4-522a1bfbe9fa.png)


---
## Review Checklist
* [ ] Changes in scope.
* [ ] Added to trello card.
