### PR TITLE
Remove references to date fields.

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -131,14 +131,6 @@ class SingleContentItemPresenter
     metadata[:document_type].tr('_', ' ').capitalize
   end
 
-  def published_at
-    format_date(metadata[:first_published_at])
-  end
-
-  def last_updated
-    format_date(metadata[:public_updated_at])
-  end
-
   def publishing_organisation
     metadata[:primary_organisation_title]
   end
@@ -237,9 +229,5 @@ private
     previous_date = @previous_metrics['upviews'][:time_series].first[:date].to_date
     days_in_month = Time.days_in_month(previous_date.month, previous_date.year)
     days_in_month != previous_value[:time_series].length
-  end
-
-  def format_date(date_str)
-    Date.parse(date_str).strftime('%-d %B %Y')
   end
 end

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -1,6 +1,4 @@
 <%
-    published_at ||= nil
-    last_updated ||= nil
     publishing_organisation ||= nil
     document_type ||= nil
     base_path ||= nil

--- a/app/views/components/docs/metadata.yml
+++ b/app/views/components/docs/metadata.yml
@@ -10,16 +10,12 @@ examples:
   default:
     data:
       status: "withdrawn"
-      published_at: "1 September 2016"
-      last_updated: "1 October 2017"
       publishing_organisation: "UK Visas and Immigration"
       document_type: "Guidance"
       base_path: "/government/publications/visitor-visa-guide-to-supporting-documents"
   without_status:
     description: Without a status
     data:
-      published_at: "1 September 2016"
-      last_updated: "1 October 2017"
       publishing_organisation: "UK Visas and Immigration"
       document_type: "Guidance"
       base_path: "/government/publications/visitor-visa-guide-to-supporting-documents"

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -16,8 +16,6 @@
     <h1 class="govuk-heading-xl"><%= @performance_data.title %></h1>
     <div class="page-metadata">
       <%= render "components/metadata",
-          published_at: @performance_data.published_at,
-          last_updated: @performance_data.last_updated,
           publishing_organisation: @performance_data.publishing_organisation,
           document_type: @performance_data.document_type.humanize,
           base_path: @performance_data.base_path,

--- a/spec/components/metadata_spec.rb
+++ b/spec/components/metadata_spec.rb
@@ -4,8 +4,6 @@ RSpec.describe "Metadata", type: :view do
   let(:data) {
     {
         status: "withdrawn",
-        published_at: "1 September 2016",
-        last_updated: "1 October 2017",
         publishing_organisation: "UK Visas and Immigration",
         document_type: "Guidance",
         base_path: "/government/publications/visitor-visa-guide-to-supporting-documents",
@@ -30,18 +28,6 @@ RSpec.describe "Metadata", type: :view do
     data[:status] = false
     render_component(data)
     assert_select ".app-c-metadata__title", text: t("components.metadata.labels.status"), count: 0
-  end
-
-  it "does not render the 'updated' fields when data is not supplied" do
-    data[:last_updated] = false
-    render_component(data)
-    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.last_updated"), count: 0
-  end
-
-  it "does not render the 'published' fields when data is not supplied" do
-    data[:published_at] = false
-    render_component(data)
-    assert_select ".app-c-metadata__title", text: t("components.metadata.labels.published_at"), count: 0
   end
 
   it "does not render the 'organisation' fields when data is not supplied" do

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -206,8 +206,6 @@ RSpec.describe SingleContentItemPresenter do
   describe '#metadata' do
     it 'returns a hash with the metadata' do
       expect(subject.base_path).to eq('/the/base/path')
-      expect(subject.published_at).to eq("17 July 2018")
-      expect(subject.last_updated).to eq("17 July 2018")
       expect(subject.document_type).to eq("News story")
       expect(subject.publishing_organisation).to eq("The Ministry")
     end


### PR DESCRIPTION
# What
Remove the code that parses/formats published_at and last_updated

# Why
We have an error formatting published_at when it is null.

As we are no longer displaying the data, the code to parse/format
it is redundant. This commit removes it.

Url to test: http://content-data-admin.dev.gov.uk/metrics/guidance/the-highway-code/traffic-signs

If you can see the page - the bug is fixed.

Trelllo: https://trello.com/c/ozp8d9RM/929-2-placeholder-traffic-signs-content-not-loading 

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
