### PR TITLE
Time periods start yesterday

### DIFF
--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -2,7 +2,7 @@ class DateRange
   attr_reader :time_period, :to, :from
 
   def initialize(time_period, relative_date = nil)
-    relative_date = relative_date || Time.zone.today
+    relative_date = relative_date || Time.zone.yesterday
 
     @time_period = time_period
     @to = date_to_range(relative_date, time_period)[:to]

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -19,7 +19,7 @@
               {
                 value: "last-30-days",
                 text: t("metrics.show.time_periods.last-30-days.leading"),
-                hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+                hint_text:  "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "last-month",
@@ -29,22 +29,22 @@
               {
                 value: "last-3-months",
                 text: t("metrics.show.time_periods.last-3-months.leading"),
-                hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+                hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "last-6-months",
                 text: t("metrics.show.time_periods.last-6-months.leading"),
-                hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+                hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "last-year",
                 text: t("metrics.show.time_periods.last-year.leading"),
-                hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+                hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "last-2-years",
                 text: t("metrics.show.time_periods.last-2-years.leading"),
-                hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+                hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               }
             ]
           } %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -51,7 +51,7 @@
       {
         value: "last-30-days",
         text: t(".time_periods.last-30-days.leading"),
-        hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+        hint_text:  "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "last-month",
@@ -61,22 +61,22 @@
       {
         value: "last-3-months",
         text: t(".time_periods.last-3-months.leading"),
-        hint_text: "#{3.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+        hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "last-6-months",
         text: t(".time_periods.last-6-months.leading"),
-        hint_text: "#{6.months.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+        hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "last-year",
         text: t(".time_periods.last-year.leading"),
-        hint_text: "#{1.year.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+        hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "last-2-years",
         text: t(".time_periods.last-2-years.leading"),
-        hint_text: "#{2.years.ago.strftime("%-d %B %Y")} to #{Date.today.strftime("%-d %B %Y")}"
+        hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       }
     ]
   } %>

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -22,12 +22,12 @@ RSpec.describe 'date selection', type: :feature do
         { el.find('label').text => el.find('span').text }
       end
       expect(time_labels).to match([
-        { I18n.t('metrics.show.time_periods.last-30-days.leading') => "25 November 2018 to 25 December 2018" },
+        { I18n.t('metrics.show.time_periods.last-30-days.leading') => "24 November 2018 to 24 December 2018" },
         { I18n.t('metrics.show.time_periods.last-month.leading') => "1 November 2018 to 30 November 2018" },
-        { I18n.t('metrics.show.time_periods.last-3-months.leading') => "25 September 2018 to 25 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-6-months.leading') => "25 June 2018 to 25 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-year.leading') => "25 December 2017 to 25 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-2-years.leading') => "25 December 2016 to 25 December 2018" },
+        { I18n.t('metrics.show.time_periods.last-3-months.leading') => "24 September 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.last-6-months.leading') => "24 June 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.last-year.leading') => "24 December 2017 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.last-2-years.leading') => "24 December 2016 to 24 December 2018" },
       ])
     end
 

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -33,13 +33,13 @@ RSpec.describe 'date selection', type: :feature do
 
     it 'renders data for the last 30 days' do
       visit page_uri
-      expect_upviews_table_to_contain_dates(['11-25', '11-26', '12-25'])
+      expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
     end
   end
 
   it 'renders data for the last 30 days when `Past 30 days` is selected' do
     visit_page_and_filter_by_date_range('last-30-days')
-    expect_upviews_table_to_contain_dates(['11-25', '11-26', '12-25'])
+    expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
   end
 
   it 'renders data for the previous month when `Past month` is selected' do
@@ -51,25 +51,25 @@ RSpec.describe 'date selection', type: :feature do
   it 'renders data for the last 3 months when `Past 3 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_3_months)
     visit_page_and_filter_by_date_range('last-3-months')
-    expect_upviews_table_to_contain_dates(['09-25', '09-26', '12-25'])
+    expect_upviews_table_to_contain_dates(['09-24', '09-25', '12-24'])
   end
 
   it 'renders data for the last 6 months when `Past 6 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_6_months)
     visit_page_and_filter_by_date_range('last-6-months')
-    expect_upviews_table_to_contain_dates(['06-25', '06-26', '12-25'])
+    expect_upviews_table_to_contain_dates(['06-24', '06-25', '12-24'])
   end
 
   it 'renders data for the last year when `Past year` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_year)
     visit_page_and_filter_by_date_range('last-year')
-    expect_upviews_table_to_contain_dates(['12-25', '12-26', '12-25'])
+    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
   end
 
   it 'renders data for the last 2 years when `Past 2 years` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_2_years)
     visit_page_and_filter_by_date_range('last-2-years')
-    expect_upviews_table_to_contain_dates(['12-25', '12-26', '12-25'])
+    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
   end
 
   def visit_page_and_filter_by_date_range(date_range)

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -60,8 +60,8 @@ RSpec.describe '/content' do
     end
 
     it 'respects the date filter' do
-      from = (Time.zone.today - 1.year).to_s('%F')
-      to = Time.zone.today.to_s('%F')
+      from = (Time.zone.yesterday - 1.year).to_s('%F')
+      to = Time.zone.yesterday.to_s('%F')
       stub_metrics_page(base_path: 'path/1', time_period: :last_year)
       content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
 
@@ -93,8 +93,8 @@ RSpec.describe '/content' do
     end
 
     it 'respects date range' do
-      from = (Time.zone.today - 1.year).to_s('%F')
-      to = Time.zone.today.to_s('%F')
+      from = (Time.zone.yesterday - 1.year).to_s('%F')
+      to = Time.zone.yesterday.to_s('%F')
       stub_metrics_page(base_path: 'path/1', time_period: :last_year)
       content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
-  let(:prev_from) { Time.zone.today - 60.days }
-  let(:from) { Time.zone.today - 30.days }
-  let(:to) { Time.zone.today }
+  let(:prev_from) { Time.zone.yesterday - 60.days }
+  let(:from) { Time.zone.yesterday - 30.days }
+  let(:to) { Time.zone.yesterday }
 
   around do |example|
     Timecop.freeze Date.new(2018, 12, 25) do
@@ -87,7 +87,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     describe 'page metric section' do
-      let(:expected_table_dates) { ['', '11-25', '11-26', '12-25'] }
+      let(:expected_table_dates) { ['', '11-24', '11-25', '12-24'] }
 
       it 'renders the metric for upviews' do
         expect(page).to have_selector '.metric-summary__upviews', text: '6,000'

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe DateRange do
   describe 'for last 30 days' do
     let(:time_period) { 'last-30-days' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-25') }
-      it { is_expected.to have_attributes(from: '2018-11-25') }
+      it { is_expected.to have_attributes(to: '2018-12-24') }
+      it { is_expected.to have_attributes(from: '2018-11-24') }
       it { is_expected.to have_attributes(time_period: 'last-30-days') }
     end
 
@@ -29,8 +29,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-11-25') }
-      it { is_expected.to have_attributes(from: '2018-10-26') }
+      it { is_expected.to have_attributes(to: '2018-11-24') }
+      it { is_expected.to have_attributes(from: '2018-10-25') }
       it { is_expected.to have_attributes(time_period: 'last-30-days') }
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe DateRange do
   describe 'for last month' do
     let(:time_period) { 'last-month' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-11-30') }
@@ -68,11 +68,11 @@ RSpec.describe DateRange do
   describe 'for last 3 months' do
     let(:time_period) { 'last-3-months' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-25') }
-      it { is_expected.to have_attributes(from: '2018-09-25') }
+      it { is_expected.to have_attributes(to: '2018-12-24') }
+      it { is_expected.to have_attributes(from: '2018-09-24') }
       it { is_expected.to have_attributes(time_period: 'last-3-months') }
     end
 
@@ -89,8 +89,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-09-25') }
-      it { is_expected.to have_attributes(from: '2018-06-25') }
+      it { is_expected.to have_attributes(to: '2018-09-24') }
+      it { is_expected.to have_attributes(from: '2018-06-24') }
       it { is_expected.to have_attributes(time_period: 'last-3-months') }
     end
   end
@@ -98,11 +98,11 @@ RSpec.describe DateRange do
   describe 'for last 6 months' do
     let(:time_period) { 'last-6-months' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-25') }
-      it { is_expected.to have_attributes(from: '2018-06-25') }
+      it { is_expected.to have_attributes(to: '2018-12-24') }
+      it { is_expected.to have_attributes(from: '2018-06-24') }
       it { is_expected.to have_attributes(time_period: 'last-6-months') }
     end
 
@@ -119,8 +119,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2017-12-25') }
+      it { is_expected.to have_attributes(to: '2018-06-24') }
+      it { is_expected.to have_attributes(from: '2017-12-24') }
       it { is_expected.to have_attributes(time_period: 'last-6-months') }
     end
   end
@@ -128,11 +128,11 @@ RSpec.describe DateRange do
   describe 'for last year' do
     let(:time_period) { 'last-year' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-25') }
-      it { is_expected.to have_attributes(from: '2017-12-25') }
+      it { is_expected.to have_attributes(to: '2018-12-24') }
+      it { is_expected.to have_attributes(from: '2017-12-24') }
       it { is_expected.to have_attributes(time_period: 'last-year') }
     end
 
@@ -149,8 +149,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2017-12-25') }
-      it { is_expected.to have_attributes(from: '2016-12-25') }
+      it { is_expected.to have_attributes(to: '2017-12-24') }
+      it { is_expected.to have_attributes(from: '2016-12-24') }
       it { is_expected.to have_attributes(time_period: 'last-year') }
     end
   end
@@ -158,11 +158,11 @@ RSpec.describe DateRange do
   describe 'for last 2 year' do
     let(:time_period) { 'last-2-years' }
 
-    describe 'relative to today' do
+    describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-25') }
-      it { is_expected.to have_attributes(from: '2016-12-25') }
+      it { is_expected.to have_attributes(to: '2018-12-24') }
+      it { is_expected.to have_attributes(from: '2016-12-24') }
       it { is_expected.to have_attributes(time_period: 'last-2-years') }
     end
 
@@ -179,8 +179,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2016-12-25') }
-      it { is_expected.to have_attributes(from: '2014-12-25') }
+      it { is_expected.to have_attributes(to: '2016-12-24') }
+      it { is_expected.to have_attributes(from: '2014-12-24') }
       it { is_expected.to have_attributes(time_period: 'last-2-years') }
     end
   end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe ChartPresenter do
   end
 
   it 'returns start date' do
-    expect(subject.from).to eq '2018-01-01'
+    expect(subject.from).to eq '2017-12-31'
   end
   it 'returns end date' do
-    expect(subject.to).to eq '2018-01-31'
+    expect(subject.to).to eq '2018-01-30'
   end
 
   it 'returns the correct message for no data' do
@@ -39,7 +39,7 @@ RSpec.describe ChartPresenter do
 
   def upviews_chart_data
     {
-      caption: "Unique pageviews from 2018-01-01 to 2018-01-31",
+      caption: "Unique pageviews from 2017-12-31 to 2018-01-30",
       chart_id: "upviews_chart",
       chart_label: "Unique pageviews",
       keys: [

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe SingleContentItemPresenter do
   describe '#feedback_explorer_href' do
     it 'returns a URI for the feedback explorer' do
       host = Plek.new.external_url_for('support')
-      expected_link = "#{host}/anonymous_feedback?from=2018-05-02&to=2018-06-01&paths=%2Fthe%2Fbase%2Fpath"
+      expected_link = "#{host}/anonymous_feedback?from=2018-05-01&to=2018-05-31&paths=%2Fthe%2Fbase%2Fpath"
       expect(subject.feedback_explorer_href).to eq(expected_link)
     end
   end


### PR DESCRIPTION
# What
Change date ranges so that the range ends `yesterday` rather than `today`

# Why
We get data every day for the previous day's data. This means we never have `today`'s data. This has become an issue when comparing previous periods to the current period as we have one day less than is expected in the current period.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
