### PR TITLE
Fix date ranges to be accurate

### DIFF
--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -11,6 +11,7 @@ class DateRange
 
   def previous
     relative_date = Date.parse(@from)
+    relative_date = relative_date - 1.day unless @time_period == 'last-month'
     DateRange.new(time_period, relative_date)
   end
 
@@ -25,27 +26,27 @@ private
       }
     when 'past-3-months'
       {
-        from: (relative_date - 3.months).to_s,
+        from: ((relative_date - 3.months) + 1.day).to_s,
         to: relative_date.to_s
       }
     when 'past-6-months'
       {
-        from: (relative_date - 6.months).to_s,
+        from: ((relative_date - 6.months) + 1.day).to_s,
         to: relative_date.to_s
       }
     when 'past-year'
       {
-        from: (relative_date - 1.year).to_s,
+        from: ((relative_date - 1.year) + 1.day).to_s,
         to: relative_date.to_s
       }
     when 'past-2-years'
       {
-        from: (relative_date - 2.years).to_s,
+        from: ((relative_date - 2.years) + 1.day).to_s,
         to: relative_date.to_s
       }
     else
       {
-        from: (relative_date - 30.days).to_s,
+        from: (relative_date - 29.days).to_s,
         to: relative_date.to_s
       }
     end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -21,7 +21,7 @@
               {
                 value: "past-30-days",
                 text: t("metrics.show.time_periods.past-30-days.leading"),
-                hint_text: "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+                hint_text: "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "last-month",
@@ -31,17 +31,17 @@
               {
                 value: "past-3-months",
                 text: t("metrics.show.time_periods.past-3-months.leading"),
-                hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+                hint_text: "#{(3.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "past-6-months",
                 text: t("metrics.show.time_periods.past-6-months.leading"),
-                hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+                hint_text: "#{(6.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               },
               {
                 value: "past-year",
                 text: t("metrics.show.time_periods.past-year.leading"),
-                hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+                hint_text: "#{(1.year.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
               }
             ]
           } %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -53,7 +53,7 @@
       {
         value: "past-30-days",
         text: t(".time_periods.past-30-days.leading"),
-        hint_text:  "#{31.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+        hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "last-month",
@@ -63,22 +63,22 @@
       {
         value: "past-3-months",
         text: t(".time_periods.past-3-months.leading"),
-        hint_text: "#{(3.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+        hint_text: "#{(3.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "past-6-months",
         text: t(".time_periods.past-6-months.leading"),
-        hint_text: "#{(6.months.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+        hint_text: "#{(6.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "past-year",
         text: t(".time_periods.past-year.leading"),
-        hint_text: "#{(1.year.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+        hint_text: "#{(1.year.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       },
       {
         value: "past-2-years",
         text: t(".time_periods.past-2-years.leading"),
-        hint_text: "#{(2.years.ago - 1.day).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
+        hint_text: "#{(2.years.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
       }
     ]
   } %>

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -22,24 +22,24 @@ RSpec.describe 'date selection', type: :feature do
         { el.find('label').text => el.find('span').text }
       end
       expect(time_labels).to match([
-        { I18n.t('metrics.show.time_periods.past-30-days.leading') => "24 November 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-30-days.leading') => "25 November 2018 to 24 December 2018" },
         { I18n.t('metrics.show.time_periods.last-month.leading') => "1 November 2018 to 30 November 2018" },
-        { I18n.t('metrics.show.time_periods.past-3-months.leading') => "24 September 2018 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.past-6-months.leading') => "24 June 2018 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.past-year.leading') => "24 December 2017 to 24 December 2018" },
-        { I18n.t('metrics.show.time_periods.past-2-years.leading') => "24 December 2016 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-3-months.leading') => "25 September 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-6-months.leading') => "25 June 2018 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-year.leading') => "25 December 2017 to 24 December 2018" },
+        { I18n.t('metrics.show.time_periods.past-2-years.leading') => "25 December 2016 to 24 December 2018" },
       ])
     end
 
     it 'renders data for the past 30 days' do
       visit page_uri
-      expect_upviews_table_to_contain_dates(['24 Nov 2018', '25 Nov 2018', '24 Dec 2018'])
+      expect_upviews_table_to_contain_dates(['25 Nov 2018', '26 Nov 2018', '24 Dec 2018'])
     end
   end
 
   it 'renders data for the past 30 days when `Past 30 days` is selected' do
     visit_page_and_filter_by_date_range('past-30-days')
-    expect_upviews_table_to_contain_dates(['24 Nov 2018', '25 Nov 2018', '24 Dec 2018'])
+    expect_upviews_table_to_contain_dates(['25 Nov 2018', '26 Nov 2018', '24 Dec 2018'])
   end
 
   it 'renders data for the previous month when `Past month` is selected' do
@@ -51,25 +51,25 @@ RSpec.describe 'date selection', type: :feature do
   it 'renders data for the past 3 months when `Past 3 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :past_3_months)
     visit_page_and_filter_by_date_range('past-3-months')
-    expect_upviews_table_to_contain_dates(['24 Sep 2018', '25 Sep 2018', '24 Dec 2018'])
+    expect_upviews_table_to_contain_dates(['25 Sep 2018', '26 Sep 2018', '24 Dec 2018'])
   end
 
   it 'renders data for the past 6 months when `Past 6 months` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :past_6_months)
     visit_page_and_filter_by_date_range('past-6-months')
-    expect_upviews_table_to_contain_dates(['24 Jun 2018', '25 Jun 2018', '24 Dec 2018'])
+    expect_upviews_table_to_contain_dates(['25 Jun 2018', '26 Jun 2018', '24 Dec 2018'])
   end
 
   it 'renders data for the past year when `Past year` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :past_year)
     visit_page_and_filter_by_date_range('past-year')
-    expect_upviews_table_to_contain_dates(['24 Dec 2017', '25 Dec 2017', '24 Dec 2018'])
+    expect_upviews_table_to_contain_dates(['25 Dec 2017', '26 Dec 2017', '24 Dec 2018'])
   end
 
   it 'renders data for the past 2 years when `Past 2 years` is selected' do
     stub_metrics_page(base_path: base_path, time_period: :past_2_years)
     visit_page_and_filter_by_date_range('past-2-years')
-    expect_upviews_table_to_contain_dates(['24 Dec 2016', '25 Dec 2016', '24 Dec 2018'])
+    expect_upviews_table_to_contain_dates(['25 Dec 2016', '26 Dec 2016', '24 Dec 2018'])
   end
 
   def visit_page_and_filter_by_date_range(date_range)

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -2,8 +2,9 @@ RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
-  let(:prev_from) { Time.zone.yesterday - 60.days }
-  let(:from) { Time.zone.yesterday - 30.days }
+  let(:prev_from) { Time.zone.yesterday - 59.days }
+  let(:prev_to) { Time.zone.yesterday - 30.days }
+  let(:from) { Time.zone.yesterday - 29.days }
   let(:to) { Time.zone.yesterday }
 
   around do |example|
@@ -97,7 +98,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
 
     describe 'page metric section' do
-      let(:expected_table_dates) { ['', '24 Nov 2018', '25 Nov 2018', '24 Dec 2018'] }
+      let(:expected_table_dates) { ['', '25 Nov 2018', '26 Nov 2018', '24 Dec 2018'] }
 
       it 'renders the metric for upviews' do
         expect(page).to have_selector '.metric-summary__upviews', text: '6,000'
@@ -227,7 +228,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
                                          to: to.to_s)
         content_data_api_has_single_page_with_nil_values(base_path: 'base/path',
                                                          from: prev_from.to_s,
-                                                         to: from.to_s)
+                                                         to: prev_to.to_s)
         visit '/metrics/base/path'
         expect(page.status_code).to eq(200)
         expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: 'no comparison data'
@@ -248,7 +249,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
     context 'no time series from the data-api' do
       before do
         content_data_api_has_single_page_missing_data(base_path: 'base/path', from: from.to_s, to: to.to_s)
-        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: prev_from.to_s, to: from.to_s)
+        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: prev_from.to_s, to: prev_to.to_s)
         visit '/metrics/base/path'
       end
 

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-11-24') }
+      it { is_expected.to have_attributes(from: '2018-11-25') }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
@@ -21,7 +21,7 @@ RSpec.describe DateRange do
       let(:specified_date) { Date.new(2018, 6, 25) }
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2018-05-26') }
+      it { is_expected.to have_attributes(from: '2018-05-27') }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
@@ -30,7 +30,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-11-24') }
-      it { is_expected.to have_attributes(from: '2018-10-25') }
+      it { is_expected.to have_attributes(from: '2018-10-26') }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
   end
@@ -72,7 +72,7 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-09-24') }
+      it { is_expected.to have_attributes(from: '2018-09-25') }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
@@ -81,7 +81,7 @@ RSpec.describe DateRange do
       let(:specified_date) { Date.new(2018, 6, 25) }
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2018-03-25') }
+      it { is_expected.to have_attributes(from: '2018-03-26') }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
@@ -90,7 +90,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-09-24') }
-      it { is_expected.to have_attributes(from: '2018-06-24') }
+      it { is_expected.to have_attributes(from: '2018-06-25') }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
   end
@@ -102,7 +102,7 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-06-24') }
+      it { is_expected.to have_attributes(from: '2018-06-25') }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
@@ -111,7 +111,7 @@ RSpec.describe DateRange do
       let(:specified_date) { Date.new(2018, 6, 25) }
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2017-12-25') }
+      it { is_expected.to have_attributes(from: '2017-12-26') }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
@@ -120,7 +120,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2018-06-24') }
-      it { is_expected.to have_attributes(from: '2017-12-24') }
+      it { is_expected.to have_attributes(from: '2017-12-25') }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
   end
@@ -132,7 +132,7 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2017-12-24') }
+      it { is_expected.to have_attributes(from: '2017-12-25') }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
@@ -141,7 +141,7 @@ RSpec.describe DateRange do
       let(:specified_date) { Date.new(2018, 6, 25) }
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2017-06-25') }
+      it { is_expected.to have_attributes(from: '2017-06-26') }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
@@ -150,7 +150,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2017-12-24') }
-      it { is_expected.to have_attributes(from: '2016-12-24') }
+      it { is_expected.to have_attributes(from: '2016-12-25') }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
   end
@@ -162,7 +162,7 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period) }
 
       it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2016-12-24') }
+      it { is_expected.to have_attributes(from: '2016-12-25') }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
@@ -171,7 +171,7 @@ RSpec.describe DateRange do
       let(:specified_date) { Date.new(2018, 6, 25) }
 
       it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2016-06-25') }
+      it { is_expected.to have_attributes(from: '2016-06-26') }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
@@ -180,7 +180,7 @@ RSpec.describe DateRange do
 
       it { is_expected.to be_an_instance_of(DateRange) }
       it { is_expected.to have_attributes(to: '2016-12-24') }
-      it { is_expected.to have_attributes(from: '2014-12-24') }
+      it { is_expected.to have_attributes(from: '2014-12-25') }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
   end

--- a/spec/presenters/chart_presenter_spec.rb
+++ b/spec/presenters/chart_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ChartPresenter do
   end
 
   it 'returns start date' do
-    expect(subject.from).to eq Date.new(2017, 12, 31)
+    expect(subject.from).to eq Date.new(2018, 1, 1)
   end
   it 'returns end date' do
     expect(subject.to).to eq Date.new(2018, 1, 30)
@@ -39,10 +39,10 @@ RSpec.describe ChartPresenter do
 
   def upviews_chart_data
     {
-      caption: "Unique pageviews from 2017-12-31 to 2018-01-30",
+      caption: "Unique pageviews from 2018-01-01 to 2018-01-30",
       chart_id: "upviews_chart",
       chart_label: "Unique pageviews",
-      from: "Date(2017, 11, 31)",
+      from: "Date(2018, 0, 1)",
       to: "Date(2018, 0, 30)",
       keys: [
         Date.new(2018, 1, 13),

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,9 +1,15 @@
 RSpec.describe SingleContentItemPresenter do
   include GdsApi::TestHelpers::ContentDataApi
 
+  around do |example|
+    Timecop.freeze Date.new(2018, 12, 25) do
+      example.run
+    end
+  end
+
   let(:date_range) { build(:date_range, :past_30_days) }
-  let(:current_period_data) { default_single_page_payload('the/base/path', '2018-11-25', '2018-12-25') }
-  let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-25') }
+  let(:current_period_data) { default_single_page_payload('the/base/path', '2018-11-25', '2018-12-24') }
+  let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-24') }
   let(:default_timeseries_metrics) {
     [
       {
@@ -28,13 +34,6 @@ RSpec.describe SingleContentItemPresenter do
       }
     ]
   }
-
-
-  around do |example|
-    Timecop.freeze Date.new(2018, 12, 25) do
-      example.run
-    end
-  end
 
   subject do
     SingleContentItemPresenter.new(current_period_data, previous_period_data, date_range)
@@ -107,7 +106,7 @@ RSpec.describe SingleContentItemPresenter do
 
     it 'returns `no comparison data` if there is incomplete comparison data' do
       current_time_series = [{ date: '2018-11-25', value: 100 }, { date: '2018-11-26', value: 100 }]
-      previous_time_series = [{ date: '2018-11-25', value: 100 }]
+      previous_time_series = [{ date: '2018-11-24', value: 100 }]
 
       current_period_data[:time_series_metrics] = time_series_metrics(100, current_time_series)
       previous_period_data[:time_series_metrics] = time_series_metrics(100, previous_time_series)
@@ -220,7 +219,7 @@ RSpec.describe SingleContentItemPresenter do
   describe '#feedback_explorer_href' do
     it 'returns a URI for the feedback explorer' do
       host = Plek.new.external_url_for('support')
-      expected_link = "#{host}/anonymous_feedback?from=2018-11-24&to=2018-12-24&paths=%2Fthe%2Fbase%2Fpath"
+      expected_link = "#{host}/anonymous_feedback?from=2018-11-25&to=2018-12-24&paths=%2Fthe%2Fbase%2Fpath"
       expect(subject.feedback_explorer_href).to eq(expected_link)
     end
   end


### PR DESCRIPTION
# What
Most of the date ranges were off by 1 day being inclusive of the `to` and `from` dates specified.

# Why
To make the date ranges accurate to the time period specified and comparable to data sources i.e. Google Analytics

# Screenshots
## Before
![image](https://user-images.githubusercontent.com/11051676/49458416-aa813a00-f7e4-11e8-8870-a661261d88d7.png)

## After
![image](https://user-images.githubusercontent.com/11051676/49458674-32674400-f7e5-11e8-9705-4c83a648db89.png)

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.