### PR TITLE
Fix number of pdfs copy

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -97,8 +97,7 @@ class SingleContentItemPresenter
   end
 
   def metric_about_label(metric_name)
-    short_title = metric_short_title(metric_name).downcase
-    I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
+    I18n.t("metrics.#{metric_name}.about_title")
   end
 
   def trend_percentage(metric_name)

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -110,11 +110,10 @@ en:
       unit: ''
       data_source: none
       external_link: ''
-      about_title: 'About number of pdfs'
+      about_title: 'About number of PDFs'
       about: >
         Compared with HTML content, information published in a PDF is harder to find, use and 
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
         Several PDFs on one page may indicate that too many users needs are being met by them.
         <a href="https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/">Read more about why to avoid PDFs</a>.
-
 

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -14,6 +14,7 @@ en:
       unit: ''
       data_source: google_analytics
       external_link: ''
+      about_title: 'About unique pageviews'
       about: >
         This represents the number of visits in which the page was viewed at least once.
         For example, if a user visits the same page 5 times during their browsing session,
@@ -26,6 +27,7 @@ en:
       unit: ''
       data_source: google_analytics
       external_link: ''
+      about_title: 'About pageviews'
       about: >
         This is a count of every time the page was viewed. For example, if someone visits page X,
         then goes to page Y and then back to page X again, page X will have 2 pageviews (and
@@ -38,6 +40,7 @@ en:
       unit: ''
       data_source: calculated_google_analytics
       external_link: ''
+      about_title: 'About pageviews per visit'
       about: >
         This figure is calculated by dividing Google Analytics pageviews by unique pageviews. It
         shows on average how many times a page was viewed during a user's session. If a page has a
@@ -51,6 +54,7 @@ en:
       unit: 'search terms'
       data_source: google_analytics
       external_link: ''
+      about_title: 'About searches from the page'
       about: >
         This is the number of internal site searches that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.
@@ -63,6 +67,7 @@ en:
       short_context: '%{total_responses} responses'
       data_source: calculated_google_analytics
       external_link: ''
+      about_title: 'About satisfaction score'
       about: >
         Percentage of users who answered 'Yes' rather than 'No' to the 'Is this page useful?' survey.
         The more users who responded, the more reliable the score is. For a more reliable score
@@ -76,6 +81,7 @@ en:
       unit: 'comments'
       data_source: feedback_explorer
       external_link: 'See comments in Feedback Explorer'
+      about_title: 'About feedback comments'
       about: >
         You can use Feedback Explorer ('Feedex') to find out what users are saying about your
         content. A high rate of feedback could indicate a problem with the content. The data comes
@@ -91,6 +97,7 @@ en:
       unit: ''
       data_source: none
       external_link: ''
+      about_title: 'About word count'
       about: >
         Lots of words on a page can make content difficult for users to read online. The longer the
         page is, the less usable it is likely to be. You could investigate whether this content could
@@ -103,9 +110,11 @@ en:
       unit: ''
       data_source: none
       external_link: ''
+      about_title: 'About number of pdfs'
       about: >
         Compared with HTML content, information published in a PDF is harder to find, use and 
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
         Several PDFs on one page may indicate that too many users needs are being met by them.
         <a href="https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/">Read more about why to avoid PDFs</a>.
+
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for pdf count' do
-        label = 'About number of pdfs'
+        label = 'About number of PDFs'
         expect(page).to have_selector(".metric-summary__pdf-count .govuk-details__summary-text", text: label)
       end
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for upviews' do
-        label = expected_metric_label('upviews')
+        label = 'About unique pageviews'
         expect(page).to have_selector(".metric-summary__upviews .govuk-details__summary-text", text: label)
         expect(page).to have_selector '.metric-summary__upviews', text: '6,000'
       end
@@ -119,7 +119,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for pviews' do
-        label = expected_metric_label('pviews')
+        label = 'About pageviews'
         expect(page).to have_selector(".metric-summary__pviews .govuk-details__summary-text", text: label)
       end
 
@@ -128,7 +128,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for satisfaction' do
-        label = expected_metric_label('satisfaction')
+        label = 'About satisfaction score'
         expect(page).to have_selector(".metric-summary__satisfaction .govuk-details__summary-text", text: label)
       end
 
@@ -141,7 +141,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for feedex' do
-        label = expected_metric_label('feedex')
+        label = 'About feedback comments'
         expect(page).to have_selector(".metric-summary__feedex .govuk-details__summary-text", text: label)
       end
 
@@ -154,7 +154,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for pdf count' do
-        label = expected_metric_label('pdf_count')
+        label = 'About number of pdfs'
         expect(page).to have_selector(".metric-summary__pdf-count .govuk-details__summary-text", text: label)
       end
 
@@ -163,7 +163,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for  words count' do
-        label = expected_metric_label('words')
+        label = 'About word count'
         expect(page).to have_selector(".metric-summary__words .govuk-details__summary-text", text: label)
       end
 
@@ -294,9 +294,4 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
     end
   end
-end
-
-def expected_metric_label(metric_name)
-  short_title = I18n.t("metrics.#{metric_name}.short_title").downcase
-  I18n.t("components.info-metric.about_dropdown", metric_short_title: short_title)
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/sVHzYTTF/1058-1-capitalise-pdfs-in-about-number-of-pdfs-link)

### What
The link should say 'About number of PDFs' for consistency with the 'Number of PDFs' heading.

### Why

It looks like there is code to make the whole of a metric's short title lower case when it follows 'About' (Polly can't change it in the YAML file). It's only the first letter that needs to be lower case ie 'About number of PDFs' rather than 'About number of pdfs'.

## Before

![image](https://user-images.githubusercontent.com/227328/51382125-ddba2700-1b0d-11e9-8340-ffda0a7eb54a.png)


## After

![image](https://user-images.githubusercontent.com/227328/51382102-caa75700-1b0d-11e9-87fa-5bf1119c6606.png)
