### PR TITLE
Format document types

### DIFF
--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -21,7 +21,7 @@ class FilterPresenter
              }]
     @document_types.each do |document_type|
       types.push(
-        text: document_type.try(:tr, '_', ' ').try(:capitalize),
+        text: document_type.humanize,
         value: document_type,
         selected: document_type == @search_parameters[:document_type]
       )

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -19,7 +19,7 @@
           published_at: @performance_data.published_at,
           last_updated: @performance_data.last_updated,
           publishing_organisation: @performance_data.publishing_organisation,
-          document_type: @performance_data.document_type,
+          document_type: @performance_data.document_type.humanize,
           base_path: @performance_data.base_path,
           status: @performance_data.status
       %>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,16 +1,15 @@
 # Be sure to restart your server when you modify this file.
 
-# Add new inflection rules using the following format. Inflections
-# are locale specific, and you may define rules for as many different
-# locales as you wish. All of these examples are active by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.plural /^(ox)$/i, '\1en'
-#   inflect.singular /^(ox)en/i, '\1'
-#   inflect.irregular 'person', 'people'
-#   inflect.uncountable %w( fish sheep )
-# end
-
 # These inflection rules are supported but not enabled by default:
-# ActiveSupport::Inflector.inflections(:en) do |inflect|
-#   inflect.acronym 'RESTful'
-# end
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'AAIB'
+  inflect.acronym 'CMA'
+  inflect.acronym 'DFID'
+  inflect.acronym 'ESI'
+  inflect.acronym 'FOI'
+  inflect.acronym 'HMRC'
+  inflect.acronym 'HTML'
+  inflect.acronym 'MAIB'
+  inflect.acronym 'RAIB'
+  inflect.acronym 'UTAAC'
+end

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe FilterPresenter do
           { text: 'All document types', value: '', selected: false },
           { text: 'Case study', value: 'case_study', selected: false },
           { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: true }
+          { text: 'News story', value: 'news_story', selected: true },
+          { text: 'HTML publication', value: 'html_publication', selected: false }
         ])
       end
     end
@@ -36,7 +37,8 @@ RSpec.describe FilterPresenter do
           { text: 'All document types', value: '', selected: true },
           { text: 'Case study', value: 'case_study', selected: false },
           { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: false }
+          { text: 'News story', value: 'news_story', selected: false },
+          { text: 'HTML publication', value: 'html_publication', selected: false }
         ])
       end
     end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -377,7 +377,7 @@ module GdsApi
       end
 
       def default_document_types
-        %w[case_study guide news_story]
+        %w[case_study guide news_story html_publication]
       end
     end
   end


### PR DESCRIPTION
# What
[Trello card](https://trello.com/c/xMSR3zFQ/899-3-change-document-types-to-the-correct-case-in-the-filter-list-and-in-the-metadata-section)

Format document types so that some acronyms are properly capitalised.

# Why
In order to help end users more easily understand the document types.

# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
