### PR TITLE
Fix link to Manuals Publisher for manual_section

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -1,12 +1,16 @@
 module ExternalLinksHelper
-  def edit_url_for(content_id:, publishing_app:, base_path:, document_type:)
+  def edit_url_for(content_id:, publishing_app:, base_path:, document_type:, parent_content_id: '')
     case publishing_app
     when 'whitehall'
       "#{external_url_for('whitehall-admin')}/government/admin/by-content-id/#{content_id}"
     when 'publisher'
       "#{external_url_for('support')}/content_change_request/new"
     when 'manuals-publisher'
-      "#{external_url_for('manuals-publisher')}/manuals/#{content_id}"
+      if document_type == 'manual'
+        "#{external_url_for('manuals-publisher')}/manuals/#{content_id}"
+      elsif document_type == 'manual_section'
+        "#{external_url_for('manuals-publisher')}/manuals/#{parent_content_id}/sections/#{content_id}"
+      end
     when 'maslow', 'need-api'
       "#{external_url_for('maslow')}/needs/#{content_id}"
     when 'contacts'

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -107,6 +107,7 @@ class SingleContentItemPresenter
       content_id: metadata[:content_id],
       publishing_app: metadata[:publishing_app],
       base_path: base_path,
+      parent_content_id: metadata[:parent_content_id],
       document_type: metadata[:document_type]
     )
   end

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -55,6 +55,35 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
+    context 'with manuals-publisher' do
+      it 'generates a link to the manuals publisher app for manual itself' do
+        expect(
+          edit_url_for(
+            content_id: 'manual-id',
+            publishing_app: 'manuals-publisher',
+            base_path: '/guidance/style-guide',
+            document_type: 'manual'
+          )
+        ).to eq(
+          "#{external_url_for('manuals-publisher')}/manuals/manual-id"
+        )
+      end
+
+      it 'generates a link to the manuals publisher app for a manual section' do
+        expect(
+          edit_url_for(
+            content_id: 'manual-section-id',
+            publishing_app: 'manuals-publisher',
+            base_path: '/guidance/style-guide/a-to-z-of-gov-uk-style',
+            document_type: 'manual_section',
+            parent_content_id: 'manual-id'
+          )
+        ).to eq(
+          "#{external_url_for('manuals-publisher')}/manuals/manual-id/sections/manual-section-id"
+        )
+      end
+    end
+
     context 'with collections' do
       it 'generates a link to the collections publisher app' do
         expect(

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -230,7 +230,8 @@ RSpec.describe SingleContentItemPresenter do
         content_id: 'content-id',
         publishing_app: 'whitehall',
         base_path: '/the/base/path',
-        document_type: 'news_story'
+        document_type: 'news_story',
+        parent_content_id: ''
       ).and_return(
         'https://expected-link'
       )

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -153,7 +153,8 @@ module GdsApi
             document_type:  "news_story",
             primary_organisation_title:  "The Ministry",
             historical: false,
-            withdrawn: false
+            withdrawn: false,
+            parent_content_id: ''
           },
           time_period: {
             to: to,


### PR DESCRIPTION
# What/Why

Links to edit `manual_sections` in Manuals Publisher require the
`content_id` of it's parent `manual`. This is now sent as
`parent_content_id` from the API.

# Screenshots

## Before
<img width="757" alt="screen shot 2018-12-24 at 11 06 22 am" src="https://user-images.githubusercontent.com/424772/50397991-1f082280-076c-11e9-81db-5c7447276bd5.png">

## After
<img width="878" alt="screen shot 2018-12-24 at 11 06 36 am" src="https://user-images.githubusercontent.com/424772/50397998-31825c00-076c-11e9-8270-7f7f9d392c77.png">

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
