### PR TITLE
Remove past 2 years time period

### DIFF
--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -38,11 +38,6 @@ private
         from: (relative_date - 1.year).to_s,
         to: relative_date.to_s
       }
-    when 'past-2-years'
-      {
-        from: (relative_date - 2.years).to_s,
-        to: relative_date.to_s
-      }
     else
       {
         from: (relative_date - 30.days).to_s,

--- a/app/views/components/docs/time-select.yml
+++ b/app/views/components/docs/time-select.yml
@@ -27,6 +27,3 @@ examples:
         - value: "past-year"
           text: "Past year"
           hint_text: "20 August 2017 - 19 August 2018"
-        - value: "past-2-years"
-          text: "Past 2 years"
-          hint_text: "20 August 2016 - 19 August 2018"

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -42,11 +42,6 @@
                 value: "past-year",
                 text: t("metrics.show.time_periods.past-year.leading"),
                 hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "past-2-years",
-                text: t("metrics.show.time_periods.past-2-years.leading"),
-                hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               }
             ]
           } %>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -40,11 +40,6 @@
                 value: "past-year",
                 text: "Past year",
                 hint_text: "20 August 2017 - 19 August 2018"
-              },
-              {
-                value: "past-2-years",
-                text: "Past 2 years",
-                hint_text: "20 August 2016 - 19 August 2018"
               }
             ]
           } %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -74,11 +74,6 @@
         value: "past-year",
         text: t(".time_periods.past-year.leading"),
         hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "past-2-years",
-        text: t(".time_periods.past-2-years.leading"),
-        hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       }
     ]
   } %>

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -34,6 +34,3 @@ en:
         past-year:
           leading: 'past year'
           reference: 'from previous year'
-        past-2-years:
-          leading: 'past 2 years'
-          reference: 'from previous 2 years'

--- a/spec/factories/date_range.rb
+++ b/spec/factories/date_range.rb
@@ -20,10 +20,6 @@ FactoryBot.define do
       time_period { 'past-year' }
     end
 
-    trait :past_2_years do
-      time_period { 'past-2-years' }
-    end
-
     initialize_with { new(time_period) }
   end
 end

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'date selection', type: :feature do
         { I18n.t('metrics.show.time_periods.past-3-months.leading') => "24 September 2018 to 24 December 2018" },
         { I18n.t('metrics.show.time_periods.past-6-months.leading') => "24 June 2018 to 24 December 2018" },
         { I18n.t('metrics.show.time_periods.past-year.leading') => "24 December 2017 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.past-2-years.leading') => "24 December 2016 to 24 December 2018" },
       ])
     end
 
@@ -64,12 +63,6 @@ RSpec.describe 'date selection', type: :feature do
     stub_metrics_page(base_path: base_path, time_period: :past_year)
     visit_page_and_filter_by_date_range('past-year')
     expect_upviews_table_to_contain_dates(['24 Dec 2017', '25 Dec 2017', '24 Dec 2018'])
-  end
-
-  it 'renders data for the past 2 years when `Past 2 years` is selected' do
-    stub_metrics_page(base_path: base_path, time_period: :past_2_years)
-    visit_page_and_filter_by_date_range('past-2-years')
-    expect_upviews_table_to_contain_dates(['24 Dec 2016', '25 Dec 2016', '24 Dec 2018'])
   end
 
   def visit_page_and_filter_by_date_range(date_range)

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -154,34 +154,4 @@ RSpec.describe DateRange do
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
   end
-
-  describe 'for past 2 year' do
-    let(:time_period) { 'past-2-years' }
-
-    describe 'relative to yesterday' do
-      subject { DateRange.new(time_period) }
-
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2016-12-24') }
-      it { is_expected.to have_attributes(time_period: 'past-2-years') }
-    end
-
-    describe 'relative to specified date' do
-      subject { DateRange.new(time_period, specified_date) }
-      let(:specified_date) { Date.new(2018, 6, 25) }
-
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2016-06-25') }
-      it { is_expected.to have_attributes(time_period: 'past-2-years') }
-    end
-
-    describe '#previous' do
-      subject { DateRange.new(time_period).previous }
-
-      it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2016-12-24') }
-      it { is_expected.to have_attributes(from: '2014-12-24') }
-      it { is_expected.to have_attributes(time_period: 'past-2-years') }
-    end
-  end
 end


### PR DESCRIPTION
# What
Removing the `past 2 years` option from the change time period filter and from the date range model.

# Why
This time period is no longer supported by the Content Performance Manager and will throw an error if a user selects it.

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/11051676/49449021-ebbc1e80-f7d1-11e8-8a5e-cf255e510684.png)

## After
![image](https://user-images.githubusercontent.com/11051676/49449143-2c1b9c80-f7d2-11e8-8b95-1043ae04a3da.png)

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [ ] Added to Trello card.
