### PR TITLE
Remove `Published` and `Last updated`

### DIFF
--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -15,16 +15,6 @@
     </dl>
   <% end %>
   <dl class="app-c-metadata__list">
-    <% if published_at %>
-      <dt class="app-c-metadata__title"><%= t ".labels.published_at" %></dt>
-      <dd class="app-c-metadata__description"><%= published_at %></dd>
-    <% end %>
-    <% if last_updated %>
-      <dt class="app-c-metadata__title"><%= t ".labels.last_updated" %></dt>
-      <dd class="app-c-metadata__description"><%= last_updated %></dd>
-    <% end %>
-  </dl>
-  <dl class="app-c-metadata__list">
     <% if publishing_organisation %>
       <dt class="app-c-metadata__title"><%= t ".labels.publishing_organisation" %></dt>
       <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -15,13 +15,9 @@ RSpec.describe "Metadata", type: :view do
   it "renders correctly when given valid data" do
     render_component(data)
     assert_select ".app-c-metadata"
-    assert_select ".app-c-metadata__title", 6
+    assert_select ".app-c-metadata__title", 4
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.status")
     assert_select ".app-c-metadata__description", text: "withdrawn"
-    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.published_at")
-    assert_select ".app-c-metadata__description", text: "1 September 2016"
-    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.last_updated")
-    assert_select ".app-c-metadata__description", text: "1 October 2017"
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.publishing_organisation")
     assert_select ".app-c-metadata__description", text: "UK Visas and Immigration"
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.document_type")

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -31,8 +31,6 @@ RSpec.describe '/metrics/base/path', type: :feature do
           el.all('dt,dd').map(&:text)
         end
         expect(metadata).to eq([
-                                 [I18n.t("components.metadata.labels.published_at"), '17 July 2018',
-                                  I18n.t("components.metadata.labels.last_updated"), '17 July 2018'],
                                  [I18n.t("components.metadata.labels.publishing_organisation"), 'The Ministry',
                                   I18n.t("components.metadata.labels.document_type"), 'News story',
                                   I18n.t("components.metadata.labels.base_path"), 'gov.uk/base/path']


### PR DESCRIPTION
#What
Don't display 'published' and 'last updated' in metadata on the Page Data page.

#Why
We don't trust dates to be accurate and are worried we'll mislead our users. We need to investigate the accuracy of dates more thoroughly before we can display them to users.

## Trello https://trello.com/c/5xJV5Xrk/870-1-page-data-dont-display-published-and-last-updated-in-metadata

# Screenshots
## Before
![before](https://user-images.githubusercontent.com/511319/49025629-fce2ab00-f193-11e8-96ba-0bd58ca38fb9.png)
## After
![after](https://user-images.githubusercontent.com/511319/49025635-ff450500-f193-11e8-99c1-f7121c130f77.png)

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
