### PR TITLE
Clarify feedback comments short title

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -70,7 +70,7 @@ en:
         introduced in February 2018 so there are no responses before this date.
     feedex:
       title: 'Number of feedback comments'
-      short_title: 'Feedback comments'
+      short_title: 'Number of feedback comments'
       summary: 'Number of anonymous user responses to ''Is there anything wrong with this page?'''
       context: ''
       unit: 'comments'


### PR DESCRIPTION
# What
Change the feedback comments short title to 'Number of feedback comments'.

#Why
User research shows that users expect 'About feedback comments' to contain the feedback comments. The change will help clarify that this is information about the metric rather than the comments.

I've checked the other places this is used (index page, at a glance metrics) and we have space for the longer title.
