### PR TITLE
Change browser title

### DIFF
--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -4,7 +4,7 @@ en:
       download_link: 'Download %{metric_name} CSV'
       external_link: 'See %{metric_unit} in %{data_source}'
     show:
-      browser_title: 'Page data: %{content_title}'
+      browser_title: '%{content_title}: Page data'
       page_kicker: 'Page data'
       navigation:
         back_link: 'View all pages'


### PR DESCRIPTION
# What
This PR changes the formatting of the browser title from "Page data: <content_title>" to "<content_title>: Page data"

# Why
To allow user to differentiate tabs based on which content item they represent.

# Screenshots


---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.