### PR TITLE
Fix publisher links

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -14,7 +14,7 @@ module ExternalLinksHelper
     when 'specialist-publisher'
       "#{external_url_for('specialist-publisher')}/#{specialist_publisher_path(document_type, content_id)}"
     when 'collections-publisher'
-      "#{external_url_for('support')}/general_request/new"
+      "#{external_url_for('support')}/content_change_request/new"
     when 'travel-advice-publisher'
       "#{external_url_for('travel-advice-publisher')}/admin/countries/#{slug_from_basepath(base_path)}"
     end

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -16,7 +16,7 @@ module ExternalLinksHelper
     when 'collections-publisher'
       "#{external_url_for('support')}/general_request/new"
     when 'travel-advice-publisher'
-      "#{external_url_for('travel-advice-publisher')}/admin/#{slug_from_basepath(base_path)}"
+      "#{external_url_for('travel-advice-publisher')}/admin/countries/#{slug_from_basepath(base_path)}"
     end
   end
 

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -26,6 +26,8 @@ module ExternalLinksHelper
     case publishing_app
     when 'publisher'
       I18n.t('metrics.show.navigation.publisher_edit_link')
+    when 'collections-publisher'
+      I18n.t('metrics.show.navigation.request_change_link')
     else
       I18n.t(
         'metrics.show.navigation.edit_link',

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -13,6 +13,7 @@ en:
         edit_page: 'Make changes to the page'
         edit_link: 'Edit in %{publishing_app}'
         publisher_edit_link: 'Request a content change in GOV.UK Support'
+        request_change_link: 'Request a content change in the GOV.UK support form'
       section_headings:
         performance: 'Performance'
         feedback: 'Feedback'

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the travel advice application' do
         stub_metrics_page(base_path: 'travel/path', time_period: :past_30_days, publishing_app: 'travel-advice-publisher')
         visit '/metrics/travel/path'
-        expect(page).to have_link("Edit in Travel advice publisher", href: 'http://travel-advice-publisher.dev.gov.uk/admin/path')
+        expect(page).to have_link("Edit in Travel advice publisher", href: 'http://travel-advice-publisher.dev.gov.uk/admin/countries/path')
       end
     end
   end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the collections application' do
         stub_metrics_page(base_path: 'collections/path', time_period: :past_30_days, publishing_app: 'collections-publisher')
         visit '/metrics/collections/path'
-        expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/general_request/new')
+        expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/content_change_request/new')
       end
 
       it 'renders the travel advice application' do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the collections application' do
         stub_metrics_page(base_path: 'collections/path', time_period: :past_30_days, publishing_app: 'collections-publisher')
         visit '/metrics/collections/path'
-        expect(page).to have_link("Edit in Collections publisher", href: 'http://support.dev.gov.uk/content_change_request/new')
+        expect(page).to have_link("Request a content change in the GOV.UK support form", href: 'http://support.dev.gov.uk/content_change_request/new')
       end
 
       it 'renders the travel advice application' do

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe ExternalLinksHelper do
                        base_path: '/foreign-travel-advice/brunei',
                        document_type: 'news_story')
         ).to eq(
-          "#{external_url_for('travel-advice-publisher')}/admin/brunei"
+          "#{external_url_for('travel-advice-publisher')}/admin/countries/brunei"
         )
       end
     end

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe ExternalLinksHelper do
                        base_path: 'government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line',
                        document_type: 'news_story')
         ).to eq(
-          "#{external_url_for('support')}/general_request/new"
+          "#{external_url_for('support')}/content_change_request/new"
         )
       end
     end


### PR DESCRIPTION
# What

[Trello card](https://trello.com/c/ayMhg8gT/877-3-add-links-to-the-correct-publishing-application-or-support-route-part-2)

Change publisher links for `travel-advice` and `collection` content.

# Why
Travel advice content did not correctly link to the travel advice edit page and our team decided to link to a different support form for collections content. The collections link change also needed to be reflected in the link label.

# Screenshots
*If applicable add screenshots otherwise remove this section.*
---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
