### PR TITLE
Handle CSV filename for all/no orgs.

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -1,6 +1,9 @@
 require 'csv'
 
 class ContentItemsCSVPresenter
+  ALL_ORGANISATIONS = 'all'.freeze
+  NO_ORGANISATION = 'none'.freeze
+
   def initialize(data_enum, search_params, document_types, organisations)
     @data_enum = data_enum
     @document_type = search_params[:document_type]
@@ -56,6 +59,8 @@ private
   end
 
   def organisation_title
+    return 'All organisations' if @organisation_id == ALL_ORGANISATIONS
+    return 'No organisation' if @organisation_id == NO_ORGANISATION
     organisation_data = @organisations.find do |org|
       org[:organisation_id] == @organisation_id
     end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -74,4 +74,24 @@ RSpec.describe ContentItemsCSVPresenter do
       ).to include('from-org-in-news-story.csv')
     end
   end
+
+  context 'when `All Organisations` is selected' do
+    subject { described_class.new(data_enum, search_params.merge(organisation_id: 'all'), document_types, organisations) }
+
+    it 'includes all-organisations in filename' do
+      expect(
+        subject.filename
+      ).to include('from-all-organisations-in-news-story.csv')
+    end
+  end
+
+  context 'when `No primary organisation` is selected' do
+    subject { described_class.new(data_enum, search_params.merge(organisation_id: 'none'), document_types, organisations) }
+
+    it 'includes no-organisation in filename' do
+      expect(
+        subject.filename
+      ).to include('from-no-organisation-in-news-story.csv')
+    end
+  end
 end


### PR DESCRIPTION
# What
Handle `No organisations` and `No organisation` filter
in CSV download.

# Why
CSV Download was failing when `All organisations` or
`No primary organisation` is selected.

This was because it was trying to get the organisation
name to generate the filename.

`all` and `none` do not exist in the list of organisations so this was
failing.

Short-circuit for `all` and `none` to return `All organisations` and
`No organisation`.

# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
