### PR TITLE
Remove past 2 years from the index page filters

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -42,11 +42,6 @@
                 value: "past-year",
                 text: t("metrics.show.time_periods.past-year.leading"),
                 hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "past-2-years",
-                text: t("metrics.show.time_periods.past-2-years.leading"),
-                hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               }
             ]
           } %>


### PR DESCRIPTION
# What
Removing past 2 years option from the time select options on the index page.

# Why
Backend no longer support this and user will be shown an error.

# Screenshots

## Before
![image](https://user-images.githubusercontent.com/11051676/49452407-0fcf2e00-f7d9-11e8-94e1-9ef04982d4a1.png)

## After


---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
