### PR TITLE
Add link to search terms

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -47,9 +47,9 @@ module ExternalLinksHelper
   end
 
   def google_analytics_url(from:, to:, base_path:)
-    from.delete!('-')
-    to.delete!('-')
-    base_path.gsub!(%r((\/)(?!\z)), '~2F')
+    from = from.delete('-')
+    to = to.delete('-')
+    base_path = base_path.gsub(%r((\/)(?!\z)), '~2F')
     "https://analytics.google.com/analytics/web/?hl=en&pli=1"\
     "#/report/content-site-search-pages/a26179049w50705554p53872948/"\
     "_u.date00=#{to}&_u.date01=#{from}&"\

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -46,6 +46,13 @@ module ExternalLinksHelper
     "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
   end
 
+  def google_analytics_url(from:, to:, base_path:)
+    from.delete!('-')
+    to.delete!('-')
+    base_path.gsub!(%r((\/)(?!\z)), '~2F')
+    "https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=#{to}&_u.date01=#{from}&_r.drilldown=analytics.searchStartPage:#{base_path}"
+  end
+
   def external_url_for(service)
     Plek.new.external_url_for(service)
   end

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -50,7 +50,10 @@ module ExternalLinksHelper
     from.delete!('-')
     to.delete!('-')
     base_path.gsub!(%r((\/)(?!\z)), '~2F')
-    "https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=#{to}&_u.date01=#{from}&_r.drilldown=analytics.searchStartPage:#{base_path}"
+    "https://analytics.google.com/analytics/web/?hl=en&pli=1"\
+    "#/report/content-site-search-pages/a26179049w50705554p53872948/"\
+    "_u.date00=#{to}&_u.date01=#{from}&"\
+    "_r.drilldown=analytics.searchStartPage:#{base_path}"
   end
 
   def external_url_for(service)

--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -40,6 +40,12 @@ module ExternalLinksHelper
     end
   end
 
+  def feedex_url(from:, to:, base_path:)
+    host = Plek.new.external_url_for('support')
+    path = CGI.escape(base_path)
+    "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
+  end
+
   def external_url_for(service)
     Plek.new.external_url_for(service)
   end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -77,11 +77,7 @@ class SingleContentItemPresenter
   end
 
   def feedback_explorer_href
-    host = Plek.new.external_url_for('support')
-    from = @date_range.from
-    to = @date_range.to
-    path = CGI.escape(base_path)
-    "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
+    feedex_url(from: date_range.from, to: date_range.to, base_path: base_path)
   end
 
   def period

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -80,6 +80,10 @@ class SingleContentItemPresenter
     feedex_url(from: date_range.from, to: date_range.to, base_path: base_path)
   end
 
+  def search_terms_href
+    google_analytics_url(from: date_range.from, to: date_range.to, base_path: base_path)
+  end
+
   def period
     I18n.t("metrics.show.time_periods.#{@date_range.time_period}.reference")
   end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -139,7 +139,7 @@
         metric_name: 'searches',
         total: @performance_data.total_searches,
         short_context: nil,
-        external_link: nil %>
+        external_link: @performance_data.search_terms_href %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -53,7 +53,7 @@ en:
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       data_source: google_analytics
-      external_link: ''
+      external_link: 'See search terms in Google Analytics'
       about_title: 'About searches from the page'
       about: >
         This is the number of internal site searches that were started from the page. When people

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -203,6 +203,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
         ])
       end
 
+      it 'renders link to search terms' do
+        expect(page).to have_selector('.govuk-link', text: I18n.t("metrics.searches.external_link"))
+      end
+
       it 'renders the metric timeseries for satisfaction' do
         satisfaction_rows = extract_table_content(".chart.satisfaction table")
         expect(satisfaction_rows).to match_array([

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -142,4 +142,17 @@ RSpec.describe ExternalLinksHelper do
       end
     end
   end
+
+  describe '#feedex_url' do
+    it 'generates URL to feedex with given parameters' do
+      host = Plek.new.external_url_for('support')
+      expected_link = "#{host}/anonymous_feedback?from=2018-11-25&to=2018-12-24&paths=%2Fthe%2Fbase%2Fpath"
+
+      expect(feedex_url(
+               from: '2018-11-25',
+               to: '2018-12-24',
+               base_path: '/the/base/path'
+      )).to eq(expected_link)
+    end
+  end
 end

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -155,4 +155,16 @@ RSpec.describe ExternalLinksHelper do
       )).to eq(expected_link)
     end
   end
+
+  describe '#google_analytics_url' do
+    it 'generates URL to Google Analytics with given parameters' do
+      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181224&_u.date01=20181125&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
+
+      expect(google_analytics_url(
+               from: '2018-11-25',
+               to: '2018-12-24',
+               base_path: '/the/base/path'
+      )).to eq(expected_link)
+    end
+  end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -212,6 +212,14 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
+  describe '#google_analytics_href' do
+    it 'returns a URI for Google Analytics' do
+      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181224&_u.date01=20181125&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
+
+      expect(subject.search_terms_href).to eq(expected_link)
+    end
+  end
+
   describe '#edit_url' do
     it 'uses the ExternalLinksHelper' do
       allow_any_instance_of(ExternalLinksHelper).to receive(


### PR DESCRIPTION
# What
Adds a link to Google Analytics. The report is which search terms were used when users made internal site searches from a page.

# Why
Knowing the search terms will help us to identify what information the users are expecting to find on a given page.

# Screenshots

## Before
<img width="345" alt="screenshot at jan 23 4-23-51 pm" src="https://user-images.githubusercontent.com/424772/51620937-5f092380-1f2b-11e9-9e01-e9b64c93a90a.png">


## After
<img width="358" alt="screenshot at jan 23 4-24-07 pm" src="https://user-images.githubusercontent.com/424772/51620949-68928b80-1f2b-11e9-863d-e755425d73c4.png">


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
