### PR TITLE
Fix `Showing` appearing twice in the header

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,4 +1,4 @@
-<h1 class="table-header">Showing
+<h1 class="table-header">
     <% if pagination.total_results > 0 %>
         Showing
         <span class="table-header__param"><%= pagination.first_record %></span> to

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 3 of 3 results from another org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 3 of 3 results from another org')
     end
 
     it 'respects date range' do
@@ -137,7 +137,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results from All organisations')
       end
     end
 
@@ -210,7 +210,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results for "Relevant" from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results for "Relevant" from All organisations')
       end
     end
   end
@@ -234,7 +234,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 1 of 1 results in News story from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results in News story from org')
     end
 
     it 'allows the filter to be cleared' do
@@ -243,7 +243,7 @@ RSpec.describe '/content' do
       expect(page).to have_select('document_type', selected: 'All document types')
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 3 of 3 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 3 of 3 results from org')
     end
   end
 
@@ -282,7 +282,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows the second page of data' do
-      expect(page).to have_css('h1.table-header', text: 'Showing 1 to 100 of 102 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 102 results from org')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -292,7 +292,7 @@ RSpec.describe '/content' do
           ['forth title /path/4', 'News story', '100,018', '68% (42 responses)', '12'],
         ]
       )
-      expect(page).to have_css('h1.table-header', text: 'Showing 101 to 102 of 102 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 101 to 102 of 102 results from org')
     end
   end
 
@@ -303,7 +303,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows a no data message in the table header' do
-      expect(page).to have_css('h1.table-header', text: "#{I18n.t 'no_matching_results'} from org")
+      expect(page).to have_css('h1.table-header', exact_text: "#{I18n.t 'no_matching_results'} from org")
     end
   end
 


### PR DESCRIPTION
# What
Fix the text in the table header

# Why
Previously the table header said:
`Showing Showing 1 to 2 of 2 results for...`

This commit removes the repeated word so now it says:
`Showing 1 to 2 of 2 results for...`

Trello: https://trello.com/c/cx3X7pIT/934-2-filter-description-says-3-results-instead-of-2-results

# Screenshots

## Before
<img width="724" alt="before" src="https://user-images.githubusercontent.com/511319/49735873-65e01d80-fc80-11e8-8723-9cb65cf51eaf.png">

## After
<img width="641" alt="after" src="https://user-images.githubusercontent.com/511319/49735880-6973a480-fc80-11e8-9b4e-a079c4641550.png">


---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added to Trello card.
