### PR TITLE
Fix last-month comparison data bug

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -220,10 +220,7 @@ private
     return true if no_previous_timeseries?(previous_value)
     return incomplete_last_month_data?(previous_value) if @date_range.time_period == 'last-month'
 
-    current_timeseries_length = length_of_timeseries(current_value[:time_series])
-    previous_time_series_length = length_of_timeseries(previous_value[:time_series])
-
-    current_timeseries_length != previous_time_series_length
+    current_value[:time_series].length != previous_value[:time_series].length
   end
 
   def no_previous_timeseries?(previous_value)
@@ -238,10 +235,6 @@ private
     previous_date = @previous_metrics['upviews'][:time_series].first[:date].to_date
     days_in_month = Time.days_in_month(previous_date.month, previous_date.year)
     days_in_month != previous_value[:time_series].length
-  end
-
-  def length_of_timeseries(time_series)
-    (time_series.last[:date].to_date - time_series.first[:date].to_date).to_i
   end
 
   def format_date(date_str)

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -218,6 +218,7 @@ private
   def incomplete_previous_data?(current_value, previous_value, metric_name)
     return incomplete_previous_pageviews_per_visit_data? if metric_name == 'pageviews_per_visit'
     return true if no_previous_timeseries?(previous_value)
+    return incomplete_last_month_data?(previous_value) if @date_range.time_period == 'last-month'
 
     current_timeseries_length = length_of_timeseries(current_value[:time_series])
     previous_time_series_length = length_of_timeseries(previous_value[:time_series])
@@ -231,6 +232,12 @@ private
 
   def incomplete_previous_pageviews_per_visit_data?
     incomplete_previous_data?(@metrics['pviews'], @previous_metrics['pviews'], 'pviews') && incomplete_previous_data?(@metrics['upviews'], @previous_metrics['upviews'], 'upviews')
+  end
+
+  def incomplete_last_month_data?(previous_value)
+    previous_date = @previous_metrics['upviews'][:time_series].first[:date].to_date
+    days_in_month = Time.days_in_month(previous_date.month, previous_date.year)
+    days_in_month != previous_value[:time_series].length
   end
 
   def length_of_timeseries(time_series)


### PR DESCRIPTION
### What?

[Trello card](https://trello.com/c/a34qyfIg/786-3-page-data-display-no-data-when-there-isnt-comparison-data-available-for-a-previous-time-period#)

Fix trends in the at a glance section of the single page data page for the `past-month` date range.

### Why?

At a glance trends currentl returns `no comparison data` when the
date period `last-month` is selected. This is because we checked for
complete data based on the number of days in each month being the
same. Obviously this is not the case.

This PR changes the logic for the `past-month` date range in order to
check that the previous month has data for each day in the month,
regardless of the length of the month and regardless of how many
days are in the current month.

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before

## After


---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [x] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
