### PR TITLE
Remove extra "Showing" in filter description

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,6 +1,6 @@
-<h1 class="table-header">Showing
+<h1 class="table-header">
+    Showing
     <% if pagination.total_results > 0 %>
-        Showing
         <span class="table-header__param"><%= pagination.first_record %></span> to
         <span class="table-header__param"><%= pagination.last_record %></span> of
         <span class="table-header__param"><%= pagination.total_results %></span> results


### PR DESCRIPTION
# What
The filter incorrectly has an extra "Showing" at the start.

# Why
Its confusing to users reading the filter description. 

# Screenshots
## Before
<img width="734" alt="image" src="https://user-images.githubusercontent.com/11051676/49597089-a2a3d000-f973-11e8-9cd3-8a87761bf236.png">

## After

<img width="670" alt="image" src="https://user-images.githubusercontent.com/11051676/49597266-f7dfe180-f973-11e8-9d67-32e5930fe5e8.png">

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [ ] Added to Trello card.
