### PR TITLE
Make filter headings bold and reduce font size on table

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -28,7 +28,7 @@
   }
 
   .govuk-table__header {
-    @include govuk-font(16);
+    @include govuk-font(14);
     outline: 1px solid $govuk-border-colour;
   }
 
@@ -37,7 +37,12 @@
   }
 
   .govuk-table__cell {
-    @include govuk-font(16);
+    @include govuk-font(14);
+    @include govuk-responsive-padding(2);
+  }
+
+  .govuk-table__cell--numeric {
+    @include govuk-font($size: 14, $tabular: true);
     @include govuk-responsive-padding(2);
   }
 
@@ -57,10 +62,6 @@
     font-weight: normal;
   }
 
-  .govuk-table__cell {
-    @include govuk-responsive-padding(2);
-  }
-
   .govuk-table__cell:last-child {
     @include govuk-responsive-padding(2);
   }
@@ -72,9 +73,6 @@
 
   .filter-form {
     @include govuk-responsive-padding(3, "left");
-    .govuk-label--s {
-      @include govuk-font(16);
-    }
 
     .govuk-radios__hint {
       @include govuk-font(16);
@@ -90,7 +88,7 @@
     @include govuk-responsive-padding(3, "top");
 
     .govuk-label {
-      @include govuk-font(16);
+      @include govuk-font($size: 16, $weight: bold);
     }
 
     .govuk-select {


### PR DESCRIPTION
# What
Resize fonts, make headings bold, make table cells with numbers use the correct font
https://trello.com/c/0wrQu0gW/1030-1-font-sizes-for-the-index-table-contents-and-column-headers-to-14px
https://trello.com/c/qHoeN2OC/1028-1-make-all-headings-in-the-filter-column-and-the-sentence-summary-font-size-16px-make-filter-names-bold
https://trello.com/c/CP2ty8Ap/1052-1-make-sure-that-the-cells-in-the-index-page-table-that-contain-numbers-are-using-the-nta-tabular-numbers-font
# Why
Match design, fit more onto screen

# Screenshots

## Before
![screen shot 2019-01-17 at 09 16 27](https://user-images.githubusercontent.com/31649453/51307994-ff95aa00-1a38-11e9-9af3-163ccf390b3a.png)

## After
![screen shot 2019-01-17 at 09 16 13](https://user-images.githubusercontent.com/31649453/51308004-06bcb800-1a39-11e9-923f-bf48ae9223f0.png)
