### PR TITLE
Make the CSV download respect the filter

### DIFF
--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -26,6 +26,7 @@ class FindContent
       date_range: @date_range,
       organisation_id: @organisation,
       document_type: @document_type,
+      search_term: @search_term,
     }
 
     Enumerator.new do |yielder|

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -312,14 +312,21 @@ RSpec.describe '/content' do
     # partial page back from the Content Performance Manager.
     let(:csv_items) { items * 11 }
 
-    it 'it provides a CSV file' do
+    it 'it provides a CSV file respecting all filters' do
       content_data_api_has_content_items(
         date_range: 'last-month',
         organisation_id: 'org-id',
         items: csv_items,
-        page_size: 5000
+        search_term: 'find this'
       )
-
+      content_data_api_has_content_items(
+        date_range: 'last-month',
+        organisation_id: 'org-id',
+        items: csv_items,
+        page_size: 5000,
+        search_term: 'find this'
+      )
+      visit "/content?date_range=last-month&organisation_id=org-id&search_term=find+this"
       click_link 'Download all data in CSV format'
 
       expect(CSV.parse(page.body).length).to be(csv_items.length + 1)


### PR DESCRIPTION
# What 
Beefed up the test and make the CSV download respect all the
filters.

# Why
The CSV download was ignoring the `title or URL` filter.

Test by filtering the index page, download a CSV, it should have the same rows.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
