### PR TITLE
Show blank regions in charts and tables

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -23,7 +23,7 @@ class ChartPresenter
       chart_label: human_friendly_metric.to_s,
       chart_id: "#{metric}_chart",
       table_id: "#{metric}_table",
-      table_direction: "vertical",
+      table_direction: "horizontal",
       from: google_charts_date_string(from),
       to: google_charts_date_string(to),
       keys: keys,

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -5,8 +5,8 @@ class ChartPresenter
   def initialize(json:, metric:, date_range:)
     @metric = metric
     @time_series = json
-    @from = date_range.from
-    @to = date_range.to
+    @from = date_range.from.to_date
+    @to = date_range.to.to_date
   end
 
   def has_values?
@@ -19,7 +19,7 @@ class ChartPresenter
 
   def chart_data
     {
-      caption: "#{human_friendly_metric} from #{from.to_date} to #{to.to_date}",
+      caption: "#{human_friendly_metric} from #{from} to #{to}",
       chart_label: human_friendly_metric.to_s,
       chart_id: "#{metric}_chart",
       table_id: "#{metric}_table",

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -38,7 +38,7 @@ class ChartPresenter
     return [] unless time_series
 
     time_series.map do |point|
-      point[:date].to_date.strftime("%m-%d")
+      point[:date].to_date
     end
   end
 

--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -24,6 +24,8 @@ class ChartPresenter
       chart_id: "#{metric}_chart",
       table_id: "#{metric}_table",
       table_direction: "vertical",
+      from: google_charts_date_string(from),
+      to: google_charts_date_string(to),
       keys: keys,
       rows: [
         {
@@ -32,6 +34,11 @@ class ChartPresenter
         }
       ]
     }
+  end
+
+  # https://developers.google.com/chart/interactive/docs/datesandtimes#dates-and-times-using-the-date-string-representation
+  def google_charts_date_string(date)
+    "Date(#{date.year}, #{date.month - 1}, #{date.day})"
   end
 
   def keys

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -9,24 +9,29 @@
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
     legend: 'none',
-    chartArea:{width:'90%',height:'80%'},
+    chartArea: { width: '90%', height: '80%' },
     curveType: 'none',
-    tooltip: {textStyle: {color: '#000'}, showColorCode: true},
+    tooltip: { textStyle: { color: '#000' }, showColorCode: true },
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },
-    hAxis: { textStyle: {color: '#000', fontName: 'nta', fontSize: '12'}},
-    vAxis: {format:'#,###,###.###', textStyle: {color: '#000', fontName: 'nta', fontSize: '12'}},
+    hAxis: {
+      textStyle: { color: '#000', fontName: 'nta', fontSize: '12' }
+    },
+    vAxis: {
+      format: '#,###,###.###',
+      textStyle: { color: '#000', fontName: 'nta', fontSize: '12' }
+    },
     pointSize: 0,
     series: {
-        0 => {lineWidth: 2, color: '#912B88'},
-        1 => {lineWidth: 2, lineDashStyle: [10, 2], color: '#454a4c'}
+      0 => { lineWidth: 2, color: '#912B88' },
+      1 => { lineWidth: 2, lineDashStyle: [10, 2], color: '#454a4c' }
     }
   }
   if rows.length > 0 && keys.length > 0
     chart_format_data = rows.each_with_object([]) do |row, acc|
       acc << {
-      name: row[:label],
-      linewidth: 10,
-      data: keys.zip(row[:values])
+        name: row[:label],
+        linewidth: 10,
+        data: keys.zip(row[:values])
       }
     end
   end

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -57,7 +57,7 @@
       ) do %>
         <div tabindex="0" class="app-c-chart__table-wrapper">
           <table class="govuk-table">
-            <% if table_direction == "vertical" %>
+            <% if table_direction == "horizontal" %>
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"></td>

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -39,61 +39,73 @@
 <% if rows.length > 0 && keys.length > 0 && chart_id && table_id %>
   <div class="app-c-chart">
     <div class="app-c-chart__chart" id="<%= chart_id %>">
-        <%= render "govuk_publishing_components/components/govspeak" do %>
-          <div class="app-c-chart__accessibility-message">
-            The chart is a visual representation of the data available in the <a href="#<%= table_id %>">table</a>.
-          </div>
-        <% end %>
-        <%= line_chart(chart_format_data, library: chart_library_options) %>
+      <%= render "govuk_publishing_components/components/govspeak" do %>
+        <div class="app-c-chart__accessibility-message">
+          The chart is a visual representation of the data available
+          in the <a href="#<%= table_id %>">table</a>.
+        </div>
+      <% end %>
+      <%= line_chart(chart_format_data, library: chart_library_options) %>
     </div>
     <div class="app-c-chart__table" id="<%= table_id %>">
-      <%= render "govuk_publishing_components/components/details", {
-              title: t(".table_dropdown", metric_name: chart_label)
-            } do %>
-          <div tabindex="0" class="app-c-chart__table-wrapper">
-             <table class="govuk-table">
-                <% if table_direction == "vertical" %>
-                  <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                      <td class="govuk-table__cell"></td>
-                      <% keys.each do |d| %>
-                        <th class="govuk-table__header govuk-table__header--numeric" scope="col"><%= d %></th>
-                      <% end %>
-                    </tr>
-                  </thead>
-                  <tbody class="govuk-table__body">
-                    <% rows.each do |r| %>
-                      <tr class="govuk-table__row">
-                        <th class="govuk-table__header" scope="row"><%= r[:label]  %></th>
-                        <% r[:values].each do |v| %>
-                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter v %></td>
-                        <% end %>
-                      </tr>
+      <%= render(
+        "govuk_publishing_components/components/details",
+        title: t(".table_dropdown", metric_name: chart_label)
+      ) do %>
+        <div tabindex="0" class="app-c-chart__table-wrapper">
+          <table class="govuk-table">
+            <% if table_direction == "vertical" %>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"></td>
+                  <% keys.each do |d| %>
+                    <th class="govuk-table__header govuk-table__header--numeric" scope="col">
+                      <%= d %>
+                    </th>
+                  <% end %>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <% rows.each do |r| %>
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="row"><%= r[:label]  %></th>
+                    <% r[:values].each do |v| %>
+                      <td class="govuk-table__cell govuk-table__cell--numeric">
+                        <%= number_with_delimiter v %>
+                      </td>
                     <% end %>
-                  </tbody>
-                <% else %>
-                  <thead class="govuk-table__head">
-                    <tr class="govuk-table__row">
-                      <td class="govuk-table__cell"></td>
-                      <% rows.each do |r| %>
-                          <th class="govuk-table__header govuk-table__header--stacked govuk-table__header--numeric" scope="row"><%= r[:label] %></th>
-                      <% end %>
-                    </tr>
-                  </thead>
-                  <tbody class="govuk-table__body">
-                    <% keys.each_with_index do |k,i| %>
-                      <tr>
-                        <th class="govuk-table__header govuk-table__header--numeric" scope="row"><%= k %></th>
-                        <% rows.each do |r| %>
-                          <td class="govuk-table__cell govuk-table__cell--numeric"><%= number_with_delimiter r[:values][i] %></td>
-                        <% end %>
-                      </tr>
-                    <% end %>
-                  </tbody>
+                  </tr>
                 <% end %>
-              </table>
-            </div>
-        <% end %>
-      </div>
+              </tbody>
+            <% else %>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell"></td>
+                  <% rows.each do |r| %>
+                    <th class="govuk-table__header govuk-table__header--stacked govuk-table__header--numeric" scope="row">
+                      <%= r[:label] %>
+                    </th>
+                  <% end %>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <% keys.each_with_index do |k, i| %>
+                  <tr>
+                    <th class="govuk-table__header govuk-table__header--numeric" scope="row">
+                      <%= k %>
+                    </th>
+                    <% rows.each do |r| %>
+                      <td class="govuk-table__cell govuk-table__cell--numeric">
+                        <%= number_with_delimiter r[:values][i] %>
+                      </td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              </tbody>
+            <% end %>
+          </table>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+  </div>
+<% end %>

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -3,6 +3,8 @@
   chart_label ||= "data"
   table_id ||= false
   table_direction ||= "horizontal"
+  from ||= false
+  to ||= false
   rows ||= []
   keys ||= []
   Chartkick.options[:html] = '<div id="%{id}"><noscript><p>Our charts are built using javascript but all the data is also available in the table.</p></noscript></div>'
@@ -14,6 +16,7 @@
     tooltip: { textStyle: { color: '#000' }, showColorCode: true },
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },
     hAxis: {
+      viewWindow: { min: from, max: to },
       textStyle: { color: '#000', fontName: 'nta', fontSize: '12' }
     },
     vAxis: {

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -61,20 +61,20 @@
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"></td>
-                  <% keys.each do |d| %>
+                  <% keys.each do |key| %>
                     <th class="govuk-table__header govuk-table__header--numeric" scope="col">
-                      <%= d %>
+                      <%= key %>
                     </th>
                   <% end %>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-                <% rows.each do |r| %>
+                <% rows.each do |row| %>
                   <tr class="govuk-table__row">
-                    <th class="govuk-table__header" scope="row"><%= r[:label]  %></th>
-                    <% r[:values].each do |v| %>
+                    <th class="govuk-table__header" scope="row"><%= row[:label]  %></th>
+                    <% row[:values].each do |value| %>
                       <td class="govuk-table__cell govuk-table__cell--numeric">
-                        <%= number_with_delimiter v %>
+                        <%= number_with_delimiter value %>
                       </td>
                     <% end %>
                   </tr>
@@ -84,22 +84,22 @@
               <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
                   <td class="govuk-table__cell"></td>
-                  <% rows.each do |r| %>
+                  <% rows.each do |row| %>
                     <th class="govuk-table__header govuk-table__header--stacked govuk-table__header--numeric" scope="row">
-                      <%= r[:label] %>
+                      <%= row[:label] %>
                     </th>
                   <% end %>
                 </tr>
               </thead>
               <tbody class="govuk-table__body">
-                <% keys.each_with_index do |k, i| %>
+                <% keys.each_with_index do |key, index| %>
                   <tr>
                     <th class="govuk-table__header govuk-table__header--numeric" scope="row">
-                      <%= k %>
+                      <%= key %>
                     </th>
-                    <% rows.each do |r| %>
+                    <% rows.each do |row| %>
                       <td class="govuk-table__cell govuk-table__cell--numeric">
-                        <%= number_with_delimiter r[:values][i] %>
+                        <%= number_with_delimiter row[:values][index] %>
                       </td>
                     <% end %>
                   </tr>

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -27,8 +27,8 @@
     }
   }
   if rows.length > 0 && keys.length > 0
-    chart_format_data = rows.each_with_object([]) do |row, acc|
-      acc << {
+    chart_format_data = rows.map do |row|
+      {
         name: row[:label],
         linewidth: 10,
         data: keys.zip(row[:values])

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe "Chart", type: :view do
     assert_select '.app-c-chart', 1
   end
 
-  it "renders the correct table data vertically" do
-    data[:table_direction] = 'vertical'
+  it "renders the correct table data horizontally" do
+    data[:table_direction] = 'horizontal'
     render_component(data)
     assert_select ".govuk-table__body .govuk-table__header:nth-child(1)", text: "2017"
     assert_select ".govuk-table__cell--numeric", 24
@@ -58,8 +58,8 @@ RSpec.describe "Chart", type: :view do
     assert_select "td:last", text: "121"
   end
 
-  it "renders the correct table data horizontally" do
-    data[:table_direction] = 'horizontal'
+  it "renders the correct table data vertically" do
+    data[:table_direction] = 'vertical'
     render_component(data)
     assert_select ".govuk-table__body .govuk-table__header:nth-child(1)", text: "Jan"
     assert_select ".govuk-table__cell--numeric", 24

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -33,43 +33,43 @@ RSpec.describe 'date selection', type: :feature do
 
     it 'renders data for the last 30 days' do
       visit page_uri
-      expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
+      expect_upviews_table_to_contain_dates(['2018-11-24', '2018-11-25', '2018-12-24'])
     end
   end
 
   it 'renders data for the last 30 days when `Past 30 days` is selected' do
     visit_page_and_filter_by_date_range('last-30-days')
-    expect_upviews_table_to_contain_dates(['11-24', '11-25', '12-24'])
+    expect_upviews_table_to_contain_dates(['2018-11-24', '2018-11-25', '2018-12-24'])
   end
 
   it 'renders data for the previous month when `Past month` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_month)
     visit_page_and_filter_by_date_range('last-month')
-    expect_upviews_table_to_contain_dates(['11-01', '11-02', '11-30'])
+    expect_upviews_table_to_contain_dates(['2018-11-01', '2018-11-02', '2018-11-30'])
   end
 
   it 'renders data for the last 3 months when `Past 3 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_3_months)
     visit_page_and_filter_by_date_range('last-3-months')
-    expect_upviews_table_to_contain_dates(['09-24', '09-25', '12-24'])
+    expect_upviews_table_to_contain_dates(['2018-09-24', '2018-09-25', '2018-12-24'])
   end
 
   it 'renders data for the last 6 months when `Past 6 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_6_months)
     visit_page_and_filter_by_date_range('last-6-months')
-    expect_upviews_table_to_contain_dates(['06-24', '06-25', '12-24'])
+    expect_upviews_table_to_contain_dates(['2018-06-24', '2018-06-25', '2018-12-24'])
   end
 
   it 'renders data for the last year when `Past year` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_year)
     visit_page_and_filter_by_date_range('last-year')
-    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
+    expect_upviews_table_to_contain_dates(['2017-12-24', '2017-12-25', '2018-12-24'])
   end
 
   it 'renders data for the last 2 years when `Past 2 years` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :last_2_years)
     visit_page_and_filter_by_date_range('last-2-years')
-    expect_upviews_table_to_contain_dates(['12-24', '12-25', '12-24'])
+    expect_upviews_table_to_contain_dates(['2016-12-24', '2016-12-25', '2018-12-24'])
   end
 
   def visit_page_and_filter_by_date_range(date_range)

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     describe 'page metric section' do
-      let(:expected_table_dates) { ['', '11-24', '11-25', '12-24'] }
+      let(:expected_table_dates) { ['', '2018-11-24', '2018-11-25', '2018-12-24'] }
 
       it 'renders the metric for upviews' do
         expect(page).to have_selector '.metric-summary__upviews', text: '6,000'

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe ChartPresenter do
         }
       ],
       table_id: "upviews_table",
-      table_direction: "vertical"
+      table_direction: "horizontal"
     }
   end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe ChartPresenter do
   end
 
   it 'returns start date' do
-    expect(subject.from).to eq '2017-12-31'
+    expect(subject.from).to eq Date.new(2017, 12, 31)
   end
   it 'returns end date' do
-    expect(subject.to).to eq '2018-01-30'
+    expect(subject.to).to eq Date.new(2018, 1, 30)
   end
 
   it 'returns the correct message for no data' do
@@ -42,10 +42,12 @@ RSpec.describe ChartPresenter do
       caption: "Unique pageviews from 2017-12-31 to 2018-01-30",
       chart_id: "upviews_chart",
       chart_label: "Unique pageviews",
+      from: "Date(2017, 11, 31)",
+      to: "Date(2018, 0, 30)",
       keys: [
-        "01-13",
-        "01-14",
-        "01-15"
+        Date.new(2018, 1, 13),
+        Date.new(2018, 1, 14),
+        Date.new(2018, 1, 15)
       ],
 
       rows: [


### PR DESCRIPTION
# What

Display the full date range in the charts and tables, even when we have no data for all or some of that time period.

Currently, the date range displayed in the charts & tables matches dates that we have data for (and ignores dates we don't have data for).

# Why

It's misleading for users of Content Data app if the date range in the charts & tables doesn't match the date range they have selected.

This problem will regularly occur for newly published content.

# Screenshots

## Before
![screen shot 2018-11-19 at 10 59 59](https://user-images.githubusercontent.com/1130010/48702978-4a867300-ebea-11e8-8671-02679f6fdc14.png)
## After
![screen shot 2018-11-19 at 10 59 45](https://user-images.githubusercontent.com/1130010/48702977-4a867300-ebea-11e8-9bee-c983286655ee.png)



---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
