### PR TITLE
Add spring-commands-rspec gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,5 +32,6 @@ group :development, :test do
   gem "govuk-lint", "~> 3"
   gem 'pry'
   gem "rspec-rails", "~> 3"
+  gem "spring-commands-rspec"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,6 +317,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    spring (2.0.2)
+      activesupport (>= 4.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -377,6 +381,7 @@ DEPENDENCIES
   rails (~> 5.2)
   rspec-rails (~> 3)
   simplecov (~> 0.16)
+  spring-commands-rspec
   timecop (~> 0.9.1)
   uglifier (~> 4)
   webmock
@@ -385,4 +390,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/bin/rails
+++ b/bin/rails
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative '../config/boot'
 require 'rails/commands'

--- a/bin/rake
+++ b/bin/rake
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 require_relative '../config/boot'
 require 'rake'
 Rake.application.run

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,4 +1,9 @@
 #!/usr/bin/env ruby
+begin
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
+end
 # frozen_string_literal: true
 
 #

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# This file loads spring without using Bundler, in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+unless defined?(Spring)
+  require 'rubygems'
+  require 'bundler'
+
+  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
+  spring = lockfile.specs.detect { |spec| spec.name == "spring" }
+  if spring
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem 'spring', spring.version
+    require 'spring/binstub'
+  end
+end


### PR DESCRIPTION
I had wrongly assumed in 63971e15c316e941287079ad06147d9660fa2458 that
this allowed me to just run rspec. Since upgrading local ruby version
I've realised I must have installed rspec globally. This also adds other
binstubs for running rake and rails commands via spring.

Note: I also have a this local alias:

`alias rspec=./bin/rspec`
