### PR TITLE
Change the default filter to `All Organisations`

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -2,6 +2,8 @@ class ContentController < ApplicationController
   include PaginationHelper
   include Concerns::ExportableToCSV
 
+  DEFAULT_ORGANISATION_ID = 'all'.freeze
+
   layout 'application'
   before_action :set_constants
 
@@ -40,7 +42,7 @@ private
     @search_params ||= begin
       defaults = {
         date_range: 'past-30-days',
-        organisation_id: current_user.organisation_content_id,
+        organisation_id: DEFAULT_ORGANISATION_ID,
         document_type: ''
       }
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -118,26 +118,26 @@ RSpec.describe '/content' do
       expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.past-year.leading')}")
     end
 
-    context 'with users organisation' do
+    context 'when no organisation_id in params' do
       before do
         content_data_api_has_content_items(
           date_range: 'last-month',
-          organisation_id: 'users-org-id',
+          organisation_id: 'all',
           items: [
-            items[0].merge(title: 'Content from users-org-id')
+            items[0].merge(title: 'Content from all-orgs')
           ]
         )
 
         visit "/content?date_range=last-month"
       end
 
-      it 'uses the users organisation by default' do
+      it 'uses the `all` filter by default' do
         expect(page.status_code).to eq(200)
-        expect(page).to have_content('Content from users-org-id')
+        expect(page).to have_content('Content from all-orgs')
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from Users Org')
+        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from All organisations')
       end
     end
 
@@ -153,7 +153,7 @@ RSpec.describe '/content' do
           organisation_id: 'all',
           items: [items[0].merge(title: 'Content from all orgs')]
         )
-        visit '/content?date_range=past-30-days'
+        visit '/content?date_range=past-30-days&organisation_id=users-org-id'
         select('All organisations', from: 'organisation_id')
         click_on 'Filter'
       end
@@ -176,7 +176,7 @@ RSpec.describe '/content' do
           organisation_id: 'none',
           items: [items[0].merge(title: 'Content with no primary org')]
         )
-        visit '/content?date_range=past-30-days'
+        visit '/content?date_range=past-30-days&organisation_id=users-org-id'
         select('No primary organisation', from: 'organisation_id')
         click_on 'Filter'
       end
@@ -191,12 +191,12 @@ RSpec.describe '/content' do
       before do
         content_data_api_has_content_items(
           date_range: 'past-30-days',
-          organisation_id: 'users-org-id',
+          organisation_id: 'all',
           items: items
         )
         content_data_api_has_content_items(
           date_range: 'past-30-days',
-          organisation_id: 'users-org-id',
+          organisation_id: 'all',
           search_term: 'Relevant',
           items: [items[0].merge(title: 'Relevant content article')]
         )
@@ -210,7 +210,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for "Relevant" from Users Org')
+        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for "Relevant" from All organisations')
       end
     end
   end


### PR DESCRIPTION
# What
Change the default filter to `All Organisations`

# Why
We have found from user research that users are having
problems finding content.

We think this is because of the organisation filter which defaults
to the users organisation.

# Screenshots

## Before
<img width="617" alt="before" src="https://user-images.githubusercontent.com/511319/49653966-6f724700-fa2e-11e8-91e7-0aea44bb8ed0.png">

## After
<img width="659" alt="after" src="https://user-images.githubusercontent.com/511319/49653974-7436fb00-fa2e-11e8-8c7b-deee2cd099ca.png">


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
