### PR TITLE
Add links to content items publisher application

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -1,5 +1,5 @@
 module ExternalLinksHelper
-  def edit_url_for(content_id:, publishing_app:, base_path:)
+  def edit_url_for(content_id:, publishing_app:, base_path:, document_type:)
     case publishing_app
     when 'whitehall'
       "#{external_url_for('whitehall-admin')}/government/admin/by-content-id/#{content_id}"
@@ -12,7 +12,7 @@ module ExternalLinksHelper
     when 'contacts'
       "#{external_url_for('contacts-admin')}/admin/contacts/#{slug_from_basepath(base_path)}/edit"
     when 'specialist-publisher'
-      "#{external_url_for('specialist-publisher')}/service-standard-reports/#{content_id}/edit"
+      "#{external_url_for('specialist-publisher')}/#{specialist_publisher_path(document_type, content_id)}"
     when 'collections-publisher'
       "#{external_url_for('support')}/general_request/new"
     when 'travel-advice-publisher'
@@ -40,5 +40,10 @@ module ExternalLinksHelper
 
   def slug_from_basepath(base_path)
     base_path.split('/').last
+  end
+
+  def specialist_publisher_path(document_type, content_id)
+    formatted_document_type = document_type.tr("_", "-") + 's'
+    "#{formatted_document_type}/#{content_id}/edit"
   end
 end

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -15,6 +15,8 @@ module ExternalLinksHelper
       "#{external_url_for('specialist-publisher')}/service-standard-reports/#{content_id}/edit"
     when 'collections-publisher'
       "#{external_url_for('support')}/general_request/new"
+    when 'travel-advice-publisher'
+      "#{external_url_for('travel-advice-publisher')}/admin/#{slug_from_basepath(base_path)}"
     end
   end
 

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -11,6 +11,8 @@ module ExternalLinksHelper
       "#{external_url_for('maslow')}/needs/#{content_id}"
     when 'contacts'
       "#{external_url_for('contacts-admin')}/admin/contacts/#{slug_from_basepath(base_path)}/edit"
+    when 'specialist-publisher'
+      "#{external_url_for('specialist-publisher')}/service-standard-reports/#{content_id}/edit"
     end
   end
 

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -13,6 +13,8 @@ module ExternalLinksHelper
       "#{external_url_for('contacts-admin')}/admin/contacts/#{slug_from_basepath(base_path)}/edit"
     when 'specialist-publisher'
       "#{external_url_for('specialist-publisher')}/service-standard-reports/#{content_id}/edit"
+    when 'collections-publisher'
+      "#{external_url_for('support')}/general_request/new"
     end
   end
 

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -1,5 +1,5 @@
 module ExternalLinksHelper
-  def edit_url_for(content_id:, publishing_app:)
+  def edit_url_for(content_id:, publishing_app:, base_path:)
     case publishing_app
     when 'whitehall'
       "#{external_url_for('whitehall-admin')}/government/admin/by-content-id/#{content_id}"
@@ -9,6 +9,8 @@ module ExternalLinksHelper
       "#{external_url_for('manuals-publisher')}/manuals/#{content_id}"
     when 'maslow', 'need-api'
       "#{external_url_for('maslow')}/needs/#{content_id}"
+    when 'contacts'
+      "#{external_url_for('contacts-admin')}/admin/contacts/#{slug_from_basepath(base_path)}/edit"
     end
   end
 
@@ -28,5 +30,9 @@ module ExternalLinksHelper
 
   def external_url_for(service)
     Plek.new.external_url_for(service)
+  end
+
+  def slug_from_basepath(base_path)
+    base_path.split('/').last
   end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -106,7 +106,8 @@ class SingleContentItemPresenter
     edit_url_for(
       content_id: metadata[:content_id],
       publishing_app: metadata[:publishing_app],
-      base_path: base_path
+      base_path: base_path,
+      document_type: metadata[:document_type]
     )
   end
 

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -105,7 +105,8 @@ class SingleContentItemPresenter
   def edit_url
     edit_url_for(
       content_id: metadata[:content_id],
-      publishing_app: metadata[:publishing_app]
+      publishing_app: metadata[:publishing_app],
+      base_path: base_path
     )
   end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -261,7 +261,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the specialist publisher application' do
         stub_metrics_page(base_path: 'specialist/path', time_period: :last_30_days, publishing_app: 'specialist-publisher')
         visit '/metrics/specialist/path'
-        expect(page).to have_link("Edit in Specialist publisher", href: "http://specialist-publisher.dev.gov.uk/service-standard-reports/content-id/edit")
+        expect(page).to have_link("Edit in Specialist publisher", href: "http://specialist-publisher.dev.gov.uk/news-storys/content-id/edit")
       end
 
       it 'renders the collections application' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -251,6 +251,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the publishing application' do
         expect(page).to have_selector '.related-actions', text: 'Whitehall'
       end
+
+      it 'renders the contacts application' do
+        stub_metrics_page(base_path: 'contacts/path', time_period: :last_30_days, publishing_app: 'contacts')
+        visit '/metrics/contacts/path'
+        expect(page).to have_link("Edit in Contacts", href: 'http://contacts-admin.dev.gov.uk/admin/contacts/path/edit')
+      end
     end
   end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -253,25 +253,25 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders the contacts application' do
-        stub_metrics_page(base_path: 'contacts/path', time_period: :last_30_days, publishing_app: 'contacts')
+        stub_metrics_page(base_path: 'contacts/path', time_period: :past_30_days, publishing_app: 'contacts')
         visit '/metrics/contacts/path'
         expect(page).to have_link("Edit in Contacts", href: 'http://contacts-admin.dev.gov.uk/admin/contacts/path/edit')
       end
 
       it 'renders the specialist publisher application' do
-        stub_metrics_page(base_path: 'specialist/path', time_period: :last_30_days, publishing_app: 'specialist-publisher')
+        stub_metrics_page(base_path: 'specialist/path', time_period: :past_30_days, publishing_app: 'specialist-publisher')
         visit '/metrics/specialist/path'
         expect(page).to have_link("Edit in Specialist publisher", href: "http://specialist-publisher.dev.gov.uk/news-storys/content-id/edit")
       end
 
       it 'renders the collections application' do
-        stub_metrics_page(base_path: 'collections/path', time_period: :last_30_days, publishing_app: 'collections-publisher')
+        stub_metrics_page(base_path: 'collections/path', time_period: :past_30_days, publishing_app: 'collections-publisher')
         visit '/metrics/collections/path'
         expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/general_request/new')
       end
 
       it 'renders the travel advice application' do
-        stub_metrics_page(base_path: 'travel/path', time_period: :last_30_days, publishing_app: 'travel-advice-publisher')
+        stub_metrics_page(base_path: 'travel/path', time_period: :past_30_days, publishing_app: 'travel-advice-publisher')
         visit '/metrics/travel/path'
         expect(page).to have_link("Edit in Travel advice publisher", href: 'http://travel-advice-publisher.dev.gov.uk/admin/path')
       end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -263,6 +263,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
         visit '/metrics/specialist/path'
         expect(page).to have_link("Edit in Specialist publisher", href: "http://specialist-publisher.dev.gov.uk/service-standard-reports/content-id/edit")
       end
+
+      it 'renders the collections application' do
+        stub_metrics_page(base_path: 'collections/path', time_period: :last_30_days, publishing_app: 'collections-publisher')
+        visit '/metrics/collections/path'
+        expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/general_request/new')
+      end
     end
   end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -269,6 +269,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
         visit '/metrics/collections/path'
         expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/general_request/new')
       end
+
+      it 'renders the travel advice application' do
+        stub_metrics_page(base_path: 'travel/path', time_period: :last_30_days, publishing_app: 'travel-advice-publisher')
+        visit '/metrics/travel/path'
+        expect(page).to have_link("Edit in Travel advice publisher", href: 'http://travel-advice-publisher.dev.gov.uk/admin/path')
+      end
     end
   end
 end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -257,6 +257,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
         visit '/metrics/contacts/path'
         expect(page).to have_link("Edit in Contacts", href: 'http://contacts-admin.dev.gov.uk/admin/contacts/path/edit')
       end
+
+      it 'renders the specialist publisher application' do
+        stub_metrics_page(base_path: 'specialist/path', time_period: :last_30_days, publishing_app: 'specialist-publisher')
+        visit '/metrics/specialist/path'
+        expect(page).to have_link("Edit in Specialist publisher", href: "http://specialist-publisher.dev.gov.uk/service-standard-reports/content-id/edit")
+      end
     end
   end
 end

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ExternalLinksHelper do
     context 'with a known publishing app' do
       it 'generates an expected URL' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'whitehall', base_path: '/base-path')
+          edit_url_for(content_id: 'content_id', publishing_app: 'whitehall', base_path: '/base-path', document_type: 'news_story')
         ).to eq(
           "#{Plek.new.external_url_for('whitehall-admin')}/government/admin/by-content-id/content_id"
         )
@@ -13,7 +13,7 @@ RSpec.describe ExternalLinksHelper do
     context 'with publisher' do
       it 'generates a link to the Support app' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'publisher', base_path: '/base-path')
+          edit_url_for(content_id: 'content_id', publishing_app: 'publisher', base_path: '/base-path', document_type: 'news_story')
         ).to eq(
           "#{Plek.new.external_url_for('support')}/content_change_request/new"
         )
@@ -25,7 +25,8 @@ RSpec.describe ExternalLinksHelper do
         expect(
           edit_url_for(content_id: 'content_id',
                        publishing_app: 'contacts',
-                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line',
+                       document_type: 'news_story')
         ).to eq(
           "#{external_url_for('contacts-admin')}/admin/contacts/tax-credits-agent-priority-line/edit"
         )
@@ -33,13 +34,23 @@ RSpec.describe ExternalLinksHelper do
     end
 
     context 'with specialist-publisher' do
-      it 'generates a link to the specialist publisher app' do
+      it 'generates a link to the specialist publisher app with document_type' do
         expect(
           edit_url_for(content_id: 'spec-pub-id',
                        publishing_app: 'specialist-publisher',
-                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line',
+                       document_type: 'service_standard_report')
         ).to eq(
           "#{external_url_for('specialist-publisher')}/service-standard-reports/spec-pub-id/edit"
+        )
+
+        expect(
+          edit_url_for(content_id: 'spec-pub-id',
+                       publishing_app: 'specialist-publisher',
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line',
+                       document_type: 'aaib_report')
+        ).to eq(
+          "#{external_url_for('specialist-publisher')}/aaib-reports/spec-pub-id/edit"
         )
       end
     end
@@ -49,7 +60,8 @@ RSpec.describe ExternalLinksHelper do
         expect(
           edit_url_for(content_id: 'coll-pub-id',
                        publishing_app: 'collections-publisher',
-                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line',
+                       document_type: 'news_story')
         ).to eq(
           "#{external_url_for('support')}/general_request/new"
         )
@@ -61,7 +73,8 @@ RSpec.describe ExternalLinksHelper do
         expect(
           edit_url_for(content_id: 'ta-pub-id',
                        publishing_app: 'travel-advice-publisher',
-                       base_path: '/foreign-travel-advice/brunei')
+                       base_path: '/foreign-travel-advice/brunei',
+                       document_type: 'news_story')
         ).to eq(
           "#{external_url_for('travel-advice-publisher')}/admin/brunei"
         )
@@ -71,7 +84,7 @@ RSpec.describe ExternalLinksHelper do
     context 'with an unknown publishing app' do
       it 'returns nil' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'not-an-app', base_path: '/base-path')
+          edit_url_for(content_id: 'content_id', publishing_app: 'not-an-app', base_path: '/base-path', document_type: 'news_story')
         ).to eq(
           nil
         )

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ExternalLinksHelper do
     context 'with a known publishing app' do
       it 'generates an expected URL' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'whitehall')
+          edit_url_for(content_id: 'content_id', publishing_app: 'whitehall', base_path: '/base-path')
         ).to eq(
           "#{Plek.new.external_url_for('whitehall-admin')}/government/admin/by-content-id/content_id"
         )
@@ -13,17 +13,30 @@ RSpec.describe ExternalLinksHelper do
     context 'with publisher' do
       it 'generates a link to the Support app' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'publisher')
+          edit_url_for(content_id: 'content_id', publishing_app: 'publisher', base_path: '/base-path')
         ).to eq(
           "#{Plek.new.external_url_for('support')}/content_change_request/new"
         )
       end
     end
 
+    context 'with contacts' do
+      it 'generates a link to the contacts publisher app' do
+        expect(
+          edit_url_for(content_id: 'content_id',
+                       publishing_app: 'contacts',
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+        ).to eq(
+          "#{external_url_for('contacts-admin')}/admin/contacts/tax-credits-agent-priority-line/edit"
+        )
+      end
+    end
+
+
     context 'with an unknown publishing app' do
       it 'returns nil' do
         expect(
-          edit_url_for(content_id: 'content_id', publishing_app: 'not-an-app')
+          edit_url_for(content_id: 'content_id', publishing_app: 'not-an-app', base_path: '/base-path')
         ).to eq(
           nil
         )

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -32,6 +32,17 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
+    context 'with specialist-publisher' do
+      it 'generates a link to the specialist publisher app' do
+        expect(
+          edit_url_for(content_id: 'spec-pub-id',
+                       publishing_app: 'specialist-publisher',
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+        ).to eq(
+          "#{external_url_for('specialist-publisher')}/service-standard-reports/spec-pub-id/edit"
+        )
+      end
+    end
 
     context 'with an unknown publishing app' do
       it 'returns nil' do

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -44,6 +44,18 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
+    context 'with collections' do
+      it 'generates a link to the collections publisher app' do
+        expect(
+          edit_url_for(content_id: 'coll-pub-id',
+                       publishing_app: 'collections-publisher',
+                       base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line')
+        ).to eq(
+          "#{external_url_for('support')}/general_request/new"
+        )
+      end
+    end
+
     context 'with an unknown publishing app' do
       it 'returns nil' do
         expect(

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -56,6 +56,18 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
+    context 'with travel advice' do
+      it 'generates a link to the collections publisher app' do
+        expect(
+          edit_url_for(content_id: 'ta-pub-id',
+                       publishing_app: 'travel-advice-publisher',
+                       base_path: '/foreign-travel-advice/brunei')
+        ).to eq(
+          "#{external_url_for('travel-advice-publisher')}/admin/brunei"
+        )
+      end
+    end
+
     context 'with an unknown publishing app' do
       it 'returns nil' do
         expect(

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -231,7 +231,8 @@ RSpec.describe SingleContentItemPresenter do
         :edit_url_for
       ).with(
         content_id: 'content-id',
-        publishing_app: 'whitehall'
+        publishing_app: 'whitehall',
+        base_path: '/the/base/path'
       ).and_return(
         'https://expected-link'
       )

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -232,7 +232,8 @@ RSpec.describe SingleContentItemPresenter do
       ).with(
         content_id: 'content-id',
         publishing_app: 'whitehall',
-        base_path: '/the/base/path'
+        base_path: '/the/base/path',
+        document_type: 'news_story'
       ).and_return(
         'https://expected-link'
       )

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -3,7 +3,7 @@ require 'gds_api/content_data_api'
 module GdsApi
   module TestHelpers
     module ContentDataApi
-      def stub_metrics_page(base_path:, time_period:)
+      def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall')
         dates = build(:date_range, time_period)
         prev_dates = dates.previous
 
@@ -13,6 +13,9 @@ module GdsApi
         previous_period_data = default_previous_single_page_payload(
           base_path, prev_dates.from, prev_dates.to
         )
+
+        current_period_data[:metadata][:publishing_app] = publishing_app
+        previous_period_data[:metadata][:publishing_app] = publishing_app
 
         content_data_api_has_single_page(
           base_path: base_path,
@@ -66,10 +69,10 @@ module GdsApi
         end
       end
 
-      def content_data_api_has_single_page(base_path:, from:, to:, payload: nil)
+      def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
         query = query(from: from, to: to)
         url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
-        body = payload || default_single_page_payload(base_path, from, to)
+        body = payload || default_single_page_payload(base_path, from, to, publishing_app)
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
@@ -118,7 +121,7 @@ module GdsApi
         "?#{param_pairs.join('&')}"
       end
 
-      def default_single_page_payload(base_path, from, to)
+      def default_single_page_payload(base_path, from, to, publishing_app = 'whitehall')
         day1 = from
         day2 = (Date.parse(from) + 1.day).to_s
         day3 = to
@@ -129,7 +132,7 @@ module GdsApi
             content_id: 'content-id',
             first_published_at:  "2018-07-17T10:35:59.000Z",
             public_updated_at:  "2018-07-17T10:35:57.000Z",
-            publishing_app:  "whitehall",
+            publishing_app:  publishing_app,
             document_type:  "news_story",
             primary_organisation_title:  "The Ministry",
             historical: false,


### PR DESCRIPTION
# What
[Trello card](https://trello.com/c/ayMhg8gT/877-3-add-links-to-the-correct-publishing-application-or-support-route-part-2#)

This PR adds links to edit the content in additional publisher applications. Namely:
- Contacts
- Specialist Publisher
- Travel Advice Publisher

For `collections` we link to the 'Content change request' support form as noted on the trello card.

# Why
Previously we did not show any links for documents published from these publishing applications.

# Screenshots
<img width="1091" alt="screen shot 2018-11-27 at 12 11 14" src="https://user-images.githubusercontent.com/13124899/49081191-e5f89300-f23d-11e8-85f0-648f0f92a37a.png">
<img width="1119" alt="screen shot 2018-11-27 at 12 11 45" src="https://user-images.githubusercontent.com/13124899/49081197-e85aed00-f23d-11e8-9a3c-2e815d9ef8dc.png">
<img width="1190" alt="screen shot 2018-11-27 at 12 12 47" src="https://user-images.githubusercontent.com/13124899/49081200-e98c1a00-f23d-11e8-8359-e6fffd755014.png">
<img width="1156" alt="screen shot 2018-11-27 at 12 13 34" src="https://user-images.githubusercontent.com/13124899/49081205-eb55dd80-f23d-11e8-8183-46c5e792b89e.png">

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
