### PR TITLE
Close up space after heading on time select component

### DIFF
--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -12,3 +12,7 @@
 .govuk-details__summary {
   @include govuk-font(16);
 }
+
+.app-c-time-select__heading {
+  @include govuk-responsive-margin(1, "bottom");
+}

--- a/app/views/components/_time-select.html.erb
+++ b/app/views/components/_time-select.html.erb
@@ -17,14 +17,13 @@
 <% if dates.length > 1 && current_selection %>
   <div class="app-c-time-select <% if compact %> app-c-time-select--compact<% end %>">
     <%if compact %>
-      <h2 class="govuk-heading-s"><%= t '.title_compact', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
+      <h2 class="govuk-heading-s app-c-time-select__heading"><%= t '.title_compact', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
     <% else %>
-      <h2 class="govuk-heading-l"><%= t '.title', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
+      <h2 class="govuk-heading-l app-c-time-select__heading"><%= t '.title', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
     <% end %>
     <%= render "govuk_publishing_components/components/details", {
       title: t('.change_dropdown')
     } do %>
-
         <%= render "govuk_publishing_components/components/radio", {
           name: "date_range",
           items: dates


### PR DESCRIPTION
# What
Reduce space after heading on time select
https://trello.com/c/knEyUjiU/1027-1-decrease-the-gap-between-the-heading-and-the-link-in-the-date-range-picker

# Why
Meet design requirements

# Screenshots

## Before
![screen shot 2019-01-15 at 13 31 57](https://user-images.githubusercontent.com/31649453/51183793-3e592200-18ca-11e9-9ebc-9f860e3f030d.png)

## After
![screen shot 2019-01-15 at 13 32 06](https://user-images.githubusercontent.com/31649453/51183801-42853f80-18ca-11e9-990b-93a21fccb138.png)

