### PR TITLE
Fix formatting of numbers in table header

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -34,8 +34,16 @@ class PaginationPresenter
     previous_record_count + 1
   end
 
+  def formatted_first_record
+    number_with_delimiter first_record
+  end
+
   def last_record
     [@page * @per_page, @total_results].min
+  end
+
+  def formatted_last_record
+    number_with_delimiter last_record
   end
 
   def paginate(items)

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,9 +1,9 @@
 <h1 class="table-header">
     <% if pagination.total_results > 0 %>
         Showing
-        <span class="table-header__param"><%= pagination.first_record %></span> to
-        <span class="table-header__param"><%= pagination.last_record %></span> of
-        <span class="table-header__param"><%= pagination.total_results %></span> results
+        <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
+        <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
+        <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
     <% else %>
         <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -307,6 +307,17 @@ RSpec.describe '/content' do
     end
   end
 
+  describe 'large set of results' do
+    before do
+      content_data_api_has_many_matching_items(date_range: 'past-3-months', organisation_id: 'org-id', page: 200)
+      visit "/content?date_range=past-3-months&organisation_id=org-id"
+    end
+
+    it 'formats the page numbers correctly in the table header' do
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 19,901 to 20,000 of 30,000 results from org')
+    end
+  end
+
   context 'CSV export' do
     # Use lots of items to test getting a couple of full pages, plus a
     # partial page back from the Content Performance Manager.

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -55,12 +55,20 @@ RSpec.describe PaginationPresenter do
       expect(subject.prev_label).to eq('123456 of 123457')
     end
 
-    it 'returns 100 for #first_record' do
+    it 'returns 1234561 for #first_record' do
       expect(subject.first_record).to eq(1234561)
     end
 
-    it 'returns 105 for #last_record' do
+    it 'returns "1,234,561" for #formatted_first_record' do
+      expect(subject.formatted_first_record).to eq('1,234,561')
+    end
+
+    it 'returns 1234567 for #last_record' do
       expect(subject.last_record).to eq(1234567)
+    end
+
+    it 'returns "1,234,567" for #formatted_last_record' do
+      expect(subject.formatted_last_record).to eq('1,234,567')
     end
   end
 

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -86,6 +86,21 @@ module GdsApi
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
+      def content_data_api_has_many_matching_items(date_range:, organisation_id:, page: 1)
+        params = {
+          date_range: date_range,
+          organisation_id: organisation_id,
+        }.reject { |_, v| v.blank? }
+        body = {
+          results: [],
+          total_results: 30_000,
+          total_pages: 3000,
+          page: page
+        }.to_json
+        url = "#{content_data_api_endpoint}/content#{query(params)}"
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
+
       def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
         query = query(from: from, to: to)
         url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"


### PR DESCRIPTION
# What
Format page numbers in the /content table header

# Why

We were showing numbers formatted with commas in the
pagination description above the table.

I seem to have removed it accidentally.

This commit corrects that and adds to the feature
test for the index page to make sure we can't break it again.
Now all page numbers are formatted, not just the total.

# Screenshots

## Before
<img width="625" alt="before" src="https://user-images.githubusercontent.com/511319/49753965-cab16d00-fcac-11e8-853a-af4ba7d532ba.png">


## After
<img width="737" alt="after" src="https://user-images.githubusercontent.com/511319/49753968-d0a74e00-fcac-11e8-9895-55de65c7a4a3.png">



---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
