### PR TITLE
Reduce space at top of screens.

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -33,5 +33,8 @@ $govuk-global-styles: true;
   border: none;
 }
 
+.govuk-main-wrapper {
+  @include govuk-responsive-padding(2, "top");
+}
 //overrides must be imported last
 @import "govuk-frontend/overrides/all";


### PR DESCRIPTION
# What
Tighten up spacing
https://trello.com/c/OvTGt5uX/1087-1-adjust-the-padding-top-on-the-main-wrapper-to-10px

# Why
Meet designs

# Screenshots

## Before
![screen shot 2019-01-24 at 08 58 49](https://user-images.githubusercontent.com/31649453/51666736-66c1da00-1fb6-11e9-9d20-524770dc7b34.png)

## After
![screen shot 2019-01-24 at 08 59 12](https://user-images.githubusercontent.com/31649453/51666768-6a556100-1fb6-11e9-9d0d-91833518f919.png)
