### PR TITLE
Fix satisfaction responses bug

### DIFF
--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -6,7 +6,7 @@ class ContentRowPresenter
     @base_path = format_base_path(data[:base_path])
     @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
     @upviews = data[:upviews]
-    @user_satisfaction = format_satisfaction(data[:satisfaction], data[:satisfaction_responses])
+    @user_satisfaction = format_satisfaction(data[:satisfaction], data[:satisfaction_score_responses])
     @searches = data[:searches]
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe '/content' do
         upviews: 233_018,
         document_type: 'news_story',
         satisfaction: 0.81301,
-        satisfaction_responses: 250,
+        satisfaction_score_responses: 250,
         searches: 220
       },
       {
@@ -21,7 +21,7 @@ RSpec.describe '/content' do
         upviews: 100_018,
         document_type: 'guide',
         satisfaction: 0.68,
-        satisfaction_responses: 42,
+        satisfaction_score_responses: 42,
         searches: 12
       }
     ]
@@ -163,7 +163,7 @@ RSpec.describe '/content' do
           upviews: 233_018,
           document_type: 'press_release',
           satisfaction: 0.81301,
-          satisfaction_responses: 250,
+          satisfaction_score_responses: 250,
           searches: 220
         },
         {
@@ -172,7 +172,7 @@ RSpec.describe '/content' do
           upviews: 100_018,
           document_type: 'news_story',
           satisfaction: 0.68,
-          satisfaction_responses: 42,
+          satisfaction_score_responses: 42,
           searches: 12
         }
       ]

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ContentRowPresenter do
       title: 'a title',
       upviews: 200_001,
       satisfaction: 0.801001,
-      satisfaction_responses: 301,
+      satisfaction_score_responses: 301,
     }
   end
 


### PR DESCRIPTION
# What
[Trello card](https://trello.com/c/FVwAMbMc/837-2-index-page-add-number-of-responses)
We were not showing the number of responses to user satisfaction surveys
in our UI. This PR allows us to show the number of responses.


# Why
The problem was caused by us referencing `satisfaction_responses` when
in the api response the correct key is `satisfaction_score_responses`.

This PR corrects this error and updates the tests to reflect this.

<img width="844" alt="screen shot 2018-11-14 at 15 55 49" src="https://user-images.githubusercontent.com/13124899/48494439-c9b02b80-e825-11e8-9b19-bd448eeabb14.png">

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
