### PR TITLE
Re-align quality metrics layout

### DIFF
--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -23,6 +23,11 @@
   margin: 0;
 }
 
+.section-content__quality {
+  @include govuk-responsive-margin(2, "left");
+  @include govuk-responsive-margin(2, "right");
+}
+
 .govuk-section-break--visible {
   border-width: 1px;
 }

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -164,7 +164,7 @@
 
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full section-content">
+  <div class="govuk-grid-column-full section-content section-content__quality">
     <h2 class="section-content__header"><%= t ".section_headings.content" %></h2>
     <div class="govuk-grid-column-one-half metric-summary metric-summary__words">
       <%= render 'metric_header', metric_name: 'words', value: @performance_data.total_words, show_trend: false %>


### PR DESCRIPTION
# What
Bring the last section of the page in line with the margins for the rest

# Why
Buggy layout needs fixing

# Screenshots

## Before
![screen shot 2019-01-15 at 09 32 16](https://user-images.githubusercontent.com/31649453/51171456-de05b880-18a8-11e9-9543-28a304661d08.png)

## After
![screen shot 2019-01-15 at 09 31 36](https://user-images.githubusercontent.com/31649453/51171443-d6deaa80-18a8-11e9-8ec1-df4fd9eee4f6.png)
