### PR TITLE
Guard against missing data to avoid layout breaking

### DIFF
--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,31 +1,37 @@
 <%
-    published_at ||= ""
-    last_updated ||= ""
-    publishing_organisation ||= ""
-    document_type ||= ""
-    base_path ||= ""
-    status ||= ""
+    published_at ||= nil
+    last_updated ||= nil
+    publishing_organisation ||= nil
+    document_type ||= nil
+    base_path ||= nil
+    status ||= nil
 %>
 
 <div class="app-c-metadata govuk-body govuk-body-xs">
-  <% if status != "" %>
+  <% if status %>
     <dl class="app-c-metadata__list">
       <dt class="app-c-metadata__title"><%= t ".labels.status" %></dt>
       <dd class="app-c-metadata__description govuk-!-font-weight-bold"><%= status %></dd>
     </dl>
   <% end %>
   <dl class="app-c-metadata__list">
-    <dt class="app-c-metadata__title"><%= t ".labels.published_at" %></dt>
-    <dd class="app-c-metadata__description"><%= published_at %></dd>
-    <dt class="app-c-metadata__title"><%= t ".labels.last_updated" %></dt>
-    <dd class="app-c-metadata__description"><%= last_updated %></dd>
+    <% if published_at %>
+      <dt class="app-c-metadata__title"><%= t ".labels.published_at" %></dt>
+      <dd class="app-c-metadata__description"><%= published_at %></dd>
+    <% end %>
+    <% if last_updated %>
+      <dt class="app-c-metadata__title"><%= t ".labels.last_updated" %></dt>
+      <dd class="app-c-metadata__description"><%= last_updated %></dd>
+    <% end %>
   </dl>
   <dl class="app-c-metadata__list">
-    <dt class="app-c-metadata__title"><%= t ".labels.publishing_organisation" %></dt>
-    <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>
+    <% if publishing_organisation %>
+      <dt class="app-c-metadata__title"><%= t ".labels.publishing_organisation" %></dt>
+      <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>
+    <% end %>
     <dt class="app-c-metadata__title"><%= t ".labels.document_type" %></dt>
     <dd class="app-c-metadata__description"><%= document_type %></dd>
     <dt class="app-c-metadata__title app-c-metadata__title--wrappable"><%= t ".labels.base_path" %></dt>
-    <dd class="app-c-metadata__description"><% if base_path != "" %>gov.uk<%= base_path %><% end %></dd>
+    <dd class="app-c-metadata__description">gov.uk<%= base_path %></dd>
   </dl>
 </div>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -30,16 +30,28 @@ RSpec.describe "Metadata", type: :view do
     assert_select ".app-c-metadata__description", text: "gov.uk/government/publications/visitor-visa-guide-to-supporting-documents"
   end
 
-  it "renders blank values for expected fields when data items aren't provided" do
-    data = false
-    render_component(data)
-    assert_select ".app-c-metadata__description", text: "", count: 5
-  end
-
-  it "does not render status info when a status is not supplied" do
+  it "does not render the 'status' fields when data is not supplied" do
     data[:status] = false
     render_component(data)
-    assert_select ".app-c-metadata__title", text: "Status", count: 0
+    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.status"), count: 0
+  end
+
+  it "does not render the 'updated' fields when data is not supplied" do
+    data[:last_updated] = false
+    render_component(data)
+    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.last_updated"), count: 0
+  end
+
+  it "does not render the 'published' fields when data is not supplied" do
+    data[:published_at] = false
+    render_component(data)
+    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.published_at"), count: 0
+  end
+
+  it "does not render the 'organisation' fields when data is not supplied" do
+    data[:publishing_organisation] = false
+    render_component(data)
+    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.publishing_organisation"), count: 0
   end
 
   def render_component(locals)


### PR DESCRIPTION
# What
https://trello.com/c/eJtCoZ3g/826-page-data-fix-formatting-of-metadata-when-we-have-no-value-for-primary-publishing-organisation
Guards against empty metadata items and renders nothing for blank fields

# Why
Layout currently breaks when the value is empty

# Screenshots

## Before
![screen shot 2018-11-08 at 15 25 02](https://user-images.githubusercontent.com/31649453/48208455-bb1bcd00-e36a-11e8-88c9-990b1eb5356b.png)

## After

![screen shot 2018-11-08 at 15 25 18](https://user-images.githubusercontent.com/31649453/48208484-d2f35100-e36a-11e8-8da4-51fefe28e5ec.png)
