### PR TITLE
Remove duplicate linking of application.js

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -76,7 +76,7 @@
           in the <a href="#<%= table_id %>">table</a>.
         </div>
       <% end %>
-      <%= line_chart(chart_format_data, library: chart_library_options) %>
+      <%= line_chart(chart_format_data, library: chart_library_options, defer: true) %>
     </div>
     <div class="app-c-chart__table" id="<%= table_id %>">
       <%= render(

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,6 @@
 <% content_for :head do %>
   <%= javascript_include_tag "https://www.gstatic.com/charts/loader.js" %>
   <%= stylesheet_link_tag "application" %>
-  <%= javascript_include_tag "application" %>
 
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
     <script>


### PR DESCRIPTION
`application.js` is linked twice, in `layout/application.html.erb` and also as part of the layout_for_admin GOV.UK publishing component.

https://github.com/alphagov/govuk_publishing_components/blob/81d7aaf/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb#L21