### PR TITLE
Restrict /dev route to development and integration environments

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,10 @@ Rails.application.routes.draw do
     GovukError.notify('Sentry works')
     [200, {}, ["Sentry notified"]]
   }
-  get '/dev' => 'development#index'
+
+  if Rails.env.development? || Rails.application.config.govuk_environment == 'integration'
+    get '/dev' => 'development#index'
+  end
 
   get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics
   get '/content', to: 'content#index'


### PR DESCRIPTION
# What
Our frontend dev uses `/dev` for testing and development of components and styles as part of their development workflow but this route is live on production. This change sets it to 404 on any other environment but development and integration.

# Why
Users shouldn't be seeing this page.

---
# Review Checklist
* [ ] Changes in scope.
