### PR TITLE
Fix case on title tag for content page

### DIFF
--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -4,7 +4,7 @@ class ContentItemsPresenter
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
 
   def initialize(search_results, search_parameters, document_types, organisations)
-    @title = 'Content Items'
+    @title = 'Content items'
     @filter = FilterPresenter.new(search_parameters, document_types, organisations)
     @search_parameters = search_parameters
     @pagination = PaginationPresenter.new(


### PR DESCRIPTION
# What
https://trello.com/c/cx9UZewB/1064-1-bug-change-itemsto-lower-case-in-the-browser-title-tag
Change "Content Items" to "Content items" in page title.

# Why
Meet style guide
