### PR TITLE
Add the organisation_slug for the current user to the dataLayer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,9 @@
   <%= javascript_include_tag "application" %>
 
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+    <script>
+      dataLayer = [{ 'user-organisation': '<%= current_user.organisation_slug %>' }];
+    </script>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],


### PR DESCRIPTION
# What
Add the organisation_slug for the current user to the dataLayer

# Why
So that it's picked up and recorded in Google Analytics. This is a
copy of the functionality in Content Publisher.

https://trello.com/c/dR47oQfR/828-2-page-data-and-index-page-add-the-user-account-organisation-to-the-gtm-data-layer

---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
