### PR TITLE
Use better filename for CSV download

### DIFF
--- a/app/controllers/concerns/exportable_to_csv.rb
+++ b/app/controllers/concerns/exportable_to_csv.rb
@@ -4,8 +4,8 @@ module Concerns::ExportableToCSV
   extend ActiveSupport::Concern
 
   included do
-    def export_to_csv(enum:)
-      set_file_headers
+    def export_to_csv(enum:, filename: 'download.csv')
+      set_file_headers(filename)
       set_streaming_headers
 
       response.status = 200
@@ -14,9 +14,9 @@ module Concerns::ExportableToCSV
 
   private
 
-    def set_file_headers
+    def set_file_headers(filename)
       headers['Content-Type'] = 'text/csv'
-      headers['Content-disposition'] = "attachment; filename=\"download.csv\""
+      headers['Content-disposition'] = "attachment; filename=\"#{filename}\""
     end
 
     def set_streaming_headers

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -29,7 +29,7 @@ class ContentController < ApplicationController
           organisations
         )
 
-        export_to_csv(enum: presenter.csv_rows)
+        export_to_csv(enum: presenter.csv_rows, filename: presenter.filename)
       end
     end
   end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -24,7 +24,7 @@ class ContentController < ApplicationController
       format.csv do
         presenter = ContentItemsCSVPresenter.new(
           FindContent.enum(search_params),
-          DateRange.new(search_params[:date_range]),
+          search_params,
           document_types,
           organisations
         )

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -1,9 +1,9 @@
 require 'csv'
 
 class ContentItemsCSVPresenter
-  def initialize(data_enum, date_range, document_types, organisations)
+  def initialize(data_enum, search_params, document_types, organisations)
     @data_enum = data_enum
-    @date_range = date_range
+    @date_range = DateRange.new(search_params[:date_range])
     @document_types = document_types
     @organisations = organisations
   end

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -10,10 +10,6 @@ class ContentItemsCSVPresenter
     @organisations = organisations
   end
 
-  def raw_field(name)
-    lambda { |result_row| result_row[name] }
-  end
-
   def csv_rows
     fields = {
       'Title' => raw_field(:title),
@@ -42,14 +38,6 @@ class ContentItemsCSVPresenter
     end
   end
 
-  def organisation_title
-    organisation_data = @organisations.find do |org|
-      org[:organisation_id] == @organisation_id
-    end
-
-    organisation_data[:title]
-  end
-
   def filename
     "content-data-export-from-%<from>s-to-%<to>s-from-%<org>s%<document_type>s.csv" % {
       from: @date_range.from,
@@ -57,6 +45,20 @@ class ContentItemsCSVPresenter
       org: organisation_title.parameterize,
       document_type: @document_type.present? ? "-in-#{@document_type.tr('_', '-')}" : ''
     }
+  end
+
+private
+
+  def raw_field(name)
+    lambda { |result_row| result_row[name] }
+  end
+
+  def organisation_title
+    organisation_data = @organisations.find do |org|
+      org[:organisation_id] == @organisation_id
+    end
+
+    organisation_data[:title]
   end
 
   def content_data_link(base_path)

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -3,6 +3,8 @@ require 'csv'
 class ContentItemsCSVPresenter
   def initialize(data_enum, search_params, document_types, organisations)
     @data_enum = data_enum
+    @document_type = search_params[:document_type]
+    @organisation_id = search_params[:organisation_id]
     @date_range = DateRange.new(search_params[:date_range])
     @document_types = document_types
     @organisations = organisations
@@ -38,6 +40,23 @@ class ContentItemsCSVPresenter
         )
       end
     end
+  end
+
+  def organisation_title
+    organisation_data = @organisations.find do |org|
+      org[:organisation_id] == @organisation_id
+    end
+
+    organisation_data[:title]
+  end
+
+  def filename
+    "content-data-export-from-%<from>s-to-%<to>s-from-%<org>s%<document_type>s.csv" % {
+      from: @date_range.from,
+      to: @date_range.to,
+      org: organisation_title.parameterize,
+      document_type: @document_type.present? ? "-in-#{@document_type.tr('_', '-')}" : ''
+    }
   end
 
   def content_data_link(base_path)

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe ContentItemsCSVPresenter do
       expect(data_row).to include('2')
     end
   end
+
+  describe '#filename' do
+    it 'includes the organisation and document_type' do
+      expect(
+        subject.filename
+      ).to include('from-org-in-news-story.csv')
+    end
+  end
 end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -3,7 +3,13 @@ RSpec.describe ContentItemsCSVPresenter do
 
   let(:document_types) { default_document_types }
   let(:organisations) { default_organisations }
-  let(:date_range) { DateRange.new('past-30-days') }
+  let(:search_params) do
+    {
+      date_range: 'past-30-days',
+      organisation_id: 'org-id',
+      document_type: 'news_story'
+    }
+  end
   let(:data_enum) do
     [
       {
@@ -26,7 +32,7 @@ RSpec.describe ContentItemsCSVPresenter do
   end
 
   subject do
-    described_class.new(data_enum, date_range, document_types, organisations)
+    described_class.new(data_enum, search_params, document_types, organisations)
   end
 
   describe '#csv_rows' do


### PR DESCRIPTION
https://trello.com/c/yLoOoyUv/864-5-index-page-add-download-csv

This generates filenames like `content-data-export-from-2018-10-26-to-2018-11-25-from-government-digital-service.csv`, rather than the previous `download.csv`.