### PR TITLE
Update index page to match design

### DIFF
--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -6,4 +6,9 @@
 
 .app-c-time-select--compact {
   border-top: 0;
+  @include govuk-font(16);
+}
+
+.govuk-details__summary {
+  @include govuk-font(16);
 }

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -12,9 +12,48 @@
   }
 }
 
+.govuk-table--sortable {
+  outline: none;
+}
+
 .table-header__param {
   @include govuk-font($size: 19, $weight: bold);
+}
 
+.govuk-table {
+  background-color: $white;
+}
+
+.govuk-table__header {
+  @include govuk-font(16);
+  outline: 1px solid $govuk-border-colour;
+}
+
+.govuk-table__body {
+  outline: 1px solid $govuk-border-colour;
+}
+
+.govuk-table__cell {
+  @include govuk-font(16);
+}
+
+.govuk-table__header {
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+}
+
+.gem-c-layout-for-admin .govuk-grid-row {
+  margin: 0;
+}
+
+.govuk-table__cell {
+  padding-right: 15px;
+}
+
+.table-wrapper {
+  min-width: 1000px;
+  background-color: $white;
 }
 
 .filter-form {
@@ -35,6 +74,15 @@
 
 .filter-form__filters {
   @include govuk-responsive-padding(3, "top");
+
+  .govuk-label {
+    @include govuk-font(16);
+  }
+
+  .govuk-select {
+    @include govuk-font(16);
+  }
+
 }
 
 .filters-control {

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,6 +1,13 @@
 class ContentController < ApplicationController
   include PaginationHelper
 
+  layout 'application'
+  before_action :set_constants
+
+  def set_constants
+    @fullwidth = true
+  end
+
   def index
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -9,6 +9,7 @@
         <span class="filters-control filters-control--show govuk-visually-hidden">
           <a href="" class="govuk-link filters-control__link filters-control__link--show">Show filters</a>&nbsp;&#x25BC;</span>
       </div>
+      <div class="filter-form">
         <%= form_tag content_path, method: 'get', name: 'organisation-picker' do %>
           <%= render "components/time-select", {
             current_selection: @presenter.time_period,
@@ -49,7 +50,6 @@
           } %>
           <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
-          <%# selects will be switched out for the accessible autocomplete component eventually, but use this in the meantime %>
           <div class="filter-form__filters">
             <%= render "govuk_publishing_components/components/select", {
               id: "organisation_id",
@@ -72,51 +72,53 @@
 
             <%= render "govuk_publishing_components/components/button", {text: "Filter"} %>
           <% end %>
+        </div>
 
             <p><a href="/content" class="govuk-link govuk-body-s">Clear filters</a></p>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
-            <p><a href="" class="govuk-link govuk-body-s">Download all data in CSV format</a></p>
+            <%# implement later: <p><a href="" class="govuk-link govuk-body-s">Download all data in CSV format</a></p> %>
 
         </div>
     </div>
     <div class="govuk-grid-column-three-quarters">
-      <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
-          self,
-          '<h2 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h2>'.html_safe,
-          sortable: true
-        ) do |t| %>
-          <%= t.head do %>
-            <!-- TODO: Once sorting is supported, fill in the href and sort_direction header arguments with proper values -->
-            <%= t.header("Page title", href: '#', sort_direction: nil) %>
-            <%= t.header("Content type", href: '#', sort_direction: nil) %>
-            <%= t.header("Unique pageviews", href: '#', sort_direction: 'descending') %>
-            <%= t.header("User satisfaction score", href: '#', sort_direction: nil) %>
-            <%= t.header("Searches from page", href: '#', sort_direction: nil) %>
-          <% end %>
+      <div class="table-wrapper">
+        <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
+            self,
+            '<h1 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h1>'.html_safe,
+            sortable: true
+          ) do |t| %>
+            <%= t.head do %>
+              <!-- TODO: Once sorting is supported, fill in the href and sort_direction header arguments with proper values -->
+              <%= t.header("Page title", href: '#', sort_direction: nil) %>
+              <%= t.header("Content type", href: '#', sort_direction: nil) %>
+              <%= t.header("Unique pageviews", href: '#', sort_direction: 'descending') %>
+              <%= t.header("User satisfaction score", href: '#', sort_direction: nil) %>
+              <%= t.header("Searches from page", href: '#', sort_direction: nil) %>
+            <% end %>
 
-          <%= t.body do %>
-            <% @presenter.content_items.each do |item| %>
-              <%= t.row do %>
-                <%= t.cell(
-                  render(
-                    partial: 'page_title',
-                    locals: {
-                      item: item,
-                      date_range: @presenter.time_period
-                    }
-                  )
-                ) %>
-                <%= t.cell item.document_type %>
-                <%= t.cell number_with_delimiter(item.upviews, delimiter: ',') %>
-                <%= t.cell item.user_satisfaction %>
-                <%= t.cell item.searches %>
+            <%= t.body do %>
+              <% @presenter.content_items.each do |item| %>
+                <%= t.row do %>
+                  <%= t.cell(
+                    render(
+                      partial: 'page_title',
+                      locals: {
+                        item: item,
+                        date_range: @presenter.time_period
+                      }
+                    )
+                  ) %>
+                  <%= t.cell item.document_type %>
+                  <%= t.cell number_with_delimiter(item.upviews, delimiter: ','), format: 'numeric' %>
+                  <%= t.cell item.user_satisfaction %>
+                  <%= t.cell item.searches, format: 'numeric' %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>
-        <% end %>
-        <%# documented at /component-guide/previous_and_next_navigation within this app - on first/last page we would need to only render the single relevant link %>
+        </div>
         <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
     </div>
 </div>


### PR DESCRIPTION
https://trello.com/c/QnkuOdxM/825-3-build-index-page-to-match-designs-including-mobile-views

This brings the index page more in line with the designs, including:

- Adjusting the page to go full browser width
- Putting a fixed width on the table to avoid wrapping (will be iterated on in future as it currently breaks outside page width and is a bit weird, but works)
- Changing font sizes and adjusting padding
- Labelling numeric cells so they gain right-alignment


# Screenshot

![screen shot 2018-11-08 at 09 22 23](https://user-images.githubusercontent.com/31649453/48189334-d6b9b000-e337-11e8-88f5-4cf589ebc6e9.png)
