### PR TITLE
Add all orgs and no orgs to filter

### DIFF
--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -56,7 +56,8 @@ private
 
   def additional_organisation_options
     [
-      { text: 'All organisations', value: 'all', selected: @search_parameters[:organisation_id] == 'all' }
+      { text: 'All organisations', value: 'all', selected: @search_parameters[:organisation_id] == 'all' },
+      { text: 'No primary organisation', value: 'none', selected: @search_parameters[:organisation_id] == 'none' }
     ]
   end
 end

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -30,13 +30,14 @@ class FilterPresenter
   end
 
   def organisation_options
-    @organisations.map do |org|
-      {
-        text: org[:title],
-        value: org[:organisation_id],
-        selected: org[:organisation_id] == @search_parameters[:organisation_id]
-      }
-    end
+    additional_organisation_options +
+      @organisations.map do |org|
+        {
+          text: org[:title],
+          value: org[:organisation_id],
+          selected: org[:organisation_id] == @search_parameters[:organisation_id]
+        }
+      end
   end
 
   def organisation_name
@@ -51,5 +52,11 @@ private
 
   def find_document_type
     document_type_options.find { |d| d[:selected] }
+  end
+
+  def additional_organisation_options
+    [
+      { text: 'All organisations', value: 'all', selected: @search_parameters[:organisation_id] == 'all' }
+    ]
   end
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -149,6 +149,29 @@ RSpec.describe '/content' do
         expect(page).to have_content('Content from all orgs')
       end
     end
+
+    context 'with no organisations' do
+      before do
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'users-org-id',
+          items: items
+        )
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'none',
+          items: [items[0].merge(title: 'Content with no primary org')]
+        )
+        visit '/content?date_range=past-30-days'
+        select('No primary organisation', from: 'organisation_id')
+        click_on 'Filter'
+      end
+
+      it 'shows the data no primary organisation' do
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content('Content with no primary org')
+      end
+    end
   end
 
   context 'filter by document_type' do

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -126,6 +126,29 @@ RSpec.describe '/content' do
         expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from Users Org')
       end
     end
+
+    context 'with all organisations' do
+      before do
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'users-org-id',
+          items: items
+        )
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'all',
+          items: [items[0].merge(title: 'Content from all orgs')]
+        )
+        visit '/content?date_range=past-30-days'
+        select('All organisations', from: 'organisation_id')
+        click_on 'Filter'
+      end
+
+      it 'shows the data for all organisations' do
+        expect(page.status_code).to eq(200)
+        expect(page).to have_content('Content from all orgs')
+      end
+    end
   end
 
   context 'filter by document_type' do

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe FilterPresenter do
       it 'formats the organisations for the options component' do
         expect(subject.organisation_options).to eq([
           { text: 'All organisations', value: 'all', selected: false },
+          { text: 'No primary organisation', value: 'none', selected: false },
           { text: 'org', value: 'org-id', selected: true },
           { text: 'another org', value: 'another-org-id', selected: false },
           { text: 'Users Org', value: 'users-org-id', selected: false }
@@ -60,6 +61,21 @@ RSpec.describe FilterPresenter do
       it 'formats the organisations for the options component' do
         expect(subject.organisation_options).to eq([
           { text: 'All organisations', value: 'all', selected: true },
+          { text: 'No primary organisation', value: 'none', selected: false },
+          { text: 'org', value: 'org-id', selected: false },
+          { text: 'another org', value: 'another-org-id', selected: false },
+          { text: 'Users Org', value: 'users-org-id', selected: false }
+        ])
+      end
+    end
+
+    context 'when organisation_id is `none` in parameter' do
+      before { search_parameters[:organisation_id] = 'none' }
+
+      it 'formats the organisations for the options component' do
+        expect(subject.organisation_options).to eq([
+          { text: 'All organisations', value: 'all', selected: false },
+          { text: 'No primary organisation', value: 'none', selected: true },
           { text: 'org', value: 'org-id', selected: false },
           { text: 'another org', value: 'another-org-id', selected: false },
           { text: 'Users Org', value: 'users-org-id', selected: false }

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -46,7 +46,21 @@ RSpec.describe FilterPresenter do
     context 'when valid organisation id in parameter' do
       it 'formats the organisations for the options component' do
         expect(subject.organisation_options).to eq([
+          { text: 'All organisations', value: 'all', selected: false },
           { text: 'org', value: 'org-id', selected: true },
+          { text: 'another org', value: 'another-org-id', selected: false },
+          { text: 'Users Org', value: 'users-org-id', selected: false }
+        ])
+      end
+    end
+
+    context 'when organisation_id is `all` in parameter' do
+      before { search_parameters[:organisation_id] = 'all' }
+
+      it 'formats the organisations for the options component' do
+        expect(subject.organisation_options).to eq([
+          { text: 'All organisations', value: 'all', selected: true },
+          { text: 'org', value: 'org-id', selected: false },
           { text: 'another org', value: 'another-org-id', selected: false },
           { text: 'Users Org', value: 'users-org-id', selected: false }
         ])


### PR DESCRIPTION
# What
Allow filtering by `All organisations` and `No primary organisation`

### Why
#### No organisation:
Some content doesn't have a primary organisation. In our current implementation content without a primary organisation is not findable. Adding a no organisation option to the filter will make it possible to find all content. It will also help us surface the size of the content estate with no primary organisation.

#### All organisations:
Some of our GDS users care about all organisations content.  We think there is a need for some to see the highest traffic content on GOV.UK, irrespective of department
# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Note
This PR is based in the fix in [PR 248](https://github.com/alphagov/content-data-admin/pull/248). So that should get merged first.
## Before
<img width="594" alt="screen shot 2018-11-30 at 13 26 14" src="https://user-images.githubusercontent.com/511319/49291908-a0d59a80-f4a3-11e8-99f0-fbb07da77b4e.png">
## After
<img width="537" alt="screen shot 2018-11-30 at 13 26 26" src="https://user-images.githubusercontent.com/511319/49291945-bc40a580-f4a3-11e8-8826-232e9d01e0c2.png">


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
