### PR TITLE
Fix crash on single item page.

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -12,7 +12,7 @@
   if percent_metric
     maximum_y = 100
   elsif rows.any?
-    row_maximums = rows.map { |row| row[:values].max }
+    row_maximums = rows.map { |row| row[:values].compact.max }
     overall_maximum = row_maximums.max
 
     if overall_maximum == 0

--- a/spec/components/chart_spec.rb
+++ b/spec/components/chart_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Chart", type: :view do
       rows: [
         {
           label: "2017",
-          values: [5, 119, 74, 117, 50, 119, 61, 110, 12, 21, 121, 67]
+          values: [5, nil, nil, 119, 74, 117, 50, 119, 61, 110, 12, 21, 121, 67]
         },
         {
           label: "2018",
@@ -52,7 +52,7 @@ RSpec.describe "Chart", type: :view do
     data[:table_direction] = 'horizontal'
     render_component(data)
     assert_select ".govuk-table__body .govuk-table__header:nth-child(1)", text: "2017"
-    assert_select ".govuk-table__cell--numeric", 24
+    assert_select ".govuk-table__cell--numeric", 26
     assert_select ".govuk-table__header", 14
     assert_select "td:first", text: "5"
     assert_select "td:last", text: "121"


### PR DESCRIPTION
# What
Replace nils with 0 when calculating max value for chart.

# Why
We now allow nulls in the data.

The chart component is trying to find the max value for each
row in the dataset. If any of these are nil, the .max call fails.


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
