### PR TITLE
Add the better_errors gem to the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ group :test do
 end
 
 group :development, :test do
+  gem "better_errors"
+  gem "binding_of_caller"
   gem "byebug", "~> 10"
   gem "capybara"
   gem "factory_bot_rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,12 @@ GEM
     ast (2.4.0)
     aws-xray-sdk (0.10.2)
       oj (~> 3.0)
+    better_errors (2.5.0)
+      coderay (>= 1.0.0)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.3.2)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -68,6 +74,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
     domain_name (0.5.20180417)
@@ -364,6 +371,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  better_errors
+  binding_of_caller
   bootsnap (~> 1)
   byebug (~> 10)
   capybara


### PR DESCRIPTION
Including the optional binding_of_caller dependency. This provides a
REPL on the error page, which is useful for debugging.