### PR TITLE
Add page information above table

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -9,7 +9,7 @@ module PaginationHelper
         previous_page:  {
           url: path_to_prev_page(@presenter.content_items),
           title: 'Previous',
-          label: "#{@presenter.page - 1} of #{@presenter.total_pages}"
+          label: @presenter.prev_label
         }
       )
     end
@@ -19,7 +19,7 @@ module PaginationHelper
         next_page: {
           url: path_to_next_page(@presenter.content_items),
           title: 'Next',
-          label: "#{@presenter.page + 1} of #{@presenter.total_pages}"
+          label: @presenter.next_label
         }
       )
     end

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,24 +1,19 @@
 class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
-  attr_reader :title, :page, :total_pages, :content_items
+  attr_reader :title, :content_items, :pagination
+  delegate :page, :total_pages, :prev_link?, :next_link?, to: :pagination
 
   def initialize(search_results, search_parameters, document_types, organisations)
     @title = 'Content Items'
     @search_parameters = search_parameters
     @document_types = document_types
     @organisations = organisations
-    @total_results = search_results[:total_results]
-    @total_pages = search_results[:total_pages]
-    @page = search_results[:page] || 1
-    @content_items = paginate(search_results[:results].map { |item| ContentRowPresenter.new(item) })
-  end
-
-  def prev_link?
-    @page > 1
-  end
-
-  def next_link?
-    @page < @total_pages
+    @pagination = PaginationPresenter.new(
+      page: search_results[:page] || 1,
+      total_pages: search_results[:total_pages],
+      total_results: search_results[:total_results]
+    )
+    @content_items = pagination.paginate(search_results[:results].map { |item| ContentRowPresenter.new(item) })
   end
 
   def time_period

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,7 +1,7 @@
 class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
   attr_reader :title, :content_items, :pagination
-  delegate :page, :total_pages, :prev_link?, :next_link?, to: :pagination
+  delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
 
   def initialize(search_results, search_parameters, document_types, organisations)
     @title = 'Content Items'

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,5 +1,5 @@
 class PaginationPresenter
-  attr_reader :page, :total_pages
+  attr_reader :page, :total_pages, :total_results
 
   def initialize(page: 1, total_pages:, total_results:, per_page: 100)
     @page = page
@@ -24,8 +24,23 @@ class PaginationPresenter
     page < total_pages
   end
 
+  def first_record
+    return 1 if page == 1
+    previous_record_count + 1
+  end
+
+  def last_record
+    [@page * @per_page, @total_results].min
+  end
+
   def paginate(items)
     Kaminari.paginate_array(items, total_count: @total_results)
       .page(@page).per(@per_page)
+  end
+
+private
+
+  def previous_record_count
+    (@page - 1) * @per_page
   end
 end

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -9,11 +9,19 @@ class PaginationPresenter
   end
 
   def prev_link?
-    @page > 1
+    page > 1
+  end
+
+  def prev_label
+    "#{page - 1} of #{total_pages}"
+  end
+
+  def next_label
+    "#{page + 1} of #{total_pages}"
   end
 
   def next_link?
-    @page < @total_pages
+    page < total_pages
   end
 
   def paginate(items)

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,0 +1,23 @@
+class PaginationPresenter
+  attr_reader :page, :total_pages
+
+  def initialize(page: 1, total_pages:, total_results:, per_page: 100)
+    @page = page
+    @total_pages = total_pages
+    @total_results = total_results
+    @per_page = per_page
+  end
+
+  def prev_link?
+    @page > 1
+  end
+
+  def next_link?
+    @page < @total_pages
+  end
+
+  def paginate(items)
+    Kaminari.paginate_array(items, total_count: @total_results)
+      .page(@page).per(@per_page)
+  end
+end

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,1 +1,7 @@
-<h1 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h1>'
+<h1 class="table-header">Showing
+    <span class="table-header__param"><%= pagination.first_record %></span> to
+    <span class="table-header__param"><%= pagination.last_record %></span> of
+    <span class="table-header__param"><%= pagination.total_results %></span> results
+    from <span class="table-header__param">UK Visas and Immigration</span>
+    in <span class="table-header__param">guidance</span>.
+</h1>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,0 +1,1 @@
+<h1 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h1>'

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -88,7 +88,7 @@
       <div class="table-wrapper">
         <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
             self,
-            '<h1 class="table-header">Showing <span class="table-header__param">21</span> to <span class="table-header__param">40</span> of <span class="table-header__param">587</span> results from <span class="table-header__param">UK Visas and Immigration</span> in <span class="table-header__param">guidance</span>.</h1>'.html_safe,
+            render('table_data_description', pagination: @presenter.pagination),
             sortable: false
           ) do |t| %>
             <%= t.head do %>

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe ContentItemsPresenter do
         ])
       end
     end
+
     context 'when no document type in parameter' do
       before { search_parameters[:document_type] = '' }
       it 'formats the document types for the options component' do
@@ -72,6 +73,13 @@ RSpec.describe ContentItemsPresenter do
     it 'returns true if on another page' do
       content_items[:page] = 2
       expect(subject.prev_link?).to eq(true)
+    end
+  end
+
+  describe '#prev_label' do
+    it 'returns the correct page numbers' do
+      content_items[:page] = 2
+      expect(subject.prev_label).to eq('1 of 3')
     end
   end
 

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe PaginationPresenter do
+  subject do
+    PaginationPresenter.new(
+      page: page,
+      total_pages: 11,
+      per_page: 10,
+      total_results: 105
+    )
+  end
+
+  context 'when on the first page' do
+    let(:page) { 1 }
+
+    it 'returns false from #prev_link?' do
+      expect(subject.prev_link?).to eq(false)
+    end
+
+    it 'returns true from #next_link?' do
+      expect(subject.next_link?).to eq(true)
+    end
+  end
+
+  context 'when on the last page' do
+    let(:page) { 11 }
+
+    it 'returns true from #prev_link?' do
+      expect(subject.prev_link?).to eq(true)
+    end
+
+    it 'returns false from #next_link?' do
+      expect(subject.next_link?).to eq(false)
+    end
+  end
+
+  context 'when somewhere in the middle' do
+    let(:page) { 6 }
+
+    it 'returns true from #prev_link?' do
+      expect(subject.prev_link?).to eq(true)
+    end
+
+    it 'returns true from #prev_link?' do
+      expect(subject.prev_link?).to eq(true)
+    end
+  end
+end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -8,9 +8,13 @@ RSpec.describe PaginationPresenter do
     )
   end
 
-  context 'when on the first page' do
-    let(:page) { 1 }
+  let(:page) { 1 }
 
+  it 'returns the #total_results' do
+    expect(subject.total_results)
+  end
+
+  context 'when on the first page' do
     it 'returns false from #prev_link?' do
       expect(subject.prev_link?).to eq(false)
     end
@@ -21,6 +25,14 @@ RSpec.describe PaginationPresenter do
 
     it 'return the correct next page label' do
       expect(subject.next_label).to eq('2 of 11')
+    end
+
+    it 'returns 1 for #first_record' do
+      expect(subject.first_record).to eq(1)
+    end
+
+    it 'returns 10 for #last_record' do
+      expect(subject.last_record).to eq(10)
     end
   end
 
@@ -37,6 +49,14 @@ RSpec.describe PaginationPresenter do
 
     it 'returns the correct next page label' do
       expect(subject.prev_label).to eq('10 of 11')
+    end
+
+    it 'returns 100 for #first_record' do
+      expect(subject.first_record).to eq(101)
+    end
+
+    it 'returns 105 for #last_record' do
+      expect(subject.last_record).to eq(105)
     end
   end
 
@@ -57,6 +77,14 @@ RSpec.describe PaginationPresenter do
 
     it 'return the correct next page label' do
       expect(subject.next_label).to eq('7 of 11')
+    end
+
+    it 'returns 51 for #first_record' do
+      expect(subject.first_record).to eq(51)
+    end
+
+    it 'returns 60 for #last_record' do
+      expect(subject.last_record).to eq(60)
     end
   end
 end

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe PaginationPresenter do
     it 'returns true from #next_link?' do
       expect(subject.next_link?).to eq(true)
     end
+
+    it 'return the correct next page label' do
+      expect(subject.next_label).to eq('2 of 11')
+    end
   end
 
   context 'when on the last page' do
@@ -30,6 +34,10 @@ RSpec.describe PaginationPresenter do
     it 'returns false from #next_link?' do
       expect(subject.next_link?).to eq(false)
     end
+
+    it 'returns the correct next page label' do
+      expect(subject.prev_label).to eq('10 of 11')
+    end
   end
 
   context 'when somewhere in the middle' do
@@ -41,6 +49,14 @@ RSpec.describe PaginationPresenter do
 
     it 'returns true from #prev_link?' do
       expect(subject.prev_link?).to eq(true)
+    end
+
+    it 'returns the correct next page label' do
+      expect(subject.prev_label).to eq('5 of 11')
+    end
+
+    it 'return the correct next page label' do
+      expect(subject.next_label).to eq('7 of 11')
     end
   end
 end


### PR DESCRIPTION
# What
Make the page information in the table header show real numbers

# Why
We currently only have placeholder text.
# Note
This only includes the page information. The filter information will be in another PR.

# Screenshots
## Before
![before](https://user-images.githubusercontent.com/511319/48897992-6fc1ee00-ee43-11e8-9d3f-122272912a99.png)
## After
![after](https://user-images.githubusercontent.com/511319/48898009-7c464680-ee43-11e8-821f-12021a99e553.png)

Trello: https://trello.com/c/BZrqyTPo/830-2-index-page-add-information-above-the-table-to-indicate-filters-applied

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
