### PR TITLE
Use date range to query warehouse content endpoint

### DIFF
--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -10,9 +10,7 @@ class FindContent
   end
 
   def initialize(params)
-    range = DateRange.new(params[:date_range])
-    @from = range.from
-    @to = range.to
+    @date_range = params[:date_range]
     @organisation = params[:organisation_id]
     @document_type = params[:document_type]
     @page = params[:page]
@@ -20,13 +18,12 @@ class FindContent
   end
 
   def call
-    api.content(from: @from, to: @to, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
+    api.content(date_range: @date_range, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
   end
 
   def enum
     params = {
-      from: @from,
-      to: @to,
+      date_range: @date_range,
       organisation_id: @organisation,
       document_type: @document_type,
     }

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -17,8 +17,8 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
-  def content(from:, to:, organisation_id:, document_type: nil, page: nil, page_size: nil, search_term: nil)
-    url = content_items_url(from, to, organisation_id, document_type, page, page_size, search_term)
+  def content(date_range:, organisation_id:, document_type: nil, page: nil, page_size: nil, search_term: nil)
+    url = content_items_url(date_range, organisation_id, document_type, page, page_size, search_term)
     get_json(url).to_hash.deep_symbolize_keys
   end
 
@@ -49,10 +49,9 @@ private
     "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
-  def content_items_url(from, to, organisation_id, document_type, page, page_size, search_term)
+  def content_items_url(date_range, organisation_id, document_type, page, page_size, search_term)
     params = {
-      from: from,
-      to: to,
+      date_range: date_range,
       organisation_id: organisation_id,
       document_type: document_type,
       search_term: search_term,

--- a/spec/features/index_filter_by_title_spec.rb
+++ b/spec/features/index_filter_by_title_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe '/content' do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
 
-  let(:from) { Time.zone.today.last_month.beginning_of_month.to_s('%F') }
-  let(:to) { Time.zone.today.last_month.end_of_month.to_s('%F') }
   let(:items) do
     [
       { base_path: '/path/1', title: 'The title' },
@@ -14,7 +12,7 @@ RSpec.describe '/content' do
   before do
     GDS::SSO.test_user = build(:user, organisation_content_id: 'org-id')
 
-    content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
+    content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', items: items)
     content_data_api_has_orgs
     content_data_api_has_document_types
 
@@ -23,7 +21,7 @@ RSpec.describe '/content' do
 
   describe 'Filter by title / url' do
     before do
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', search_term: 'title', items: items)
+      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', search_term: 'title', items: items)
       fill_in 'Search for a title or URL', with: 'title'
       click_on 'Filter'
     end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -2,8 +2,6 @@ RSpec.describe '/content' do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
-  let(:from) { Time.zone.today.last_month.beginning_of_month.to_s('%F') }
-  let(:to) { Time.zone.today.last_month.end_of_month.to_s('%F') }
   let(:items) do
     [
       {
@@ -29,7 +27,7 @@ RSpec.describe '/content' do
 
   before do
     stub_metrics_page(base_path: 'path/1', time_period: :last_month)
-    content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
+    content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', items: items)
     GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
     content_data_api_has_orgs
     content_data_api_has_document_types
@@ -60,10 +58,8 @@ RSpec.describe '/content' do
     end
 
     it 'respects the date filter' do
-      from = (Time.zone.yesterday - 1.year).to_s('%F')
-      to = Time.zone.yesterday.to_s('%F')
       stub_metrics_page(base_path: 'path/1', time_period: :last_year)
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', items: items)
+      content_data_api_has_content_items(date_range: 'last-year', organisation_id: 'org-id', items: items)
 
       visit "/content?date_range=last-year&organisation_id=org-id"
       click_link 'The title'
@@ -74,7 +70,7 @@ RSpec.describe '/content' do
 
   context 'filter by organisation' do
     before do
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
+      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'another-org-id', items: items)
       select 'another org', from: 'organisation_id'
       click_on 'Filter'
     end
@@ -93,10 +89,8 @@ RSpec.describe '/content' do
     end
 
     it 'respects date range' do
-      from = (Time.zone.yesterday - 1.year).to_s('%F')
-      to = Time.zone.yesterday.to_s('%F')
       stub_metrics_page(base_path: 'path/1', time_period: :last_year)
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'another-org-id', items: items)
+      content_data_api_has_content_items(date_range: 'last-year', organisation_id: 'another-org-id', items: items)
 
       visit "/content?date_range=last-year&organisation_id=another-org-id"
 
@@ -109,8 +103,7 @@ RSpec.describe '/content' do
     context 'with users organisation' do
       before do
         content_data_api_has_content_items(
-          from: from,
-          to: to,
+          date_range: 'last-month',
           organisation_id: 'users-org-id',
           items: [
             items[0].merge(title: 'Content from users-org-id')
@@ -129,7 +122,7 @@ RSpec.describe '/content' do
 
   context 'filter by document_type' do
     before do
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', document_type: 'news_story', items: [items.first])
+      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', document_type: 'news_story', items: [items.first])
       select 'News story', from: 'document_type'
       click_on 'Filter'
     end
@@ -180,8 +173,7 @@ RSpec.describe '/content' do
 
     before do
       content_data_api_has_content_items(
-        from: from,
-        to: to,
+        date_range: 'last-month',
         organisation_id: 'org-id',
         items: (items * 50) + other_page_items
       )
@@ -209,8 +201,7 @@ RSpec.describe '/content' do
 
     it 'it provides a CSV file' do
       content_data_api_has_content_items(
-        from: from,
-        to: to,
+        date_range: 'last-month',
         organisation_id: 'org-id',
         items: csv_items,
         page_size: 5000

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -34,10 +34,9 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, search_term: nil, items:, page_size: nil)
+      def content_data_api_has_content_items(date_range:, organisation_id:, document_type: nil, search_term: nil, items:, page_size: nil)
         params = {
-          from: from,
-          to: to,
+          date_range: date_range,
           organisation_id: organisation_id,
           document_type: document_type,
           search_term: search_term,


### PR DESCRIPTION
# What
Use date range to query warehouse content endpoint

# Why
We are using materialised views to render content from the content endpoint in our back end. The content end point is set up to use a `date_range` metric rather than `from` and `to` metrics. This makes sense as it will be much easier to identify the required view from a `date_range` param rather than having to do complex logic to determine the required view from `from` and `to` params.

# Notes
This PR will not make any difference to the functionality of our index page on it's own. We currently have the back end hard coded to only ever show data from the last 30 days. It does however need to be merged before the back end changes so as not to break existing functionality.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
