### PR TITLE
Swap date params to GA report

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -52,7 +52,7 @@ module ExternalLinksHelper
     base_path = base_path.gsub(%r((\/)(?!\z)), '~2F')
     "https://analytics.google.com/analytics/web/?hl=en&pli=1"\
     "#/report/content-site-search-pages/a26179049w50705554p53872948/"\
-    "_u.date00=#{to}&_u.date01=#{from}&"\
+    "_u.date00=#{from}&_u.date01=#{to}&"\
     "_r.drilldown=analytics.searchStartPage:#{base_path}"
   end
 

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe ExternalLinksHelper do
 
   describe '#google_analytics_url' do
     it 'generates URL to Google Analytics with given parameters' do
-      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181224&_u.date01=20181125&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
+      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181125&_u.date01=20181224&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
 
       expect(google_analytics_url(
                from: '2018-11-25',

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#google_analytics_href' do
     it 'returns a URI for Google Analytics' do
-      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181224&_u.date01=20181125&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
+      expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181125&_u.date01=20181224&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
 
       expect(subject.search_terms_href).to eq(expected_link)
     end


### PR DESCRIPTION
We were sending the from and to values the wrong way round.

Fixes issue in https://github.com/alphagov/content-data-admin/pull/332

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
