### PR TITLE
Block Custom HTML, Javascript and Pixels from GTM

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,10 @@
 
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
     <script>
-      dataLayer = [{ 'user-organisation': '<%= current_user.organisation_slug %>' }];
+      dataLayer = [
+        { 'gtm.blacklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] },
+        { 'user-organisation': '<%= current_user.organisation_slug %>' }
+      ];
     </script>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],


### PR DESCRIPTION
We want to ensure that all code deployed to production goes through the normal development process. This block list will prevent Google Tag Manager from running any custom code which may have not been code reviewed.