### PR TITLE
Add Acronym to the organisation name

### DIFF
--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -42,14 +42,18 @@ class FilterPresenter
   end
 
   def organisation_options
-    additional_organisation_options +
-      @organisations.map do |org|
-        {
-          text: org[:name],
-          value: org[:id],
-          selected: org[:id] == @search_parameters[:organisation_id]
-        }
-      end
+    @organisation_options ||= begin
+      additional_organisation_options +
+        @organisations.map do |org|
+          name = org[:name]
+          name.concat " (#{org[:acronym]})" if org[:acronym].present?
+          {
+            text: name,
+            value: org[:id],
+            selected: org[:id] == @search_parameters[:organisation_id]
+          }
+        end
+    end
   end
 
 private

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -237,7 +237,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result in News story from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result in News story from org (OI)')
     end
 
     it 'allows the filter to be cleared' do
@@ -246,7 +246,7 @@ RSpec.describe '/content' do
       expect(page).to have_select('document_type', selected: 'All document types')
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from org (OI)')
     end
   end
 
@@ -257,7 +257,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows a no data message in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: "#{I18n.t 'no_matching_results'} from org")
+      expect(page).to have_css('h1.table-header', exact_text: "#{I18n.t 'no_matching_results'} from org (OI)")
     end
   end
 
@@ -268,7 +268,7 @@ RSpec.describe '/content' do
     end
 
     it 'formats the page numbers correctly in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 19,901 to 20,000 of 30,000 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 19,901 to 20,000 of 30,000 results from org (OI)')
     end
   end
 

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe "Results pagination" do
     end
 
     it 'shows the second page of data' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 102 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 102 results from org (OI)')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -108,7 +108,7 @@ RSpec.describe "Results pagination" do
           ['forth title /path/4', 'News story', '100,018', '68% (42 responses)', '12'],
         ]
       )
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 101 to 102 of 102 results from org')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 101 to 102 of 102 results from org (OI)')
     end
 
     it 'has GTM data attributes' do

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -50,9 +50,9 @@ RSpec.describe FilterPresenter do
         expect(subject.organisation_options).to eq([
           { text: 'All organisations', value: 'all', selected: false },
           { text: 'No primary organisation', value: 'none', selected: false },
-          { text: 'org', value: 'org-id', selected: true },
+          { text: 'org (OI)', value: 'org-id', selected: true },
           { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org', value: 'users-org-id', selected: false }
+          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
         ])
       end
     end
@@ -64,9 +64,9 @@ RSpec.describe FilterPresenter do
         expect(subject.organisation_options).to eq([
           { text: 'All organisations', value: 'all', selected: true },
           { text: 'No primary organisation', value: 'none', selected: false },
-          { text: 'org', value: 'org-id', selected: false },
+          { text: 'org (OI)', value: 'org-id', selected: false },
           { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org', value: 'users-org-id', selected: false }
+          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
         ])
       end
     end
@@ -78,9 +78,9 @@ RSpec.describe FilterPresenter do
         expect(subject.organisation_options).to eq([
           { text: 'All organisations', value: 'all', selected: false },
           { text: 'No primary organisation', value: 'none', selected: true },
-          { text: 'org', value: 'org-id', selected: false },
+          { text: 'org (OI)', value: 'org-id', selected: false },
           { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org', value: 'users-org-id', selected: false }
+          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
         ])
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe FilterPresenter do
 
   describe '#organisation_name' do
     it 'returns the selected organisation name' do
-      expect(subject.organisation_name).to eq('org')
+      expect(subject.organisation_name).to eq('org (OI)')
     end
   end
 end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -399,15 +399,17 @@ module GdsApi
         [
           {
             name: 'org',
-            id: 'org-id'
+            id: 'org-id',
+            acronym: 'OI',
           },
           {
             name: 'another org',
-            id: 'another-org-id'
+            id: 'another-org-id',
           },
           {
             name: 'Users Org',
-            id: 'users-org-id'
+            id: 'users-org-id',
+            acronym: 'UOI',
           }
         ]
       end


### PR DESCRIPTION
[Trello card](https://trello.com/c/gAuhVJEp/1039-3-populate-organisation-filter-with-department-acronyms)

###What
Find the canonical list of all organisations' acronyms and populate them in the organisation filter.

###Why
So that we're able to support acronyms in the organisation filter

See evidence in https://trello.com/c/0rXbPvce

## Before
![image](https://user-images.githubusercontent.com/227328/51528667-1b30f400-1e2f-11e9-8a2d-4a3eae1686c5.png)

## After

![image](https://user-images.githubusercontent.com/227328/51528905-8a0e4d00-1e2f-11e9-81ab-128a851a0a76.png)

