### PR TITLE
Show full selected date range in charts

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -35,20 +35,33 @@ class ChartPresenter
   end
 
   def keys
-    return [] unless time_series
-
-    time_series.map do |point|
-      point[:date].to_date.strftime("%m-%d")
-    end
+    padded_time_series.map { |h| h[:date] }
   end
 
   def values
-    return [] unless time_series
-
-    time_series.map { |point| format_metric_value(metric, point[:value]) }
+    padded_time_series.map { |h| h[:value] }
   end
 
 private
+
+  def padded_time_series
+    @padded_time_series ||= (from.to_date..to.to_date).map do |date|
+      date_str = date.strftime("%m-%d")
+      { date: date_str, value: time_series_hash[date_str] || nil }
+    end
+  end
+
+  def time_series_hash
+    return [] unless time_series
+    @time_series_hash ||= create_time_series_hash
+  end
+
+  def create_time_series_hash
+    pairs = time_series.map do |point|
+      [point[:date].to_date.strftime("%m-%d"), format_metric_value(metric, point[:value])]
+    end
+    pairs.to_h
+  end
 
   def human_friendly_metric
     I18n.t "metrics.#{metric}.title"

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -33,43 +33,52 @@ RSpec.describe 'date selection', type: :feature do
 
     it 'renders data for the last 30 days' do
       visit page_uri
-      expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
+      expect_upviews_table_to_contain_dates(date_labels(Date.new(2018, 11, 24), Date.new(2018, 12, 24)))
     end
   end
 
   it 'renders data for the last 30 days when `Past 30 days` is selected' do
     visit_page_and_filter_by_date_range('last-30-days')
-    expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2018, 11, 24), Date.new(2018, 12, 24)))
+    expect_upviews_table_to_contain_values(pad_values(['1,000', '2,000'], 28, ['3,000']))
   end
 
   it 'renders data for the previous month when `Past month` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_month)
     visit_page_and_filter_by_date_range('last-month')
-    expect_upviews_table_to_contain_dates(['11-01', '11-02', '11-30'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2018, 11, 1), Date.new(2018, 11, 30)))
   end
 
   it 'renders data for the last 3 months when `Past 3 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_3_months)
     visit_page_and_filter_by_date_range('last-3-months')
-    expect_upviews_table_to_contain_dates(['09-24', '09-25', '12-24'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2018, 9, 24), Date.new(2018, 12, 24)))
   end
 
   it 'renders data for the last 6 months when `Past 6 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_6_months)
     visit_page_and_filter_by_date_range('last-6-months')
-    expect_upviews_table_to_contain_dates(['06-24', '06-25', '12-24'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2018, 6, 24), Date.new(2018, 12, 24)))
   end
 
   it 'renders data for the last year when `Past year` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_year)
     visit_page_and_filter_by_date_range('last-year')
-    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2017, 12, 24), Date.new(2018, 12, 24)))
   end
 
   it 'renders data for the last 2 years when `Past 2 years` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_2_years)
     visit_page_and_filter_by_date_range('last-2-years')
-    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
+    expect_upviews_table_to_contain_dates(date_labels(Date.new(2016, 12, 24), Date.new(2018, 12, 24)))
+  end
+
+  def date_labels(from, to)
+    [''] + (from..to).map { |date| date.strftime('%m-%d') }
+  end
+
+  def pad_values(start_values, number_of_blanks, end_values)
+    start_values + Array.new(number_of_blanks, '') + end_values
   end
 
   def visit_page_and_filter_by_date_range(date_range)
@@ -78,8 +87,13 @@ RSpec.describe 'date selection', type: :feature do
     click_button 'Change dates'
   end
 
+  def expect_upviews_table_to_contain_values(values)
+    upviews_rows = extract_table_content("#upviews_table")
+    expect(upviews_rows.last).to eq(["Unique pageviews"] + values)
+  end
+
   def expect_upviews_table_to_contain_dates(dates)
     upviews_rows = extract_table_content("#upviews_table")
-    expect(upviews_rows).to include([''] + dates)
+    expect(upviews_rows.first).to eq(dates)
   end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -87,8 +87,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     describe 'page metric section' do
-      let(:expected_table_dates) { ['', '11-24', '11-25', '12-24'] }
-
       it 'renders the metric for upviews' do
         expect(page).to have_selector '.metric-summary__upviews', text: '6,000'
       end
@@ -171,41 +169,41 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the metric timeseries for upviews' do
         upviews_rows = extract_table_content(".chart.upviews table")
         expect(upviews_rows).to match_array([
-          expected_table_dates,
-          ["Unique pageviews", "1,000", "2,000", "3,000"]
+          expected_table_dates(from, to),
+          pad_values(["Unique pageviews", "1,000", "2,000"], 28, ['3,000'])
         ])
       end
 
       it 'renders the metric timeseries for pviews' do
         pviews_rows = extract_table_content(".chart.pviews table")
         expect(pviews_rows).to match_array([
-          expected_table_dates,
-          %w[Pageviews 10,000 20,000 30,000]
+          expected_table_dates(from, to),
+          pad_values(%w[Pageviews 10,000 20,000], 28, ['30,000'])
         ])
       end
 
       it 'renders the metric timeseries for on-page searches' do
         internal_searches_rows = extract_table_content(".chart.searches table")
         expect(internal_searches_rows).to match_array([
-          expected_table_dates,
-          ["Searches from the page", "80", "80", "83"]
+          expected_table_dates(from, to),
+          pad_values(["Searches from the page", "80", "80"], 28, %w[83])
         ])
       end
 
       it 'renders the metric timeseries for satisfaction' do
         satisfaction_rows = extract_table_content(".chart.satisfaction table")
         expect(satisfaction_rows).to match_array([
-          expected_table_dates,
-          ["User satisfaction score", "100%", "90%", "80%"]
+          expected_table_dates(from, to),
+          pad_values(["User satisfaction score", "100%", "90%"], 28, ['80%'])
         ])
       end
 
-      it 'renders the metric timeseries for ' do
+      it 'renders the metric timeseries for feedback comments' do
         feedback_comment_rows = extract_table_content(".chart.feedex table")
 
         expect(feedback_comment_rows).to match_array([
-          expected_table_dates,
-          ["Number of feedback comments", "20", "21", "22"]
+          expected_table_dates(from, to),
+          pad_values(["Number of feedback comments", "20", "21"], 28, %w[22])
         ])
       end
     end
@@ -255,9 +253,18 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
     end
   end
-end
 
-def expected_metric_label(metric_name)
-  short_title = I18n.t("metrics.#{metric_name}.short_title").downcase
-  I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
+  def pad_values(start_values, number_of_blanks, end_values)
+    start_values + Array.new(number_of_blanks, '') + end_values
+  end
+
+  def expected_table_dates(from, to)
+    date_strs = (from..to).map { |date| date.strftime("%m-%d") }
+    [""] + date_strs
+  end
+
+  def expected_metric_label(metric_name)
+    short_title = I18n.t("metrics.#{metric_name}.short_title").downcase
+    I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
+  end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -33,29 +33,25 @@ RSpec.describe ChartPresenter do
     expect(subject.no_data_message).to eq 'No Unique pageviews data for the selected time period'
   end
 
-  it 'returns formatted hash of chart data' do
+  it 'returns formatted hash of chart data padded with nils' do
     expect(subject.chart_data).to eq upviews_chart_data
   end
 
   def upviews_chart_data
+    expected_keys = (subject.from.to_date..subject.to.to_date).map do |date|
+      date.strftime("%m-%d")
+    end
+    expected_values = Array.new(13) + [101, 202, 303] + Array.new(15)
     {
       caption: "Unique pageviews from 2017-12-31 to 2018-01-30",
       chart_id: "upviews_chart",
       chart_label: "Unique pageviews",
-      keys: [
-        "01-13",
-        "01-14",
-        "01-15"
-      ],
+      keys: expected_keys,
 
       rows: [
         {
           label: "Unique pageviews ",
-          values: [
-            101,
-            202,
-            303
-          ]
+          values: expected_values
         }
       ],
       table_id: "upviews_table",


### PR DESCRIPTION
# What
Pad out the data so that the full selected date range is shown.

# Why
We want to show the selected date range in the
metrics charts.

# Background
The correct way to do this would be to get the x axis
of the chart to recognise that it is rendering dates,
then to give a a min and max values for the x axis.

I've tried the first part of this and it works fine.
However the ChartKick js has a bug in it.

When passing the min and max values to google charts,
it mangles the date and the google chart ends up with an
empty object.

We have a work around which is to pad out the data with dummy
values for all the dates in the date range.

This also affects the table.

# Screenshots (last 6 months)

## Before
<img width="1082" alt="before" src="https://user-images.githubusercontent.com/511319/48618533-98546e80-e991-11e8-9634-8504a1bb6d85.png">

## After
<img width="989" alt="after" src="https://user-images.githubusercontent.com/511319/48618546-a0aca980-e991-11e8-9901-4e65b08743ac.png">

Trello: 
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
