### PR TITLE
Pagination when less than 100 results

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,9 +1,13 @@
 <h1 class="table-header">
     <% if pagination.total_results > 0 %>
         Showing
-        <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
-        <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
-        <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+        <% if pagination.total_pages > 1 %>
+            <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
+            <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
+            <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+        <% else %>
+            <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+        <% end %>
     <% else %>
         <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -6,7 +6,7 @@
             <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
             <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
         <% else %>
-            <span class="table-header__param"><%= pagination.formatted_total_results %></span> results
+            <span class="table-header__param"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
         <% end %>
     <% else %>
         <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 3 of 3 results from another org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from another org')
     end
 
     it 'respects date range' do
@@ -140,7 +140,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results from All organisations')
       end
     end
 
@@ -213,7 +213,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results for "Relevant" from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results for "Relevant" from All organisations')
       end
     end
   end
@@ -237,7 +237,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 1 of 1 results in News story from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results in News story from org')
     end
 
     it 'allows the filter to be cleared' do
@@ -246,7 +246,7 @@ RSpec.describe '/content' do
       expect(page).to have_select('document_type', selected: 'All document types')
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 3 of 3 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from org')
     end
   end
 

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -140,7 +140,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result from All organisations')
       end
     end
 
@@ -213,7 +213,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results for "Relevant" from All organisations')
+        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result for "Relevant" from All organisations')
       end
     end
   end
@@ -237,7 +237,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 results in News story from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result in News story from org')
     end
 
     it 'allows the filter to be cleared' do


### PR DESCRIPTION
# What
Don't show `1 to 2 of 2 results` when there is only one page.

# Why
It's a bit naff

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
<img width="639" alt="screen shot 2019-01-10 at 14 13 41" src="https://user-images.githubusercontent.com/511319/50973935-045ed900-14e2-11e9-9455-ed5e8ca8e5ce.png">

## After
<img width="526" alt="screen shot 2019-01-10 at 14 12 02" src="https://user-images.githubusercontent.com/511319/50973974-1b9dc680-14e2-11e9-973e-66681883ec42.png">

## Before
<img width="1047" alt="screen shot 2019-01-10 at 14 16 13" src="https://user-images.githubusercontent.com/511319/50974104-5c95db00-14e2-11e9-81cf-61efe4877791.png">

## After
<img width="983" alt="screen shot 2019-01-10 at 14 17 13" src="https://user-images.githubusercontent.com/511319/50974155-78997c80-14e2-11e9-9fb9-e3b1d6f163a7.png">

Trello: https://trello.com/c/I5JI3AH5/1020-showing-1-to-2-of-2-less-than-100-results

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
