### PR TITLE
Implement accessibile autocomplete component for dropdowns

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,3 +1,4 @@
 //= require govuk_publishing_components/all_components
+//= require govuk_publishing_components/dependencies
 //= require_tree ./components
 //= require_tree ./core

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -74,6 +74,10 @@
   .filter-form {
     @include govuk-responsive-padding(3, "left");
 
+    .govuk-label--s {
+      @include govuk-font($size: 16, $weight: bold);
+    }
+
     .govuk-radios__hint {
       @include govuk-font(16);
     }

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -18,27 +18,58 @@ class FilterPresenter
   end
 
   def document_type
-    find_document_type[:text]
+    find_selected_document_type || ['', '']
+  end
+
+  def document_type_id
+    find_selected_document_type[1]
+  end
+
+  def document_type_name
+    document_type[0]
+  end
+
+  def selected_document_type(params)
+    if params[:submitted].blank?
+      ['', '']
+    else
+      document_type
+    end
+  end
+
+  def organisation
+    find_selected_org || ['', 'all']
   end
 
   def organisation_name
-    find_selected_org[:text]
+    org_name = find_selected_org[0]
+    if org_name == ""
+      "All organisations"
+    else
+      org_name
+    end
+  end
+
+  def organisation_id
+    find_selected_org
+  end
+
+  def selected_organisation(params)
+    if params[:submitted].blank?
+      ['', '']
+    else
+      organisation
+    end
   end
 
   def document_type_options
-    types = [{
-               text: 'All document types',
-               value: '',
-               selected: @search_parameters[:document_type] == ''
-             }]
-    @document_types.each do |document_type|
-      types.push(
-        text: document_type[:name].humanize,
-        value: document_type[:id],
-        selected: document_type[:id] == @search_parameters[:document_type]
-      )
+    @document_type_options ||= begin
+      types = [['', 'all'], ['All document types', 'all']]
+      @document_types.each do |document_type|
+        types.push([document_type[:name], document_type[:id]])
+      end
+      types
     end
-    types
   end
 
   def organisation_options
@@ -47,11 +78,7 @@ class FilterPresenter
         @organisations.map do |org|
           name = org[:name]
           name.concat " (#{org[:acronym]})" if org[:acronym].present?
-          {
-            text: name,
-            value: org[:id],
-            selected: org[:id] == @search_parameters[:organisation_id]
-          }
+          [name, org[:id]]
         end
     end
   end
@@ -59,17 +86,18 @@ class FilterPresenter
 private
 
   def find_selected_org
-    organisation_options.find { |o| o[:selected] }
+    organisation_options.find { |o| o[1] == @search_parameters[:organisation_id] } || ['All organisations', 'all']
   end
 
-  def find_document_type
-    document_type_options.find { |d| d[:selected] }
+  def find_selected_document_type
+    document_type_options.find { |d| d[1] == @search_parameters[:document_type] } || ['All document types', 'all']
   end
 
   def additional_organisation_options
     [
-      { text: 'All organisations', value: 'all', selected: @search_parameters[:organisation_id] == 'all' },
-      { text: 'No primary organisation', value: 'none', selected: @search_parameters[:organisation_id] == 'none' }
+      ['', 'all'],
+      ['All organisations', 'all'],
+      ['No primary organisation', 'none']
     ]
   end
 end

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -18,6 +18,9 @@ class FindContent
   end
 
   def call
+    if @document_type == "all"
+      @document_type = ""
+    end
     api.content(date_range: @date_range, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
   end
 

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -14,8 +14,8 @@
     <% if filter.search_terms? %>
         for "<span class="table-header__param"><%= filter.search_terms %></span>"
     <% end %>
-    <% if filter.document_type? %>
-        in <span class="table-header__param"><%= filter.document_type %></span>
+    <% if filter.document_type? && filter.document_type_id != "all" %>
+        in <span class="table-header__param"><%= filter.document_type_name %></span>
     <% end %>
     from <span class="table-header__param"><%= filter.organisation_name %></span>
 </h1>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -11,8 +11,10 @@
       </div>
 
 
+
       <div class="filter-form">
         <%= form_tag content_path, method: 'get', name: 'organisation-picker', id: 'filter-form' do %>
+          <input type="hidden" name="submitted" value="true" >
           <%= render "components/time-select", {
             current_selection: @presenter.time_period,
             compact: true,
@@ -57,16 +59,28 @@
                 tabindex: 0,
                 value: params[:search_term],
               } %>
-              <%= render "govuk_publishing_components/components/select", {
-              id: "document_type",
-              label: "Document type",
-              options: @presenter.filter.document_type_options
-            } %>
-            <%= render "govuk_publishing_components/components/select", {
-              id: "organisation_id",
-              label: "Organisation",
-              options: @presenter.filter.organisation_options
-            } %>
+
+          <%= render "govuk_publishing_components/components/accessible_autocomplete",
+              {
+                id: 'document_type',
+                label: {
+                  text: "Document type"
+                },
+                options: @presenter.filter.document_type_options,
+                selected_option: @presenter.filter.selected_document_type(params)
+              }
+          %>
+
+          <%= render "govuk_publishing_components/components/accessible_autocomplete",
+              {
+                id: 'organisation_id',
+                label: {
+                  text: "Organisation"
+                },
+                options: @presenter.filter.organisation_options.unshift(['','all']),
+                selected_option: @presenter.filter.selected_organisation(params)
+              }
+          %>
 
             <%= render "govuk_publishing_components/components/button", {text: "Filter"} %>
           <% end %>

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -1,6 +1,50 @@
 <%# see the controller for the settings to implement full-width mode %>
 <%= content_for :title, "Dev page" %>
 
+
+<%= render "govuk_publishing_components/components/accessible_autocomplete", {
+  label: {
+    text: "Countries"
+  },
+  options: [
+    [
+      "",
+      ""
+    ],
+    [
+      "France",
+      "fr"
+    ],
+    [
+      "Germany",
+      "de"
+    ],
+    [
+      "Sweden",
+      "se"
+    ],
+    [
+      "Switzerland",
+      "ch"
+    ],
+    [
+      "United Kingdom",
+      "gb"
+    ],
+    [
+      "United States",
+      "us"
+    ],
+    [
+      "The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)",
+      "tw"
+    ]
+  ],
+  selected_option: ""
+} %>
+
+
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
       <div class="filters-control__wrapper govuk-visually-hidden" data-module="filter-toggle">

--- a/spec/features/index_page/index_filter_by_title_spec.rb
+++ b/spec/features/index_page/index_filter_by_title_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe '/content' do
     content_data_api_has_orgs
     content_data_api_has_document_types
 
-    visit '/content?date_range=last-month&organisation_id=org-id'
+    visit '/content?submitted=true&date_range=last-month&organisation_id=org-id'
   end
 
   describe 'Filter by title / url' do

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe '/content' do
     content_data_api_has_orgs
     content_data_api_has_document_types
 
-    visit "/content?date_range=last-month&organisation_id=org-id"
+    visit "/content?submitted=true&date_range=last-month&organisation_id=org-id"
   end
 
   it 'renders the page without error' do
@@ -243,7 +243,7 @@ RSpec.describe '/content' do
     it 'allows the filter to be cleared' do
       select 'All document types', from: 'document_type'
       click_on 'Filter'
-      expect(page).to have_select('document_type', selected: 'All document types')
+      expect(page).to have_select('document_type', selected: ["", "All document types"])
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
       expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from org (OI)')

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -18,71 +18,28 @@ RSpec.describe FilterPresenter do
   end
 
   describe '#document_type_options' do
-    context 'when valid document type in parameter' do
-      it 'formats the document types for the options component' do
-        expect(subject.document_type_options).to eq([
-          { text: 'All document types', value: '', selected: false },
-          { text: 'Case study', value: 'case_study', selected: false },
-          { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: true },
-          { text: 'HTML publication', value: 'html_publication', selected: false }
-        ])
-      end
-    end
-
-    context 'when no document type in parameter' do
-      before { search_parameters[:document_type] = '' }
-      it 'formats the document types for the options component' do
-        expect(subject.document_type_options).to eq([
-          { text: 'All document types', value: '', selected: true },
-          { text: 'Case study', value: 'case_study', selected: false },
-          { text: 'Guide', value: 'guide', selected: false },
-          { text: 'News story', value: 'news_story', selected: false },
-          { text: 'HTML publication', value: 'html_publication', selected: false }
-        ])
-      end
+    it 'formats the document types for the options component' do
+      expect(subject.document_type_options).to eq([
+        ["", "all"],
+        ["All document types", "all"],
+        ["Case study", "case_study"],
+        %w(Guide guide),
+        ["News story", "news_story"],
+        ["HTML publication", "html_publication"]
+      ])
     end
   end
 
   describe '#organisation_options' do
-    context 'when valid organisation id in parameter' do
-      it 'formats the organisations for the options component' do
-        expect(subject.organisation_options).to eq([
-          { text: 'All organisations', value: 'all', selected: false },
-          { text: 'No primary organisation', value: 'none', selected: false },
-          { text: 'org (OI)', value: 'org-id', selected: true },
-          { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
-        ])
-      end
-    end
-
-    context 'when organisation_id is `all` in parameter' do
-      before { search_parameters[:organisation_id] = 'all' }
-
-      it 'formats the organisations for the options component' do
-        expect(subject.organisation_options).to eq([
-          { text: 'All organisations', value: 'all', selected: true },
-          { text: 'No primary organisation', value: 'none', selected: false },
-          { text: 'org (OI)', value: 'org-id', selected: false },
-          { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
-        ])
-      end
-    end
-
-    context 'when organisation_id is `none` in parameter' do
-      before { search_parameters[:organisation_id] = 'none' }
-
-      it 'formats the organisations for the options component' do
-        expect(subject.organisation_options).to eq([
-          { text: 'All organisations', value: 'all', selected: false },
-          { text: 'No primary organisation', value: 'none', selected: true },
-          { text: 'org (OI)', value: 'org-id', selected: false },
-          { text: 'another org', value: 'another-org-id', selected: false },
-          { text: 'Users Org (UOI)', value: 'users-org-id', selected: false }
-        ])
-      end
+    it 'formats the organisations for the options component' do
+      expect(subject.organisation_options).to eq([
+        ["", "all"],
+        ["All organisations", "all"],
+        ["No primary organisation", "none"],
+        ["org (OI)", "org-id"],
+        ["another org", "another-org-id"],
+        ["Users Org (UOI)", "users-org-id"]
+      ])
     end
   end
 
@@ -101,9 +58,9 @@ RSpec.describe FilterPresenter do
     end
   end
 
-  describe '#document_type' do
+  describe '#document_type_name' do
     it 'returns the formatted document type' do
-      expect(subject.document_type).to eq("News story")
+      expect(subject.document_type_name).to eq("News story")
     end
   end
 


### PR DESCRIPTION
# What
https://trello.com/c/vbIFFSjh/1038-3-implement-basic-accessible-autocomplete-and-check-for-ie11-issues
This PR implements the accessible autocomplete component.
As agreed with Jeremy and Mark, when a user first sees the page (or when they clear their filters) we insert a blank option at the start so that the dropdown works as a dropdown, revealing the full content list. On submission we detect a hidden parameter the form sends and then auto-select their choice, or default to the "All document types" or "All organisations" option. This is because a selected item looks like a dropdown with just one option in it and a user who hasn't seen the full list may not consider deleting the content. 

This means that we are having to catch "all" as a document type where we didn't previously.

# Why
The autocomplete will allow users to find their organisation or document type more easily by typing if they know its name or abbreviation.

# Screenshots

## Before
![screen shot 2019-01-23 at 15 50 28](https://user-images.githubusercontent.com/31649453/51618736-b658c500-1f26-11e9-84b9-2233f2939fdf.png)

## After
![screen shot 2019-01-23 at 15 49 50](https://user-images.githubusercontent.com/31649453/51618754-bf499680-1f26-11e9-96bb-a5668df8bc0e.png)
