### PR TITLE
Add formatting to prev/next page links

### DIFF
--- a/app/presenters/pagination_presenter.rb
+++ b/app/presenters/pagination_presenter.rb
@@ -18,15 +18,15 @@ class PaginationPresenter
   end
 
   def prev_label
-    "#{page - 1} of #{total_pages}"
+    "#{prev_page} of #{formatted_total_pages}"
   end
 
   def next_label
-    "#{page + 1} of #{total_pages}"
+    "#{next_page} of #{formatted_total_pages}"
   end
 
   def next_link?
-    page < total_pages
+    page < @total_pages
   end
 
   def first_record
@@ -53,6 +53,18 @@ class PaginationPresenter
   end
 
 private
+
+  def formatted_total_pages
+    number_with_delimiter(@total_pages)
+  end
+
+  def prev_page
+    number_with_delimiter(@page - 1)
+  end
+
+  def next_page
+    number_with_delimiter(@page + 1)
+  end
 
   def previous_record_count
     (@page - 1) * @per_page

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -4,10 +4,8 @@
         <% if pagination.total_pages > 1 %>
             <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
             <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
-            <span class="table-header__param" data-gtm-pagination-total-results="<%= pagination.total_results %>"><%= pagination.formatted_total_results %></span> results
-        <% else %>
-            <span class="table-header__param" data-gtm-pagination-total-results="<%= pagination.total_results %>"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
         <% end %>
+        <span class="table-header__param" data-gtm-pagination-total-results="<%= pagination.total_results %>"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
     <% else %>
         <span class="table-header__param" data-gtm-pagination-total-results="0"><%= I18n.t('no_matching_results') %></span>
     <% end %>

--- a/spec/presenters/pagination_presenter_spec.rb
+++ b/spec/presenters/pagination_presenter_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe PaginationPresenter do
       expect(subject.next_link?).to eq(true)
     end
 
-    it 'return the correct next page label' do
-      expect(subject.next_label).to eq('2 of 123457')
+    it 'returns the correct next page label' do
+      expect(subject.next_label).to eq('2 of 123,457')
     end
 
     it 'returns 1 for #first_record' do
@@ -51,8 +51,8 @@ RSpec.describe PaginationPresenter do
       expect(subject.next_link?).to eq(false)
     end
 
-    it 'returns the correct next page label' do
-      expect(subject.prev_label).to eq('123456 of 123457')
+    it 'returns the correct previous page label' do
+      expect(subject.prev_label).to eq('123,456 of 123,457')
     end
 
     it 'returns 1234561 for #first_record' do
@@ -83,12 +83,12 @@ RSpec.describe PaginationPresenter do
       expect(subject.prev_link?).to eq(true)
     end
 
-    it 'returns the correct next page label' do
-      expect(subject.prev_label).to eq('5 of 123457')
+    it 'returns the correct previous page label' do
+      expect(subject.prev_label).to eq('5 of 123,457')
     end
 
-    it 'return the correct next page label' do
-      expect(subject.next_label).to eq('7 of 123457')
+    it 'returns the correct next page label' do
+      expect(subject.next_label).to eq('7 of 123,457')
     end
 
     it 'returns 51 for #first_record' do


### PR DESCRIPTION
# What
This formats numbers within the previous and next page links.

# Why
To make larger numbers easier to read.

# Screenshots
## After
<img width="169" alt="image" src="https://user-images.githubusercontent.com/11051676/51876687-2ea30880-23b5-11e9-886f-b36fd9780156.png">

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [ ] Added to Trello card.