### PR TITLE
Use new endpoints for document types organisations

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -86,10 +86,10 @@ private
     return 'All organisations' if organisation_id == ALL_ORGANISATIONS
 
     organisation_data = @organisations.find do |org|
-      org[:organisation_id] == organisation_id
+      org[:id] == organisation_id
     end
 
-    organisation_data[:title]
+    organisation_data[:name]
   end
 
   def url(base_path)

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -33,9 +33,9 @@ class FilterPresenter
              }]
     @document_types.each do |document_type|
       types.push(
-        text: document_type.humanize,
-        value: document_type,
-        selected: document_type == @search_parameters[:document_type]
+        text: document_type[:name].humanize,
+        value: document_type[:id],
+        selected: document_type[:id] == @search_parameters[:document_type]
       )
     end
     types

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -45,9 +45,9 @@ class FilterPresenter
     additional_organisation_options +
       @organisations.map do |org|
         {
-          text: org[:title],
-          value: org[:organisation_id],
-          selected: org[:organisation_id] == @search_parameters[:organisation_id]
+          text: org[:name],
+          value: org[:id],
+          selected: org[:id] == @search_parameters[:organisation_id]
         }
       end
   end

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -68,7 +68,7 @@ private
   end
 
   def organisations_url
-    "#{content_data_api_endpoint}/organisations"
+    "#{content_data_api_endpoint}/api/v1/organisations"
   end
 
   def document_types_url

--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -72,6 +72,6 @@ private
   end
 
   def document_types_url
-    "#{content_data_api_endpoint}/document_types"
+    "#{content_data_api_endpoint}/api/v1/document_types"
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -159,14 +159,14 @@ module GdsApi
         day3 = to
         {
           metadata: {
-            title:  "Content Title",
-            base_path:  "/#{base_path}",
+            title: "Content Title",
+            base_path: "/#{base_path}",
             content_id: 'content-id',
-            first_published_at:  "2018-07-17T10:35:59.000Z",
-            public_updated_at:  "2018-07-17T10:35:57.000Z",
-            publishing_app:  publishing_app,
-            document_type:  "news_story",
-            primary_organisation_title:  "The Ministry",
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: publishing_app,
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
             historical: false,
             withdrawn: false,
             parent_content_id: ''
@@ -251,13 +251,13 @@ module GdsApi
         day3 = to
         {
           metadata: {
-            title:  "Content Title",
-            base_path:  "/#{base_path}",
-            first_published_at:  "2018-07-17T10:35:59.000Z",
-            public_updated_at:  "2018-07-17T10:35:57.000Z",
-            publishing_app:  "publisher",
-            document_type:  "news_story",
-            primary_organisation_title:  "The Ministry",
+            title: "Content Title",
+            base_path: "/#{base_path}",
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: "publisher",
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
             historical: false,
             withdrawn: false
           },
@@ -338,13 +338,13 @@ module GdsApi
       def no_data_single_page_payload(base_path, from, to)
         {
           metadata: {
-            title:  "Content Title",
-            base_path:  "/#{base_path}",
-            first_published_at:  "2018-07-17T10:35:59.000Z",
-            public_updated_at:  "2018-07-17T10:35:57.000Z",
-            publishing_app:  "publisher",
-            document_type:  "news_story",
-            primary_organisation_title:  "The Ministry",
+            title: "Content Title",
+            base_path: "/#{base_path}",
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: "publisher",
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
             historical: false,
             withdrawn: false
           },
@@ -368,13 +368,13 @@ module GdsApi
       def nil_values_in_single_page_payload(base_path, from, to)
         {
           metadata: {
-            title:  "Content Title",
-            base_path:  "/#{base_path}",
-            first_published_at:  "2018-07-17T10:35:59.000Z",
-            public_updated_at:  "2018-07-17T10:35:57.000Z",
-            publishing_app:  "publisher",
-            document_type:  "news_story",
-            primary_organisation_title:  "The Ministry",
+            title: "Content Title",
+            base_path: "/#{base_path}",
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: "publisher",
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
             historical: false,
             withdrawn: false
           },

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -129,7 +129,7 @@ module GdsApi
       end
 
       def content_data_api_has_document_types
-        url = "#{content_data_api_endpoint}/document_types"
+        url = "#{content_data_api_endpoint}/api/v1/document_types"
         body = { document_types: default_document_types }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
@@ -413,7 +413,24 @@ module GdsApi
       end
 
       def default_document_types
-        %w[case_study guide news_story html_publication]
+        [
+          {
+            id: 'case_study',
+            name: 'Case study'
+          },
+          {
+            id: 'guide',
+            name: 'Guide'
+          },
+          {
+            id: 'news_story',
+            name: 'News story'
+          },
+          {
+            id: 'html_publication',
+            name: 'HTML publication'
+          }
+        ]
       end
     end
   end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -123,7 +123,7 @@ module GdsApi
       end
 
       def content_data_api_has_orgs
-        url = "#{content_data_api_endpoint}/organisations"
+        url = "#{content_data_api_endpoint}/api/v1/organisations"
         body = { organisations: default_organisations }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
@@ -398,16 +398,16 @@ module GdsApi
       def default_organisations
         [
           {
-            title: 'org',
-            organisation_id: 'org-id'
+            name: 'org',
+            id: 'org-id'
           },
           {
-            title: 'another org',
-            organisation_id: 'another-org-id'
+            name: 'another org',
+            id: 'another-org-id'
           },
           {
-            title: 'Users Org',
-            organisation_id: 'users-org-id'
+            name: 'Users Org',
+            id: 'users-org-id'
           }
         ]
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/UON8CWKJ/1057-1-tidy-up-endpoints-to-list-organisations-and-document-types)

We will no longerrely on the endpoints: `/organisations` and `/content_types`. We will start using `/api/v1/document_types` and `/api/v1/organisations`.
