### PR TITLE
Improve y-axis on charts

### DIFF
--- a/app/presenters/chart_presenter.rb
+++ b/app/presenters/chart_presenter.rb
@@ -17,6 +17,10 @@ class ChartPresenter
     "No #{human_friendly_metric} data for the selected time period"
   end
 
+  def percentage_metric?
+    metric == "satisfaction"
+  end
+
   def chart_data
     {
       caption: "#{human_friendly_metric} from #{from} to #{to}",
@@ -32,7 +36,8 @@ class ChartPresenter
           label: "#{human_friendly_metric} ",
           values: values
         }
-      ]
+      ],
+      percent_metric: percentage_metric?
     }
   end
 

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -5,8 +5,28 @@
   table_direction ||= "horizontal"
   from ||= false
   to ||= false
+  percent_metric ||= false
   rows ||= []
   keys ||= []
+
+  if percent_metric
+    maximum_y = 100
+  elsif rows.any?
+    row_maximums = rows.map { |row| row[:values].max }
+    overall_maximum = row_maximums.max
+
+    if overall_maximum == 0
+      # set max value to 3 if data is all 0 avoid negative numbers on Y axis
+      maximum_y = 3
+    elsif overall_maximum < 10
+      # for low numbers let line hit top to avoid a fractional max value
+      maximum_y = overall_maximum
+    else
+      # for higher numbers give breathing space to line
+      maximum_y = overall_maximum * 1.3
+    end
+  end
+
   Chartkick.options[:html] = '<div id="%{id}"><noscript><p>Our charts are built using javascript but all the data is also available in the table.</p></noscript></div>'
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
@@ -20,7 +40,8 @@
       textStyle: { color: '#000', fontName: 'nta', fontSize: '12' }
     },
     vAxis: {
-      format: '#,###,###.###',
+      viewWindow: { min: 0, max: maximum_y },
+      format: '#,###,###',
       textStyle: { color: '#000', fontName: 'nta', fontSize: '12' }
     },
     pointSize: 0,

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -61,7 +61,8 @@ RSpec.describe ChartPresenter do
         }
       ],
       table_id: "upviews_table",
-      table_direction: "horizontal"
+      table_direction: "horizontal",
+      percent_metric: false
     }
   end
 end


### PR DESCRIPTION
- prevent chart displaying negative numbers when all data is 0s
- prevent chart displaying fractional numbers in labels
- set sensible ranges on charts depending on max value in data, including capping charts showing percentages at 100

# What
Improve y axis as per 
https://trello.com/c/gVCYMq4q/869-3-improve-vertical-axis-on-charts

# Why
More logical chart views

# Screenshots

## Before
![screen shot 2018-11-22 at 14 39 19](https://user-images.githubusercontent.com/31649453/48911160-fa1d4880-ee69-11e8-9326-8bd8755a3d74.png)

## After
![screen shot 2018-11-22 at 14 39 51](https://user-images.githubusercontent.com/31649453/48911161-fa1d4880-ee69-11e8-815e-63ecede75ec1.png)

## Before
![screen shot 2018-11-22 at 14 41 44](https://user-images.githubusercontent.com/31649453/48911162-fa1d4880-ee69-11e8-9429-2624a89fb41c.png)

## After
![screen shot 2018-11-22 at 14 41 52](https://user-images.githubusercontent.com/31649453/48911163-fab5df00-ee69-11e8-92a1-1eb37af59457.png)

## Before
![screen shot 2018-11-22 at 14 44 40](https://user-images.githubusercontent.com/31649453/48911164-fab5df00-ee69-11e8-98de-c94cbf153a15.png)

## After
![screen shot 2018-11-22 at 14 44 48](https://user-images.githubusercontent.com/31649453/48911165-fab5df00-ee69-11e8-9b27-47829890591c.png)
