### PR TITLE
Add filter information above table

### DIFF
--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,6 +1,6 @@
 class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
-  attr_reader :title, :content_items, :pagination, :filter
+  attr_reader :title, :content_items, :pagination, :filter, :search_parameters
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
   delegate :document_type_options, :organisation_options, to: :filter
 

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -2,7 +2,6 @@ class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
   attr_reader :title, :content_items, :pagination, :filter, :search_parameters
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
-  delegate :document_type_options, :organisation_options, to: :filter
 
   def initialize(search_results, search_parameters, document_types, organisations)
     @title = 'Content Items'

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -1,13 +1,13 @@
 class ContentItemsPresenter
   include Kaminari::Helpers::HelperMethods
-  attr_reader :title, :content_items, :pagination, :search_parameters
+  attr_reader :title, :content_items, :pagination, :filter
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
+  delegate :document_type_options, :organisation_options, to: :filter
 
   def initialize(search_results, search_parameters, document_types, organisations)
     @title = 'Content Items'
+    @filter = FilterPresenter.new(search_parameters, document_types, organisations)
     @search_parameters = search_parameters
-    @document_types = document_types
-    @organisations = organisations
     @pagination = PaginationPresenter.new(
       page: search_results[:page] || 1,
       total_pages: search_results[:total_pages],
@@ -18,32 +18,6 @@ class ContentItemsPresenter
 
   def time_period
     @search_parameters[:date_range]
-  end
-
-  def document_type_options
-    types = [{
-      text: 'All document types',
-      value: '',
-      selected: @search_parameters[:document_type] == ''
-    }]
-    @document_types.each do |document_type|
-      types.push(
-        text: document_type.try(:tr, '_', ' ').try(:capitalize),
-        value: document_type,
-        selected: document_type == @search_parameters[:document_type]
-      )
-    end
-    types
-  end
-
-  def organisation_options
-    @organisations.map do |org|
-      {
-        text: org[:title],
-        value: org[:organisation_id],
-        selected: org[:organisation_id] == @search_parameters[:organisation_id]
-      }
-    end
   end
 
 private

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -6,7 +6,7 @@ class FilterPresenter
   end
 
   def document_type?
-    !@search_parameters[:document_type].blank?
+    @search_parameters[:document_type].present?
   end
 
   def document_type_options
@@ -25,6 +25,14 @@ class FilterPresenter
     types
   end
 
+  def organisation_name
+    find_selected_org[:text]
+  end
+
+  def document_type
+    find_document_type[:text]
+  end
+
   def organisation_options
     @organisations.map do |org|
       {
@@ -33,5 +41,15 @@ class FilterPresenter
         selected: org[:organisation_id] == @search_parameters[:organisation_id]
       }
     end
+  end
+
+private
+
+  def find_selected_org
+    organisation_options.find { |o| o[:selected] }
+  end
+
+  def find_document_type
+    document_type_options.find { |d| d[:selected] }
   end
 end

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -1,0 +1,37 @@
+class FilterPresenter
+  def initialize(search_parameters, document_types, organisations)
+    @document_types = document_types
+    @search_parameters = search_parameters
+    @organisations = organisations
+  end
+
+  def document_type?
+    !@search_parameters[:document_type].blank?
+  end
+
+  def document_type_options
+    types = [{
+               text: 'All document types',
+               value: '',
+               selected: @search_parameters[:document_type] == ''
+             }]
+    @document_types.each do |document_type|
+      types.push(
+        text: document_type.try(:tr, '_', ' ').try(:capitalize),
+        value: document_type,
+        selected: document_type == @search_parameters[:document_type]
+      )
+    end
+    types
+  end
+
+  def organisation_options
+    @organisations.map do |org|
+      {
+        text: org[:title],
+        value: org[:organisation_id],
+        selected: org[:organisation_id] == @search_parameters[:organisation_id]
+      }
+    end
+  end
+end

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -9,6 +9,10 @@ class FilterPresenter
     @search_parameters[:document_type].present?
   end
 
+  def document_type
+    find_document_type[:text]
+  end
+
   def document_type_options
     types = [{
                text: 'All document types',
@@ -25,14 +29,6 @@ class FilterPresenter
     types
   end
 
-  def organisation_name
-    find_selected_org[:text]
-  end
-
-  def document_type
-    find_document_type[:text]
-  end
-
   def organisation_options
     @organisations.map do |org|
       {
@@ -41,6 +37,10 @@ class FilterPresenter
         selected: org[:organisation_id] == @search_parameters[:organisation_id]
       }
     end
+  end
+
+  def organisation_name
+    find_selected_org[:text]
   end
 
 private

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -2,8 +2,8 @@
     <span class="table-header__param"><%= pagination.first_record %></span> to
     <span class="table-header__param"><%= pagination.last_record %></span> of
     <span class="table-header__param"><%= pagination.total_results %></span> results
-    from <span class="table-header__param"><%= filter.organisation_name %></span>
     <% if filter.document_type? %>
-        in <span class="table-header__param"><%= filter.document_type %></span>.
+        for <span class="table-header__param"><%= filter.document_type %></span>
     <% end %>
+    from <span class="table-header__param"><%= filter.organisation_name %></span>.
 </h1>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -2,6 +2,8 @@
     <span class="table-header__param"><%= pagination.first_record %></span> to
     <span class="table-header__param"><%= pagination.last_record %></span> of
     <span class="table-header__param"><%= pagination.total_results %></span> results
-    from <span class="table-header__param">UK Visas and Immigration</span>
-    in <span class="table-header__param">guidance</span>.
+    from <span class="table-header__param"><%= filter.organisation_name %></span>
+    <% if filter.document_type? %>
+        in <span class="table-header__param"><%= filter.document_type %></span>.
+    <% end %>
 </h1>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -65,12 +65,12 @@
               <%= render "govuk_publishing_components/components/select", {
               id: "document_type",
               label: "Document type",
-              options: @presenter.document_type_options
+              options: @presenter.filter.document_type_options
             } %>
             <%= render "govuk_publishing_components/components/select", {
               id: "organisation_id",
               label: "Organisation",
-              options: @presenter.organisation_options
+              options: @presenter.filter.organisation_options
             } %>
 
             <%= render "govuk_publishing_components/components/button", {text: "Filter"} %>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -93,7 +93,7 @@
       <div class="table-wrapper">
         <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
             self,
-            render('table_data_description', pagination: @presenter.pagination),
+            render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter),
             sortable: false
           ) do |t| %>
             <%= t.head do %>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -147,7 +147,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from org in News story')
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for News story from org')
     end
 
     it 'allows the filter to be cleared' do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe '/content' do
       expect(page).to have_select('organisation_id', selected: 'another org')
     end
 
+    it 'describes the filter in the table header' do
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 2 of 2 results from another org')
+    end
+
     it 'respects date range' do
       stub_metrics_page(base_path: 'path/1', time_period: :last_year)
       content_data_api_has_content_items(date_range: 'last-year', organisation_id: 'another-org-id', items: items)
@@ -117,6 +121,10 @@ RSpec.describe '/content' do
         expect(page.status_code).to eq(200)
         expect(page).to have_content('Content from users-org-id')
       end
+
+      it 'describes the filter in the table header' do
+        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from Users Org')
+      end
     end
   end
 
@@ -138,12 +146,17 @@ RSpec.describe '/content' do
       expect(table_rows).to all(include('News story'))
     end
 
+    it 'describes the filter in the table header' do
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from org in News story')
+    end
+
     it 'allows the filter to be cleared' do
       select 'All document types', from: 'document_type'
       click_on 'Filter'
       expect(page).to have_select('document_type', selected: 'All document types')
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(3)
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 2 of 2 results from org')
     end
   end
 
@@ -182,6 +195,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows the second page of data' do
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 100 of 102 results from org')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -191,6 +205,7 @@ RSpec.describe '/content' do
           ['forth title /path/4', 'News story', '100,018', '68% (42 responses)', '12'],
         ]
       )
+      expect(page).to have_css('h1.table-header', text: 'Showing 101 to 102 of 102 results from org')
     end
   end
 

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -29,42 +29,6 @@ RSpec.describe ContentItemsPresenter do
     ContentItemsPresenter.new(content_items, search_parameters, document_types, organisations)
   end
 
-  describe '#document_type_options' do
-    context 'when valid document type in parameter' do
-      it 'formats the document types for the options component' do
-        expect(subject.document_type_options).to eq([
-          { text: 'All document types', value: '', selected: false },
-          { text: 'Case study', value: 'case_study', selected: false },
-          { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: true }
-        ])
-      end
-    end
-
-    context 'when no document type in parameter' do
-      before { search_parameters[:document_type] = '' }
-      it 'formats the document types for the options component' do
-        expect(subject.document_type_options).to eq([
-          { text: 'All document types', value: '', selected: true },
-          { text: 'Case study', value: 'case_study', selected: false },
-          { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: false }
-        ])
-      end
-    end
-  end
-
-  describe '#organisation_options' do
-    context 'when valid organisation id in parameter' do
-      it 'formats the organisations for the options component' do
-        expect(subject.organisation_options).to eq([
-          { text: 'org', value: 'org-id', selected: true },
-          { text: 'another org', value: 'another-org-id', selected: false }
-        ])
-      end
-    end
-  end
-
   describe '#prev_link?' do
     it 'returns false if on first page' do
       expect(subject.prev_link?).to eq(false)

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe FilterPresenter do
+  include GdsApi::TestHelpers::ContentDataApi
+  let(:document_types) { default_document_types }
+  let(:organisations) { default_organisations }
+  let(:search_parameters) do
+    {
+      document_type: 'news_story',
+      organisation_id: 'org-id'
+    }
+  end
+
+  subject do
+    FilterPresenter.new(
+      search_parameters,
+      document_types,
+      organisations,
+    )
+  end
+  describe '#document_type_options' do
+    context 'when valid document type in parameter' do
+      it 'formats the document types for the options component' do
+        expect(subject.document_type_options).to eq([
+          { text: 'All document types', value: '', selected: false },
+          { text: 'Case study', value: 'case_study', selected: false },
+          { text: 'Guide', value: 'guide', selected: false },
+          { text: 'News story', value: 'news_story', selected: true }
+        ])
+      end
+    end
+
+    context 'when no document type in parameter' do
+      before { search_parameters[:document_type] = '' }
+      it 'formats the document types for the options component' do
+        expect(subject.document_type_options).to eq([
+          { text: 'All document types', value: '', selected: true },
+          { text: 'Case study', value: 'case_study', selected: false },
+          { text: 'Guide', value: 'guide', selected: false },
+          { text: 'News story', value: 'news_story', selected: false }
+        ])
+      end
+    end
+  end
+
+  describe '#organisation_options' do
+    context 'when valid organisation id in parameter' do
+      it 'formats the organisations for the options component' do
+        expect(subject.organisation_options).to eq([
+          { text: 'org', value: 'org-id', selected: true },
+          { text: 'another org', value: 'another-org-id', selected: false }
+        ])
+      end
+    end
+  end
+
+  describe '#document_type?' do
+    context 'when valid document type in parameter' do
+      it 'returns true' do
+        expect(subject.document_type?).to eq(true)
+      end
+    end
+
+    context 'when no document type in parameter' do
+      before { search_parameters[:document_type] = '' }
+      it 'returns false' do
+        expect(subject.document_type?).to eq(false)
+      end
+    end
+  end
+
+  describe '#document_type'
+end

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe FilterPresenter do
       organisations,
     )
   end
+
   describe '#document_type_options' do
     context 'when valid document type in parameter' do
       it 'formats the document types for the options component' do
@@ -46,7 +47,8 @@ RSpec.describe FilterPresenter do
       it 'formats the organisations for the options component' do
         expect(subject.organisation_options).to eq([
           { text: 'org', value: 'org-id', selected: true },
-          { text: 'another org', value: 'another-org-id', selected: false }
+          { text: 'another org', value: 'another-org-id', selected: false },
+          { text: 'Users Org', value: 'users-org-id', selected: false }
         ])
       end
     end
@@ -67,5 +69,15 @@ RSpec.describe FilterPresenter do
     end
   end
 
-  describe '#document_type'
+  describe '#document_type' do
+    it 'returns the formatted document type' do
+      expect(subject.document_type).to eq("News story")
+    end
+  end
+
+  describe '#organisation_name' do
+    it 'returns the selected organisation name' do
+      expect(subject.organisation_name).to eq('org')
+    end
+  end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -368,6 +368,10 @@ module GdsApi
           {
             title: 'another org',
             organisation_id: 'another-org-id'
+          },
+          {
+            title: 'Users Org',
+            organisation_id: 'users-org-id'
           }
         ]
       end


### PR DESCRIPTION
### What
Add the text above the table to indicate what filters are applied. This should change when a user changes the filters applied.

### Why
Currently, we only have placeholder text for UKVI. We need to implement this functionality for private beta.

### Trello
https://trello.com/c/BZrqyTPo/830-2-index-page-add-information-above-the-table-to-indicate-filters-applied
# Screenshots

## Before
![before](https://user-images.githubusercontent.com/511319/49016186-3360fb80-f17d-11e8-9eb1-2430a743342d.png)

## After
![after](https://user-images.githubusercontent.com/511319/49016197-39ef7300-f17d-11e8-8b22-3182bbd97f7e.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
