### PR TITLE
Fix truncation of large numbers on chart

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -1,6 +1,7 @@
 <%
   chart_id ||= false
   chart_label ||= "data"
+  chart_width ||= "90%"
   table_id ||= false
   table_direction ||= "horizontal"
   from ||= false
@@ -30,6 +31,10 @@
     else
       # for higher numbers give breathing space to line
       maximum_y = overall_maximum * 1.3
+
+      if overall_maximum > 99999
+        chart_width = "80%"
+      end
     end
   end
 
@@ -37,7 +42,7 @@
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
     legend: 'none',
-    chartArea: { width: '90%', height: '80%' },
+    chartArea: { width: chart_width, height: '80%' },
     curveType: 'none',
     tooltip: { textStyle: { color: '#000' }, showColorCode: true },
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },


### PR DESCRIPTION
# What
Fix the truncation of long numbers on the chart Y axis

# Why
Without this fix long numbers are not legible
https://trello.com/c/anAJGHjl/1006-x-axis-values-over-100000-wrap-to-2-lines-on-the-performance-page

The fix works by checking the max value that we are already collecting, and if it is above the threshold where it wraps or is hidden then we reduce the width of the chart from 90% to 80%, giving the edge more space for the labels on the Y axis.