### PR TITLE
Change format of satisfaction score in Content CSV

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -2,6 +2,7 @@ require 'csv'
 
 class ContentItemsCSVPresenter
   include CustomMetricsHelper
+  include MetricsFormatterHelper
 
   ALL_ORGANISATIONS = 'all'.freeze
   NO_ORGANISATION = 'none'.freeze
@@ -40,7 +41,9 @@ class ContentItemsCSVPresenter
           searches: result_row[:searches], unique_pageviews: result_row[:upviews]
         )
       end,
-      I18n.t('metrics.satisfaction.short_title') => raw_field(:satisfaction),
+      I18n.t('metrics.satisfaction.short_title') => lambda do |result_row|
+        format_metric_value('satisfaction', result_row[:satisfaction])
+      end,
       'Yes responses: satisfaction score' => raw_field(:useful_yes),
       'No responses: satisfaction score' => raw_field(:useful_no),
       I18n.t('metrics.searches.short_title') => raw_field(:searches),

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -130,7 +130,7 @@ RSpec.describe ContentItemsCSVPresenter do
       end
 
       it 'has satisfaction score' do
-        expect(subject[9]).to eq('0.25')
+        expect(subject[9]).to eq('25%')
       end
 
       it 'has yes responses' do


### PR DESCRIPTION
# What
Changing the format of the satisfaction score metric from decimal to percentage. I.e 0.50 -> 50%

# Why
Formatting is easier to read and natural as percentage.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
