### PR TITLE
Add help text to index page table

### DIFF
--- a/app/assets/images/question_mark_default.svg
+++ b/app/assets/images/question_mark_default.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 51 (57462) - http://www.bohemiancoding.com/sketch -->
+    <title>Default state</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="Default-state" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-Copy-6">
+            <circle id="Oval-3" fill="#005EA5" fill-rule="nonzero" cx="12" cy="12" r="12"></circle>
+            <text id="?" font-family="GDSTransportWebsite-Bold, GDS Transport Website" font-size="16" font-weight="bold" fill="#FFFFFF">
+                <tspan x="8" y="18">?</tspan>
+            </text>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -35,24 +35,35 @@
 
 .govuk-table__cell {
   @include govuk-font(16);
-}
-
-.govuk-table__header {
-  white-space: nowrap;
-  position: sticky;
-  top: 0;
+  @include govuk-responsive-padding(2);
 }
 
 .gem-c-layout-for-admin .govuk-grid-row {
   margin: 0;
 }
 
+.govuk-table .govuk-table__header {
+  color: $govuk-text-colour;
+  position: sticky;
+  top: 0;
+}
+
+.govuk-table .govuk-table__header {
+  @include govuk-responsive-padding(2);
+  background-color: $grey-3;
+  font-weight: normal;
+}
+
 .govuk-table__cell {
-  padding-right: 15px;
+  @include govuk-responsive-padding(2);
+}
+
+.govuk-table__cell:last-child {
+  @include govuk-responsive-padding(2);
 }
 
 .table-wrapper {
-  min-width: 1000px;
+  min-width: 900px;
   background-color: $white;
 }
 

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -9,6 +9,8 @@
         <span class="filters-control filters-control--show govuk-visually-hidden">
           <a href="" class="govuk-link filters-control__link filters-control__link--show">Show filters</a>&nbsp;&#x25BC;</span>
       </div>
+
+
       <div class="filter-form">
         <%= form_tag content_path, method: 'get', name: 'organisation-picker' do %>
           <%= render "components/time-select", {
@@ -87,15 +89,16 @@
         <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
             self,
             '<h1 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h1>'.html_safe,
-            sortable: true
+            sortable: false
           ) do |t| %>
             <%= t.head do %>
               <!-- TODO: Once sorting is supported, fill in the href and sort_direction header arguments with proper values -->
-              <%= t.header("Page title", href: '#', sort_direction: nil) %>
-              <%= t.header("Content type", href: '#', sort_direction: nil) %>
-              <%= t.header("Unique pageviews", href: '#', sort_direction: 'descending') %>
-              <%= t.header("User satisfaction score", href: '#', sort_direction: nil) %>
-              <%= t.header("Searches from page", href: '#', sort_direction: nil) %>
+              <%# t.header("Page title", href: '#', sort_direction: nil) %>
+              <%= t.header("Page title") %>
+              <%= t.header("Content type") %>
+              <%= t.header("Unique pageviews<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.upviews.summary"}")}".html_safe) %>
+              <%= t.header("User satisfaction score<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.satisfaction.summary"}")}".html_safe) %>
+              <%= t.header("Searches from page<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.searches.summary"}")}".html_safe) %>
             <% end %>
 
             <%= t.body do %>


### PR DESCRIPTION
# What

https://trello.com/c/fOwe3KC3/840-2-index-page-add-help-text-to-headers-on-table

This is the initial implementation which puts an SVG on the page,
and gives it a title tag - this means text will appear on a prolonged hover.

This also adds styles to support the table when we put it into the
non-sortable mode and applies that mode.

# Why
Move closer to designs, allow users to see help text.

# Screenshots

## Before

![screen shot 2018-11-19 at 14 59 46](https://user-images.githubusercontent.com/31649453/48714971-cf35b900-ec0b-11e8-909a-001d7f6c1646.png)

## After

![screen shot 2018-11-19 at 15 00 33](https://user-images.githubusercontent.com/31649453/48715018-e8d70080-ec0b-11e8-8064-51bb4ca53864.png)

