### PR TITLE
Handle no items in the pagination description.

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,7 +1,12 @@
 <h1 class="table-header">Showing
-    <span class="table-header__param"><%= pagination.first_record %></span> to
-    <span class="table-header__param"><%= pagination.last_record %></span> of
-    <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+    <% if pagination.total_results > 0 %>
+        Showing
+        <span class="table-header__param"><%= pagination.first_record %></span> to
+        <span class="table-header__param"><%= pagination.last_record %></span> of
+        <span class="table-header__param"><%= pagination.total_results %></span> results
+    <% else %>
+        <span class="table-header__param">no matching results</span>
+    <% end %>
     <% if filter.search_terms? %>
         for "<span class="table-header__param"><%= filter.search_terms %></span>"
     <% end %>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -5,7 +5,7 @@
         <span class="table-header__param"><%= pagination.last_record %></span> of
         <span class="table-header__param"><%= pagination.total_results %></span> results
     <% else %>
-        <span class="table-header__param">no matching results</span>
+        <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>
     <% if filter.search_terms? %>
         for "<span class="table-header__param"><%= filter.search_terms %></span>"

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -1,4 +1,5 @@
 en:
+  no_matching_results: 'no matching results'
   data_sources:
     google_analytics: 'Google Analytics'
     calculated_google_analytics: 'calculated from Google Analytics'

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows a no data message in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'no matching results from org')
+      expect(page).to have_css('h1.table-header', text: "#{I18n.t 'no_matching_results'} from org")
     end
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -296,6 +296,17 @@ RSpec.describe '/content' do
     end
   end
 
+  describe 'no results returned' do
+    before do
+      content_data_api_has_no_matching_items(date_range: 'past-3-months', organisation_id: 'org-id')
+      visit "/content?date_range=past-3-months&organisation_id=org-id"
+    end
+
+    it 'shows a no data message in the table header' do
+      expect(page).to have_css('h1.table-header', text: 'no matching results from org')
+    end
+  end
+
   context 'CSV export' do
     # Use lots of items to test getting a couple of full pages, plus a
     # partial page back from the Content Performance Manager.

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -69,6 +69,23 @@ module GdsApi
         end
       end
 
+      def content_data_api_has_no_matching_items(date_range:, organisation_id:, document_type: nil, search_term: nil)
+        params = {
+          date_range: date_range,
+          organisation_id: organisation_id,
+          document_type: document_type,
+          search_term: search_term,
+        }.reject { |_, v| v.blank? }
+        body = {
+          results: [],
+          total_results: 0,
+          total_pages: 0,
+          page: 1
+        }.to_json
+        url = "#{content_data_api_endpoint}/content#{query(params)}"
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
         query = query(from: from, to: to)
         url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"


### PR DESCRIPTION
# What
Correct the pagination description when no matching results.

# Why
This was saying "1 to 0 of 0 results"
now its says "no matching results"

# Screenshots

## Before
![before](https://user-images.githubusercontent.com/511319/49438389-1ef0b480-f7b6-11e8-81ec-e0f95ec25cec.png)

## After
![after](https://user-images.githubusercontent.com/511319/49438393-244dff00-f7b6-11e8-843b-899765eefe67.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
