### PR TITLE
Fix position of 'All document types' in filter options

### DIFF
--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -26,18 +26,19 @@ class ContentItemsPresenter
   end
 
   def document_type_options
-    types = @document_types.map do |document_type|
-      {
-        text: document_type.try(:tr, '_', ' ').try(:capitalize),
-        value: document_type,
-        selected: document_type == @search_parameters[:document_type]
-      }
-    end
-    types.push(
+    types = [{
       text: 'All document types',
       value: '',
       selected: @search_parameters[:document_type] == ''
-    )
+    }]
+    @document_types.each do |document_type|
+      types.push(
+        text: document_type.try(:tr, '_', ' ').try(:capitalize),
+        value: document_type,
+        selected: document_type == @search_parameters[:document_type]
+      )
+    end
+    types
   end
 
   def organisation_options

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe ContentItemsPresenter do
     context 'when valid document type in parameter' do
       it 'formats the document types for the options component' do
         expect(subject.document_type_options).to eq([
+          { text: 'All document types', value: '', selected: false },
           { text: 'Case study', value: 'case_study', selected: false },
           { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: true },
-          { text: 'All document types', value: '', selected: false }
+          { text: 'News story', value: 'news_story', selected: true }
         ])
       end
     end
@@ -44,10 +44,10 @@ RSpec.describe ContentItemsPresenter do
       before { search_parameters[:document_type] = '' }
       it 'formats the document types for the options component' do
         expect(subject.document_type_options).to eq([
+          { text: 'All document types', value: '', selected: true },
           { text: 'Case study', value: 'case_study', selected: false },
           { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: false },
-          { text: 'All document types', value: '', selected: true }
+          { text: 'News story', value: 'news_story', selected: false }
         ])
       end
     end


### PR DESCRIPTION
# What
Make 'All document types' the first option in select dropdown in the filter for the content page.

# Why
Typical position a user would look for the 'All documents types' option

# Screenshots
## After
![image](https://user-images.githubusercontent.com/11051676/48492471-be5b0100-e821-11e8-9463-33dd19bbc658.png)


---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
