### PR TITLE
Add data attribute for link

### DIFF
--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,10 +1,11 @@
 class ContentRowPresenter
   include ActionView::Helpers::NumberHelper
   attr_reader :title, :base_path, :document_type, :upviews,
-              :user_satisfaction, :searches
+              :user_satisfaction, :searches, :raw_document_type
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
+    @raw_document_type = data[:document_type]
     @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
     @upviews = number_with_delimiter(data[:upviews], delimiter: ',')
     @user_satisfaction = format_satisfaction(data[:satisfaction], data[:satisfaction_score_responses])

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -1,12 +1,14 @@
 class ContentRowPresenter
   include ActionView::Helpers::NumberHelper
+  include ActiveSupport::Inflector
+
   attr_reader :title, :base_path, :document_type, :upviews,
               :user_satisfaction, :searches, :raw_document_type
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
     @raw_document_type = data[:document_type]
-    @document_type = data[:document_type].try(:tr, '_', ' ').try(:capitalize)
+    @document_type = humanize(data[:document_type])
     @upviews = number_with_delimiter(data[:upviews], delimiter: ',')
     @user_satisfaction = format_satisfaction(data[:satisfaction], data[:satisfaction_score_responses])
     @searches = number_with_delimiter(data[:searches], delimiter: ',')

--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -1,3 +1,3 @@
-<%= link_to item.title, metrics_path(item.base_path, date_range: date_range) %>
+<%= link_to item.title, metrics_path(item.base_path, date_range: date_range), data: { gtm: item.raw_document_type } %>
 <br>
 <span class="base-path">/<%= item.base_path %></span>

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe ContentRowPresenter do
   it 'returns the basic attributes' do
     expect(subject).to have_attributes(
       base_path: 'some/base_path',
+      raw_document_type: 'news_story',
       title: 'a title',
       upviews: '200,001'
     )


### PR DESCRIPTION
# What
Add a data attribute link to make Google Tag Manager tracking easier.

# Why
Currently the only way of tracking content type is by using custom javascript.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.