### PR TITLE
Reduce font size of headers on index page

### DIFF
--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -7,6 +7,12 @@
 .app-c-time-select--compact {
   border-top: 0;
   @include govuk-font(16);
+
+  @include govuk-responsive-padding(2, "top");
+
+  .app-c-time-select__heading {
+    @include govuk-font($size: 16, $weight: bold);
+  }
 }
 
 .govuk-details__summary {

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -7,7 +7,7 @@
   }
 
   .table-header {
-    @include govuk-font(19);
+    @include govuk-font(16);
     @include media(mobile) {
       @include govuk-responsive-padding(3, "left");
     }
@@ -18,11 +18,13 @@
   }
 
   .table-header__param {
-    @include govuk-font($size: 19, $weight: bold);
+    @include govuk-font($size: 16, $weight: bold);
   }
 
   .govuk-table {
     background-color: $white;
+    // re-align text content of left and right columns
+    margin-top: -1px;
   }
 
   .govuk-table__header {


### PR DESCRIPTION
# What
Resize headings
https://trello.com/c/qHoeN2OC/1028-1-make-all-headings-in-the-filter-column-and-the-sentence-summary-font-size-16px
PR also adjusts spacing so the text in the left and right columns align properly.

# Why
Match designs, fit more on screen

# Screenshots

## Before
![screen shot 2019-01-16 at 10 53 12](https://user-images.githubusercontent.com/31649453/51244459-14ad0300-197d-11e9-8fad-1d40cbe545c4.png)

## After
![screen shot 2019-01-16 at 10 53 26](https://user-images.githubusercontent.com/31649453/51244478-1d053e00-197d-11e9-9cc8-7904ecb8f398.png)

