### PR TITLE
Fix typo in 'About number of PDFs'

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -105,6 +105,6 @@ en:
       about: >
         Compared with HTML content, information published in a PDF is harder to find, use and 
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
-        Serveral PDFs on one page may indicate that too many users needs are being met by them.
+        Several PDFs on one page may indicate that too many users needs are being met by them.
         <a href="https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/">Read more about why to avoid PDFs</a>.
 


### PR DESCRIPTION
# What
Several is misspelt - change 'serveral' to 'several'

# Why
So users' trust in the tool isn't undermined