### PR TITLE
Change date-range parameters to match front-end

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -39,7 +39,7 @@ private
   def search_params
     @search_params ||= begin
       defaults = {
-        date_range: 'last-30-days',
+        date_range: 'past-30-days',
         organisation_id: current_user.organisation_content_id,
         document_type: ''
       }

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,6 +1,6 @@
 class MetricsController < ApplicationController
   def show
-    time_period = params[:date_range] || 'last-30-days'
+    time_period = params[:date_range] || 'past-30-days'
     base_path = params[:base_path]
 
     curr_period = DateRange.new(time_period)

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -23,22 +23,22 @@ private
         from: relative_date.last_month.beginning_of_month.to_s,
         to: relative_date.last_month.end_of_month.to_s
       }
-    when 'last-3-months'
+    when 'past-3-months'
       {
         from: (relative_date - 3.months).to_s,
         to: relative_date.to_s
       }
-    when 'last-6-months'
+    when 'past-6-months'
       {
         from: (relative_date - 6.months).to_s,
         to: relative_date.to_s
       }
-    when 'last-year'
+    when 'past-year'
       {
         from: (relative_date - 1.year).to_s,
         to: relative_date.to_s
       }
-    when 'last-2-years'
+    when 'past-2-years'
       {
         from: (relative_date - 2.years).to_s,
         to: relative_date.to_s

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -19,8 +19,8 @@
             base_path: "/",
             dates: [
               {
-                value: "last-30-days",
-                text: t("metrics.show.time_periods.last-30-days.leading"),
+                value: "past-30-days",
+                text: t("metrics.show.time_periods.past-30-days.leading"),
                 hint_text:  "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
@@ -29,23 +29,23 @@
                 hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
               },
               {
-                value: "last-3-months",
-                text: t("metrics.show.time_periods.last-3-months.leading"),
+                value: "past-3-months",
+                text: t("metrics.show.time_periods.past-3-months.leading"),
                 hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
-                value: "last-6-months",
-                text: t("metrics.show.time_periods.last-6-months.leading"),
+                value: "past-6-months",
+                text: t("metrics.show.time_periods.past-6-months.leading"),
                 hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
-                value: "last-year",
-                text: t("metrics.show.time_periods.last-year.leading"),
+                value: "past-year",
+                text: t("metrics.show.time_periods.past-year.leading"),
                 hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
-                value: "last-2-years",
-                text: t("metrics.show.time_periods.last-2-years.leading"),
+                value: "past-2-years",
+                text: t("metrics.show.time_periods.past-2-years.leading"),
                 hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               }
             ]

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -4,7 +4,7 @@
     <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state">Search</a>
   </div>
 <% end %>
-<% current_selection = @performance_data.date_range.time_period || 'last-30-days' %>
+<% current_selection = @performance_data.date_range.time_period || 'past-30-days' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
@@ -53,8 +53,8 @@
     current_selection: current_selection,
     dates: [
       {
-        value: "last-30-days",
-        text: t(".time_periods.last-30-days.leading"),
+        value: "past-30-days",
+        text: t(".time_periods.past-30-days.leading"),
         hint_text:  "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
@@ -63,23 +63,23 @@
         hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
       },
       {
-        value: "last-3-months",
-        text: t(".time_periods.last-3-months.leading"),
+        value: "past-3-months",
+        text: t(".time_periods.past-3-months.leading"),
         hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
-        value: "last-6-months",
-        text: t(".time_periods.last-6-months.leading"),
+        value: "past-6-months",
+        text: t(".time_periods.past-6-months.leading"),
         hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
-        value: "last-year",
-        text: t(".time_periods.last-year.leading"),
+        value: "past-year",
+        text: t(".time_periods.past-year.leading"),
         hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
-        value: "last-2-years",
-        text: t(".time_periods.last-2-years.leading"),
+        value: "past-2-years",
+        text: t(".time_periods.past-2-years.leading"),
         hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       }
     ]

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -18,21 +18,21 @@ en:
         feedback: 'Feedback'
         content: 'Page content'
       time_periods:
-        last-30-days:
+        past-30-days:
           leading: 'past 30 days'
           reference: 'from previous 30 days'
         last-month:
           leading: 'last month'
           reference: 'from previous month'
-        last-3-months:
+        past-3-months:
           leading: 'past 3 months'
           reference: 'from previous 3 months'
-        last-6-months:
+        past-6-months:
           leading: 'past 6 months'
           reference: 'from previous 6 months'
-        last-year:
+        past-year:
           leading: 'past year'
           reference: 'from previous year'
-        last-2-years:
+        past-2-years:
           leading: 'past 2 years'
           reference: 'from previous 2 years'

--- a/spec/factories/date_range.rb
+++ b/spec/factories/date_range.rb
@@ -1,27 +1,27 @@
 FactoryBot.define do
   factory :date_range, class: DateRange do
-    trait :last_30_days do
-      time_period { 'last-30-days' }
+    trait :past_30_days do
+      time_period { 'past-30-days' }
     end
 
     trait :last_month do
       time_period { 'last-month' }
     end
 
-    trait :last_3_months do
-      time_period { 'last-3-months' }
+    trait :past_3_months do
+      time_period { 'past-3-months' }
     end
 
-    trait :last_6_months do
-      time_period { 'last-6-months' }
+    trait :past_6_months do
+      time_period { 'past-6-months' }
     end
 
-    trait :last_year do
-      time_period { 'last-year' }
+    trait :past_year do
+      time_period { 'past-year' }
     end
 
-    trait :last_2_years do
-      time_period { 'last-2-years' }
+    trait :past_2_years do
+      time_period { 'past-2-years' }
     end
 
     initialize_with { new(time_period) }

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'date selection', type: :feature do
     Timecop.freeze(Date.new(2018, 12, 25))
     GDS::SSO.test_user = build(:user)
     # Stub backend API for initial page visit
-    stub_metrics_page(base_path: base_path, time_period: :last_30_days)
+    stub_metrics_page(base_path: base_path, time_period: :past_30_days)
   end
 
   after do
@@ -22,23 +22,23 @@ RSpec.describe 'date selection', type: :feature do
         { el.find('label').text => el.find('span').text }
       end
       expect(time_labels).to match([
-        { I18n.t('metrics.show.time_periods.last-30-days.leading') => "24 November 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-30-days.leading') => "24 November 2018 to 24 December 2018" },
         { I18n.t('metrics.show.time_periods.last-month.leading') => "1 November 2018 to 30 November 2018" },
-        { I18n.t('metrics.show.time_periods.last-3-months.leading') => "24 September 2018 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-6-months.leading') => "24 June 2018 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-year.leading') => "24 December 2017 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.last-2-years.leading') => "24 December 2016 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-3-months.leading') => "24 September 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-6-months.leading') => "24 June 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-year.leading') => "24 December 2017 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-2-years.leading') => "24 December 2016 to 24 December 2018" },
       ])
     end
 
-    it 'renders data for the last 30 days' do
+    it 'renders data for the past 30 days' do
       visit page_uri
       expect_upviews_table_to_contain_dates(['24 Nov 2018', '25 Nov 2018', '24 Dec 2018'])
     end
   end
 
-  it 'renders data for the last 30 days when `Past 30 days` is selected' do
-    visit_page_and_filter_by_date_range('last-30-days')
+  it 'renders data for the past 30 days when `Past 30 days` is selected' do
+    visit_page_and_filter_by_date_range('past-30-days')
     expect_upviews_table_to_contain_dates(['24 Nov 2018', '25 Nov 2018', '24 Dec 2018'])
   end
 
@@ -48,27 +48,27 @@ RSpec.describe 'date selection', type: :feature do
     expect_upviews_table_to_contain_dates(['1 Nov 2018', '2 Nov 2018', '30 Nov 2018'])
   end
 
-  it 'renders data for the last 3 months when `Past 3 months` is selected' do
-    stub_metrics_page(base_path: base_path, time_period: :last_3_months)
-    visit_page_and_filter_by_date_range('last-3-months')
+  it 'renders data for the past 3 months when `Past 3 months` is selected' do
+    stub_metrics_page(base_path: base_path, time_period: :past_3_months)
+    visit_page_and_filter_by_date_range('past-3-months')
     expect_upviews_table_to_contain_dates(['24 Sep 2018', '25 Sep 2018', '24 Dec 2018'])
   end
 
-  it 'renders data for the last 6 months when `Past 6 months` is selected' do
-    stub_metrics_page(base_path: base_path, time_period: :last_6_months)
-    visit_page_and_filter_by_date_range('last-6-months')
+  it 'renders data for the past 6 months when `Past 6 months` is selected' do
+    stub_metrics_page(base_path: base_path, time_period: :past_6_months)
+    visit_page_and_filter_by_date_range('past-6-months')
     expect_upviews_table_to_contain_dates(['24 Jun 2018', '25 Jun 2018', '24 Dec 2018'])
   end
 
-  it 'renders data for the last year when `Past year` is selected' do
-    stub_metrics_page(base_path: base_path, time_period: :last_year)
-    visit_page_and_filter_by_date_range('last-year')
+  it 'renders data for the past year when `Past year` is selected' do
+    stub_metrics_page(base_path: base_path, time_period: :past_year)
+    visit_page_and_filter_by_date_range('past-year')
     expect_upviews_table_to_contain_dates(['24 Dec 2017', '25 Dec 2017', '24 Dec 2018'])
   end
 
-  it 'renders data for the last 2 years when `Past 2 years` is selected' do
-    stub_metrics_page(base_path: base_path, time_period: :last_2_years)
-    visit_page_and_filter_by_date_range('last-2-years')
+  it 'renders data for the past 2 years when `Past 2 years` is selected' do
+    stub_metrics_page(base_path: base_path, time_period: :past_2_years)
+    visit_page_and_filter_by_date_range('past-2-years')
     expect_upviews_table_to_contain_dates(['24 Dec 2016', '25 Dec 2016', '24 Dec 2018'])
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe '/content' do
     end
 
     it 'respects the date filter' do
-      stub_metrics_page(base_path: 'path/1', time_period: :last_year)
-      content_data_api_has_content_items(date_range: 'last-year', organisation_id: 'org-id', items: items)
+      stub_metrics_page(base_path: 'path/1', time_period: :past_year)
+      content_data_api_has_content_items(date_range: 'past-year', organisation_id: 'org-id', items: items)
 
-      visit "/content?date_range=last-year&organisation_id=org-id"
+      visit "/content?date_range=past-year&organisation_id=org-id"
       click_link 'The title'
       expect(current_path).to eq '/metrics/path/1'
-      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.last-year.leading')}")
+      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.past-year.leading')}")
     end
   end
 
@@ -89,15 +89,15 @@ RSpec.describe '/content' do
     end
 
     it 'respects date range' do
-      stub_metrics_page(base_path: 'path/1', time_period: :last_year)
-      content_data_api_has_content_items(date_range: 'last-year', organisation_id: 'another-org-id', items: items)
+      stub_metrics_page(base_path: 'path/1', time_period: :past_year)
+      content_data_api_has_content_items(date_range: 'past-year', organisation_id: 'another-org-id', items: items)
 
-      visit "/content?date_range=last-year&organisation_id=another-org-id"
+      visit "/content?date_range=past-year&organisation_id=another-org-id"
 
       select 'another org', from: 'organisation_id'
       click_on 'Filter'
       click_on 'The title'
-      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.last-year.leading')}")
+      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.past-year.leading')}")
     end
 
     context 'with users organisation' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
   context 'successful request' do
     before do
       GDS::SSO.test_user = build(:user)
-      stub_metrics_page(base_path: 'base/path', time_period: :last_30_days)
+      stub_metrics_page(base_path: 'base/path', time_period: :past_30_days)
       visit '/metrics/base/path'
     end
 

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe DateRange do
     end
   end
 
-  describe 'for last 30 days' do
-    let(:time_period) { 'last-30-days' }
+  describe 'for past 30 days' do
+    let(:time_period) { 'past-30-days' }
 
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
       it { is_expected.to have_attributes(from: '2018-11-24') }
-      it { is_expected.to have_attributes(time_period: 'last-30-days') }
+      it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
     describe 'relative to specified date' do
@@ -22,7 +22,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
       it { is_expected.to have_attributes(from: '2018-05-26') }
-      it { is_expected.to have_attributes(time_period: 'last-30-days') }
+      it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
     describe '#previous' do
@@ -31,7 +31,7 @@ RSpec.describe DateRange do
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-11-24') }
       it { is_expected.to have_attributes(from: '2018-10-25') }
-      it { is_expected.to have_attributes(time_period: 'last-30-days') }
+      it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
   end
 
@@ -65,15 +65,15 @@ RSpec.describe DateRange do
     end
   end
 
-  describe 'for last 3 months' do
-    let(:time_period) { 'last-3-months' }
+  describe 'for past 3 months' do
+    let(:time_period) { 'past-3-months' }
 
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
       it { is_expected.to have_attributes(from: '2018-09-24') }
-      it { is_expected.to have_attributes(time_period: 'last-3-months') }
+      it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
     describe 'relative to specified date' do
@@ -82,7 +82,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
       it { is_expected.to have_attributes(from: '2018-03-25') }
-      it { is_expected.to have_attributes(time_period: 'last-3-months') }
+      it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
     describe '#previous' do
@@ -91,19 +91,19 @@ RSpec.describe DateRange do
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-09-24') }
       it { is_expected.to have_attributes(from: '2018-06-24') }
-      it { is_expected.to have_attributes(time_period: 'last-3-months') }
+      it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
   end
 
-  describe 'for last 6 months' do
-    let(:time_period) { 'last-6-months' }
+  describe 'for past 6 months' do
+    let(:time_period) { 'past-6-months' }
 
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
       it { is_expected.to have_attributes(from: '2018-06-24') }
-      it { is_expected.to have_attributes(time_period: 'last-6-months') }
+      it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
     describe 'relative to specified date' do
@@ -112,7 +112,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
       it { is_expected.to have_attributes(from: '2017-12-25') }
-      it { is_expected.to have_attributes(time_period: 'last-6-months') }
+      it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
     describe '#previous' do
@@ -121,19 +121,19 @@ RSpec.describe DateRange do
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-06-24') }
       it { is_expected.to have_attributes(from: '2017-12-24') }
-      it { is_expected.to have_attributes(time_period: 'last-6-months') }
+      it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
   end
 
-  describe 'for last year' do
-    let(:time_period) { 'last-year' }
+  describe 'for past year' do
+    let(:time_period) { 'past-year' }
 
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
       it { is_expected.to have_attributes(from: '2017-12-24') }
-      it { is_expected.to have_attributes(time_period: 'last-year') }
+      it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
     describe 'relative to specified date' do
@@ -142,7 +142,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
       it { is_expected.to have_attributes(from: '2017-06-25') }
-      it { is_expected.to have_attributes(time_period: 'last-year') }
+      it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
     describe '#previous' do
@@ -151,19 +151,19 @@ RSpec.describe DateRange do
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2017-12-24') }
       it { is_expected.to have_attributes(from: '2016-12-24') }
-      it { is_expected.to have_attributes(time_period: 'last-year') }
+      it { is_expected.to have_attributes(time_period: 'past-year') }
     end
   end
 
-  describe 'for last 2 year' do
-    let(:time_period) { 'last-2-years' }
+  describe 'for past 2 year' do
+    let(:time_period) { 'past-2-years' }
 
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
       it { is_expected.to have_attributes(from: '2016-12-24') }
-      it { is_expected.to have_attributes(time_period: 'last-2-years') }
+      it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
     describe 'relative to specified date' do
@@ -172,7 +172,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
       it { is_expected.to have_attributes(from: '2016-06-25') }
-      it { is_expected.to have_attributes(time_period: 'last-2-years') }
+      it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
     describe '#previous' do
@@ -181,7 +181,7 @@ RSpec.describe DateRange do
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2016-12-24') }
       it { is_expected.to have_attributes(from: '2014-12-24') }
-      it { is_expected.to have_attributes(time_period: 'last-2-years') }
+      it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
   end
 end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe ChartPresenter do
   include ActiveSupport::Testing::TimeHelpers
 
-  let(:date_range) { build :date_range, :last_30_days }
+  let(:date_range) { build :date_range, :past_30_days }
 
   around do |example|
     Timecop.freeze Date.new(2018, 1, 31) do

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe ContentItemsCSVPresenter do
 
   let(:document_types) { default_document_types }
   let(:organisations) { default_organisations }
-  let(:date_range) { DateRange.new('last-30-days') }
+  let(:date_range) { DateRange.new('past-30-days') }
   let(:data_enum) do
     [
       {

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe SingleContentItemPresenter do
   include GdsApi::TestHelpers::ContentDataApi
 
-  let(:date_range) { build(:date_range, :last_30_days) }
+  let(:date_range) { build(:date_range, :past_30_days) }
   let(:current_period_data) { default_single_page_payload('the/base/path', '2018-11-25', '2018-12-25') }
   let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-25') }
   let(:default_timeseries_metrics) {
@@ -115,7 +115,7 @@ RSpec.describe SingleContentItemPresenter do
       expect(subject.trend_percentage('upviews')).to eq(nil)
     end
 
-    context 'selected date range is `last-month`' do
+    context 'selected date range is `past-month`' do
       it 'calculates percentage change if previous month has data for every day in it' do
         date_range = build(:date_range, :last_month)
         current_time_series = complete_current_data


### PR DESCRIPTION
# What
The date-range parameters have been renamed as follows:

last-30-days => past-30-days
last-3-months => past-3-months
last-6-months => past-6-months
last-year => past-year

# Why
To be consistent with the text in the UI


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
