### PR TITLE
Fix typos in contextual help

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -40,7 +40,7 @@ en:
       external_link: ''
       about: >
         This figure is calculated by dividing Google Analytics pageviews by unique pageviews. It
-        shows on average how many times a page was viewed during users' session. If a page has a
+        shows on average how many times a page was viewed during a user's session. If a page has a
         high ratio (above 1.4), this indicates that users have to come back to that page within
         their session - investigate the navigation from that page further to identify any issues.
     searches:
@@ -66,7 +66,7 @@ en:
       about: >
         Percentage of users who answered 'Yes' rather than 'No' to the 'Is this page useful?' survey.
         The more users who responded, the more reliable the score is. For a more reliable score
-        on a page that doens't have many responses, choose a longer time period. This survey was
+        on a page that doesn't have many responses, choose a longer time period. This survey was
         introduced in February 2018 so there are no responses before this date.
     feedex:
       title: 'Number of feedback comments'


### PR DESCRIPTION
About pageviews per visit

CHANGED
It shows on average how many times a page was viewed during users’ session.

TO
It shows on average how many times a page was viewed during a user's session.

WHY
It's grammatically incorrect

About user satisfaction score

CHANGED
For a more reliable score on a page that doens't have many responses, choose a longer time period.
TO
For a more reliable score on a page that doesn't have many responses, choose a longer time period.

WHY
Spelling mistake

