### PR TITLE
Add title/slug search terms to filter description

### DIFF
--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -5,12 +5,24 @@ class FilterPresenter
     @organisations = organisations
   end
 
+  def search_terms?
+    search_terms.present?
+  end
+
+  def search_terms
+    @search_parameters[:search_term]
+  end
+
   def document_type?
     @search_parameters[:document_type].present?
   end
 
   def document_type
     find_document_type[:text]
+  end
+
+  def organisation_name
+    find_selected_org[:text]
   end
 
   def document_type_options
@@ -38,10 +50,6 @@ class FilterPresenter
           selected: org[:organisation_id] == @search_parameters[:organisation_id]
         }
       end
-  end
-
-  def organisation_name
-    find_selected_org[:text]
   end
 
 private

--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -1,4 +1,5 @@
 class PaginationPresenter
+  include ActionView::Helpers::NumberHelper
   attr_reader :page, :total_pages, :total_results
 
   def initialize(page: 1, total_pages:, total_results:, per_page: 100)
@@ -6,6 +7,10 @@ class PaginationPresenter
     @total_pages = total_pages
     @total_results = total_results
     @per_page = per_page
+  end
+
+  def formatted_total_results
+    number_with_delimiter @total_results
   end
 
   def prev_link?

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -2,8 +2,11 @@
     <span class="table-header__param"><%= pagination.first_record %></span> to
     <span class="table-header__param"><%= pagination.last_record %></span> of
     <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+    <% if filter.search_terms? %>
+        for "<span class="table-header__param"><%= filter.search_terms %></span>"
+    <% end %>
     <% if filter.document_type? %>
-        for <span class="table-header__param"><%= filter.document_type %></span>
+        in <span class="table-header__param"><%= filter.document_type %></span>
     <% end %>
     from <span class="table-header__param"><%= filter.organisation_name %></span>
 </h1>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,9 +1,9 @@
 <h1 class="table-header">Showing
     <span class="table-header__param"><%= pagination.first_record %></span> to
     <span class="table-header__param"><%= pagination.last_record %></span> of
-    <span class="table-header__param"><%= pagination.total_results %></span> results
+    <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
     <% if filter.document_type? %>
         for <span class="table-header__param"><%= filter.document_type %></span>
     <% end %>
-    from <span class="table-header__param"><%= filter.organisation_name %></span>.
+    from <span class="table-header__param"><%= filter.organisation_name %></span>
 </h1>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -176,6 +176,33 @@ RSpec.describe '/content' do
         expect(page).to have_content('Content with no primary org')
       end
     end
+
+    context 'filter by title or slug' do
+      before do
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'users-org-id',
+          items: items
+        )
+        content_data_api_has_content_items(
+          date_range: 'past-30-days',
+          organisation_id: 'users-org-id',
+          search_term: 'Relevant',
+          items: [items[0].merge(title: 'Relevant content article')]
+        )
+        visit '/content?date_range=past-30-days'
+        fill_in 'search_term', with: 'Relevant'
+        click_on 'Filter'
+      end
+
+      it 'shows relevant content in results' do
+        expect(page).to have_content('Relevant content article')
+      end
+
+      it 'describes the filter in the table header' do
+        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for "Relevant" from Users Org')
+      end
+    end
   end
 
   context 'filter by document_type' do
@@ -197,7 +224,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for News story from org')
+      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results in News story from org')
     end
 
     it 'allows the filter to be cleared' do

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -2,9 +2,9 @@ RSpec.describe PaginationPresenter do
   subject do
     PaginationPresenter.new(
       page: page,
-      total_pages: 11,
+      total_pages: 123457,
       per_page: 10,
-      total_results: 105
+      total_results: 1234567
     )
   end
 
@@ -12,6 +12,10 @@ RSpec.describe PaginationPresenter do
 
   it 'returns the #total_results' do
     expect(subject.total_results)
+  end
+
+  it 'returns the #formatted_total_results' do
+    expect(subject.formatted_total_results).to eq('1,234,567')
   end
 
   context 'when on the first page' do
@@ -24,7 +28,7 @@ RSpec.describe PaginationPresenter do
     end
 
     it 'return the correct next page label' do
-      expect(subject.next_label).to eq('2 of 11')
+      expect(subject.next_label).to eq('2 of 123457')
     end
 
     it 'returns 1 for #first_record' do
@@ -37,7 +41,7 @@ RSpec.describe PaginationPresenter do
   end
 
   context 'when on the last page' do
-    let(:page) { 11 }
+    let(:page) { 123457 }
 
     it 'returns true from #prev_link?' do
       expect(subject.prev_link?).to eq(true)
@@ -48,15 +52,15 @@ RSpec.describe PaginationPresenter do
     end
 
     it 'returns the correct next page label' do
-      expect(subject.prev_label).to eq('10 of 11')
+      expect(subject.prev_label).to eq('123456 of 123457')
     end
 
     it 'returns 100 for #first_record' do
-      expect(subject.first_record).to eq(101)
+      expect(subject.first_record).to eq(1234561)
     end
 
     it 'returns 105 for #last_record' do
-      expect(subject.last_record).to eq(105)
+      expect(subject.last_record).to eq(1234567)
     end
   end
 
@@ -72,11 +76,11 @@ RSpec.describe PaginationPresenter do
     end
 
     it 'returns the correct next page label' do
-      expect(subject.prev_label).to eq('5 of 11')
+      expect(subject.prev_label).to eq('5 of 123457')
     end
 
     it 'return the correct next page label' do
-      expect(subject.next_label).to eq('7 of 11')
+      expect(subject.next_label).to eq('7 of 123457')
     end
 
     it 'returns 51 for #first_record' do


### PR DESCRIPTION
# What
This adds the title or slug search terms to the filter description, removes full stop at end of description and formats the numbers using delimiters.

# Why
This helps user see what filters are currently applied. 

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/11051676/49381048-fb246480-f70a-11e8-84ac-06ee6a8ba63d.png)

## After
![image](https://user-images.githubusercontent.com/11051676/49381130-260eb880-f70b-11e8-8565-f2b25a18fa6d.png)


---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.