### PR TITLE
Add route to handle homepage on single item page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   }
   get '/dev' => 'development#index'
 
-  get '/metrics/*base_path', to: 'metrics#show', as: :metrics
+  get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics
   get '/content', to: 'content#index'
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -5,6 +5,15 @@ RSpec.describe '/content' do
   let(:items) do
     [
       {
+        base_path: '/',
+        title: 'GOV.UK homepage',
+        upviews: 1_233_018,
+        document_type: 'homepage',
+        satisfaction: 0.85,
+        satisfaction_score_responses: 2050,
+        searches: 1220
+      },
+      {
         base_path: '/path/1',
         title: 'The title',
         upviews: 233_018,
@@ -45,6 +54,7 @@ RSpec.describe '/content' do
     expect(table_rows).to eq(
       [
         ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
+        ['GOV.UK homepage /', 'Homepage', '1,233,018', '85% (2,050 responses)', '1,220'],
         ['The title /path/1', 'News story', '233,018', '81% (250 responses)', '220'],
         ['Another title /path/2', 'Guide', '100,018', '68% (42 responses)', '12'],
       ]
@@ -89,7 +99,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 2 of 2 results from another org')
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 3 of 3 results from another org')
     end
 
     it 'respects date range' do
@@ -130,7 +140,7 @@ RSpec.describe '/content' do
 
   context 'filter by document_type' do
     before do
-      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', document_type: 'news_story', items: [items.first])
+      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', document_type: 'news_story', items: [items.second])
       select 'News story', from: 'document_type'
       click_on 'Filter'
     end
@@ -155,8 +165,8 @@ RSpec.describe '/content' do
       click_on 'Filter'
       expect(page).to have_select('document_type', selected: 'All document types')
       table_rows = extract_table_content('.govuk-table')
-      expect(table_rows.count).to eq(3)
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 2 of 2 results from org')
+      expect(table_rows.count).to eq(4)
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 3 of 3 results from org')
     end
   end
 
@@ -188,7 +198,7 @@ RSpec.describe '/content' do
       content_data_api_has_content_items(
         date_range: 'last-month',
         organisation_id: 'org-id',
-        items: (items * 50) + other_page_items
+        items: (items[1..-1] * 50) + other_page_items
       )
 
       visit "/content?date_range=last-month&organisation_id=org-id"

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
   end
 
+  context 'when the page we are requesting is the homepage' do
+    before do
+      GDS::SSO.test_user = build(:user)
+      stub_metrics_page(base_path: nil, time_period: :last_month)
+      visit '/metrics?date_range=last-month'
+    end
+
+    it 'renders the page without errors' do
+      expect(page.status_code).to eq(200)
+    end
+  end
+
   context 'successful request' do
     before do
       GDS::SSO.test_user = build(:user)

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe ContentItemsCSVPresenter do
   let(:data_enum) do
     [
       {
-        title: 'Title 1',
-        base_path: '/base-path-1',
-        doucment_type: 'guide',
+        title: 'GOV.UK homepage',
+        base_path: '/',
+        document_type: 'homepage',
         upviews: 15,
         satisfaction_score_responses: 2,
         searches: 14
@@ -23,7 +23,7 @@ RSpec.describe ContentItemsCSVPresenter do
       {
         title: 'Title 1',
         base_path: '/base-path-1',
-        doucment_type: 'guide',
+        document_type: 'guide',
         upviews: 15,
         satisfaction_score_responses: 2,
         searches: 14

--- a/spec/routing/single_page_routing_spec.rb
+++ b/spec/routing/single_page_routing_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe '/metrics routing' do
+  it 'routes correctly with given base path' do
+    expect(get: '/metrics/long/base/path?date_range=past-30-days').to route_to(
+      controller: 'metrics',
+      action: 'show',
+      base_path: 'long/base/path',
+      date_range: 'past-30-days'
+    )
+  end
+
+  it 'generates a route for the given base_path' do
+    expect(get: metrics_path('/base/path', date_range: 'past-30-days')).to route_to(
+      controller: 'metrics',
+      action: 'show',
+      base_path: 'base/path',
+      date_range: 'past-30-days'
+    )
+  end
+
+  it 'routes correctly without a base path for the homepage' do
+    expect(get: '/metrics?date_range=last-month').to route_to(
+      controller: 'metrics',
+      action: 'show',
+      date_range: 'last-month'
+    )
+  end
+
+  it 'generates a route for the homepage' do
+    expect(get: metrics_path(date_range: 'past-30-days')).to route_to(
+      controller: 'metrics',
+      action: 'show',
+      date_range: 'past-30-days'
+    )
+  end
+end


### PR DESCRIPTION
# What
Add a route to handle the GOV.UK homepage

# Why
The current routing fails because the base_path to the GOV.UK homepage
is an empty string once you have removed the leading `/`

Trello https://trello.com/c/q9YG0Ftm/915-fix-bug-with-rendering-the-govuk-homepage-in-content-data-admin

there is a [related PR in content-performance-manager](https://github.com/alphagov/content-performance-manager/pull/1033)

# Screenshots
Only after is shown. 

## Before
!!!BOOM!!! 500 Error
## After
![screen shot 2018-11-29 at 15 37 20](https://user-images.githubusercontent.com/511319/49232880-b5a32700-f3ec-11e8-9cd0-ce028ecff725.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
