### PR TITLE
Add initial CSV export from the index page

### DIFF
--- a/app/controllers/concerns/exportable_to_csv.rb
+++ b/app/controllers/concerns/exportable_to_csv.rb
@@ -1,0 +1,30 @@
+require 'active_support/concern'
+
+module Concerns::ExportableToCSV
+  extend ActiveSupport::Concern
+
+  included do
+    def export_to_csv(enum:)
+      set_file_headers
+      set_streaming_headers
+
+      response.status = 200
+      self.response_body = enum
+    end
+
+  private
+
+    def set_file_headers
+      headers['Content-Type'] = 'text/csv'
+      headers['Content-disposition'] = "attachment; filename=\"download.csv\""
+    end
+
+    def set_streaming_headers
+      #nginx doc: Setting this to "no" will allow unbuffered responses suitable for Comet and HTTP streaming applications
+      headers['X-Accel-Buffering'] = 'no'
+
+      headers['Cache-Control'] ||= 'no-cache'
+      headers.delete('Content-Length')
+    end
+  end
+end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -24,6 +24,7 @@ class ContentController < ApplicationController
       format.csv do
         presenter = ContentItemsCSVPresenter.new(
           FindContent.enum(search_params),
+          DateRange.new(search_params[:date_range]),
           document_types,
           organisations
         )

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -1,5 +1,6 @@
 class ContentController < ApplicationController
   include PaginationHelper
+  include Concerns::ExportableToCSV
 
   layout 'application'
   before_action :set_constants
@@ -11,11 +12,25 @@ class ContentController < ApplicationController
   def index
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]
-    search_results = FindContent.call(search_params)
 
-    @presenter = ContentItemsPresenter.new(
-      search_results, search_params, document_types, organisations,
-    )
+    respond_to do |format|
+      format.html do
+        search_results = FindContent.call(search_params)
+
+        @presenter = ContentItemsPresenter.new(
+          search_results, search_params, document_types, organisations,
+        )
+      end
+      format.csv do
+        presenter = ContentItemsCSVPresenter.new(
+          FindContent.enum(search_params),
+          document_types,
+          organisations
+        )
+
+        export_to_csv(enum: presenter.csv_rows)
+      end
+    end
   end
 
 private

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -1,0 +1,50 @@
+require 'csv'
+
+class ContentItemsCSVPresenter
+  def initialize(data_enum, document_types, organisations)
+    @data_enum = data_enum
+    @document_types = document_types
+    @organisations = organisations
+  end
+
+  def csv_rows
+    Enumerator.new do |yielder|
+      yielder << CSV.generate_line(
+        [
+          'Title',
+          'URL',
+          'Content Data Link',
+          'Document Type',
+          'Upviews',
+          'Satisfaction',
+          'Satisfaction Score Responses',
+          'Searches'
+        ]
+      )
+
+      @data_enum.each do |result_row|
+        yielder << CSV.generate_line(
+          [
+            result_row[:title],
+            result_row[:base_path],
+            content_data_link(result_row[:base_path]),
+            result_row[:document_type],
+            result_row[:upviews],
+            result_row[:satisfaction_score_responses],
+            result_row[:searches],
+          ]
+        )
+      end
+    end
+  end
+
+  def content_data_link(base_path)
+    base = Plek.new.external_url_for('content-data-admin')
+
+    base + Rails.application.routes.url_helpers.metrics_path(
+      # Remove / from the start of the base_path, as the url helper
+      # adds it in
+      base_path[1..-1]
+    )
+  end
+end

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -19,7 +19,8 @@ class ContentItemsCSVPresenter
           'Upviews',
           'Satisfaction',
           'Satisfaction Score Responses',
-          'Searches'
+          'Searches',
+          'Link to feedback comments'
         ]
       )
 
@@ -33,6 +34,7 @@ class ContentItemsCSVPresenter
             result_row[:upviews],
             result_row[:satisfaction_score_responses],
             result_row[:searches],
+            feedback_comments_link(result_row[:base_path])
           ]
         )
       end
@@ -47,5 +49,13 @@ class ContentItemsCSVPresenter
       # adds it in
       base_path[1..-1]
     )
+  end
+
+  def feedback_comments_link(base_path)
+    host = Plek.new.external_url_for('support')
+    from = @date_range.from
+    to = @date_range.to
+    path = CGI.escape(base_path)
+    "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
   end
 end

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -1,8 +1,9 @@
 require 'csv'
 
 class ContentItemsCSVPresenter
-  def initialize(data_enum, document_types, organisations)
+  def initialize(data_enum, date_range, document_types, organisations)
     @data_enum = data_enum
+    @date_range = date_range
     @document_types = document_types
     @organisations = organisations
   end

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,6 +1,6 @@
 class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
-  attr_reader :title, :content_items, :pagination
+  attr_reader :title, :content_items, :pagination, :search_parameters
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
 
   def initialize(search_results, search_parameters, document_types, organisations)

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -34,7 +34,7 @@ class FindContent
     Enumerator.new do |yielder|
       (1..Float::INFINITY).each do |index|
         page = api.content(
-          params.merge(page: index)
+          params.merge(page: index, page_size: 5000)
         ).to_h
 
         page

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -5,6 +5,10 @@ class FindContent
     new(params).call
   end
 
+  def self.enum(params)
+    new(params).enum
+  end
+
   def initialize(params)
     range = DateRange.new(params[:date_range])
     @from = range.from
@@ -17,5 +21,28 @@ class FindContent
 
   def call
     api.content(from: @from, to: @to, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
+  end
+
+  def enum
+    params = {
+      from: @from,
+      to: @to,
+      organisation_id: @organisation,
+      document_type: @document_type,
+    }
+
+    Enumerator.new do |yielder|
+      (1..Float::INFINITY).each do |index|
+        page = api.content(
+          params.merge(page: index)
+        ).to_h
+
+        page
+          .fetch(:results, [])
+          .each { |result| yielder << result }
+
+        break if page[:total_pages] <= index
+      end
+    end
   end
 end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -80,9 +80,13 @@
             <p><a href="/content" class="govuk-link govuk-body-s">Clear all filters</a></p>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
-
-            <%# implement later: <p><a href="" class="govuk-link govuk-body-s">Download all data in CSV format</a></p> %>
-
+            <p>
+              <a href="<%= content_path(@presenter.search_parameters.merge(format: :csv)) %>"
+                 class="govuk-link govuk-body-s"
+              >
+                Download all data in CSV format
+              </a>
+            </p>
         </div>
     </div>
     <div class="govuk-grid-column-three-quarters">

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -17,8 +17,8 @@ class GdsApi::ContentDataApi < GdsApi::Base
     get_json(url).to_hash.deep_symbolize_keys
   end
 
-  def content(from:, to:, organisation_id:, document_type: nil, page: nil, search_term: nil)
-    url = content_items_url(from, to, organisation_id, document_type, page, search_term)
+  def content(from:, to:, organisation_id:, document_type: nil, page: nil, page_size: nil, search_term: nil)
+    url = content_items_url(from, to, organisation_id, document_type, page, page_size, search_term)
     get_json(url).to_hash.deep_symbolize_keys
   end
 
@@ -49,7 +49,7 @@ private
     "#{content_data_api_endpoint}/api/v1/metrics/#{base_path}/time-series#{query_string(from: from, to: to, metrics: metrics)}"
   end
 
-  def content_items_url(from, to, organisation_id, document_type, page, search_term)
+  def content_items_url(from, to, organisation_id, document_type, page, page_size, search_term)
     params = {
       from: from,
       to: to,
@@ -57,6 +57,7 @@ private
       document_type: document_type,
       search_term: search_term,
       page: page,
+      page_size: page_size,
     }
     params.reject! { |_, v| v.blank? }
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -201,4 +201,23 @@ RSpec.describe '/content' do
       )
     end
   end
+
+  context 'CSV export' do
+    # Use lots of items to test getting a couple of full pages, plus a
+    # partial page back from the Content Performance Manager.
+    let(:csv_items) { items * 11 }
+
+    it 'it provides a CSV file' do
+      content_data_api_has_content_items(
+        from: from,
+        to: to,
+        organisation_id: 'org-id',
+        items: csv_items
+      )
+
+      click_link 'Download all data in CSV format'
+
+      expect(CSV.parse(page.body).length).to be(csv_items.length + 1)
+    end
+  end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -212,7 +212,8 @@ RSpec.describe '/content' do
         from: from,
         to: to,
         organisation_id: 'org-id',
-        items: csv_items
+        items: csv_items,
+        page_size: 5000
       )
 
       click_link 'Download all data in CSV format'

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -179,7 +179,14 @@ RSpec.describe '/content' do
     end
 
     before do
-      content_data_api_has_content_items(from: from, to: to, organisation_id: 'org-id', page: 2, items: other_page_items)
+      content_data_api_has_content_items(
+        from: from,
+        to: to,
+        organisation_id: 'org-id',
+        items: (items * 50) + other_page_items
+      )
+
+      visit "/content?date_range=last-month&organisation_id=org-id"
     end
 
     it 'shows the second page of data' do

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ContentItemsCSVPresenter do
     it 'correctly generates data rows' do
       data_row = subject.csv_rows.to_a[1]
 
-      expect(CSV.parse_line(data_row).length).to be(8)
+      expect(CSV.parse_line(data_row).length).to be(9)
       expect(data_row).to include('2')
     end
   end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe ContentItemsCSVPresenter do
 
   let(:document_types) { default_document_types }
   let(:organisations) { default_organisations }
+  let(:date_range) { DateRange.new('last-30-days') }
   let(:data_enum) do
     [
       {
@@ -24,7 +25,9 @@ RSpec.describe ContentItemsCSVPresenter do
     ]
   end
 
-  subject { described_class.new(data_enum, document_types, organisations) }
+  subject do
+    described_class.new(data_enum, date_range, document_types, organisations)
+  end
 
   describe '#csv_rows' do
     it 'returns the right number of rows' do

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -1,0 +1,47 @@
+RSpec.describe ContentItemsCSVPresenter do
+  include GdsApi::TestHelpers::ContentDataApi
+
+  let(:document_types) { default_document_types }
+  let(:organisations) { default_organisations }
+  let(:data_enum) do
+    [
+      {
+        title: 'Title 1',
+        base_path: '/base-path-1',
+        doucment_type: 'guide',
+        upviews: 15,
+        satisfaction_score_responses: 2,
+        searches: 14
+      },
+      {
+        title: 'Title 1',
+        base_path: '/base-path-1',
+        doucment_type: 'guide',
+        upviews: 15,
+        satisfaction_score_responses: 2,
+        searches: 14
+      }
+    ]
+  end
+
+  subject { described_class.new(data_enum, document_types, organisations) }
+
+  describe '#csv_rows' do
+    it 'returns the right number of rows' do
+      expect(subject.csv_rows.to_a.length).to eq(3)
+    end
+
+    it 'correctly generates the header' do
+      header = subject.csv_rows.first
+
+      expect(header).to include('Document Type')
+    end
+
+    it 'correctly generates data rows' do
+      data_row = subject.csv_rows.to_a[1]
+
+      expect(CSV.parse_line(data_row).length).to be(7)
+      expect(data_row).to include('2')
+    end
+  end
+end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ContentItemsCSVPresenter do
     it 'correctly generates data rows' do
       data_row = subject.csv_rows.to_a[1]
 
-      expect(CSV.parse_line(data_row).length).to be(7)
+      expect(CSV.parse_line(data_row).length).to be(8)
       expect(data_row).to include('2')
     end
   end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -34,15 +34,17 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, page: nil, search_term: nil, items:, page_size: 10)
+      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, page: nil, search_term: nil, items:, page_size: nil)
         params = {
           from: from,
           to: to,
           organisation_id: organisation_id,
           document_type: document_type,
           search_term: search_term,
+          page_size: page_size,
         }.reject { |_, v| v.blank? }
 
+        page_size ||= 100
         total_pages = (items.length.to_f / page_size).ceil
         items.each_slice(page_size).with_index(1) do |(*items_for_page), page|
           body = {

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -34,7 +34,7 @@ module GdsApi
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
-      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, page: nil, search_term: nil, items:, page_size: nil)
+      def content_data_api_has_content_items(from:, to:, organisation_id:, document_type: nil, search_term: nil, items:, page_size: nil)
         params = {
           from: from,
           to: to,


### PR DESCRIPTION
# What
Make it possible for a user to download data as a CSV from the index page. The CSV download should respect the filters that a user has applied (date, organisation, document type, title/URL)

# Why
We identified a need in user research for some of our users to download data from Content Data and do further analysis.

https://trello.com/c/yLoOoyUv/864-5-index-page-add-download-csv

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
![screen shot 2018-11-23 at 10 23 19](https://user-images.githubusercontent.com/1130010/48938729-f8a35d00-ef09-11e8-8cf4-561d577729ea.png)

## After
![screen shot 2018-11-23 at 10 23 07](https://user-images.githubusercontent.com/1130010/48938727-f80ac680-ef09-11e8-98b5-cf1df6a0370a.png)


---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
