### PR TITLE
Increase timeout

### DIFF
--- a/app/services/metrics_common.rb
+++ b/app/services/metrics_common.rb
@@ -5,7 +5,7 @@ private
 
   def api
     @api ||= GdsApi::ContentDataApi.new.tap do |client|
-      client.options[:timeout] = 15
+      client.options[:timeout] = 60
     end
   end
 


### PR DESCRIPTION
# What
Increasing the timeout on CDA's API client so that slow queries returned from CPM's API don't cause a timeout on production.

To address:

```
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] GdsApi::HTTPGatewayTimeout (URL: https://<REDACTED>/content?date_range=past-30-days&organisation_id=all&search_term=https%3A%2F%2Fwww.gov.uk%2Fgovernment%2Fpublications%2F
Response body:
<html>
<head><title>504 Gateway Time-out</title></head>
<body bgcolor="white">
<center><h1>504 Gateway Time-out</h1></center>
<hr><center>nginx</center>
</body>
</html>


Request body:
):
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e]
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] lib/gds_api/content_data_api.rb:22:in `content'
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] app/services/find_content.rb:21:in `call'
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] app/services/find_content.rb:5:in `call'
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] app/controllers/content_controller.rb:20:in `block (2 levels) in index'
[0c6d156e-8dfe-4ca8-a064-0295a4559b2e] app/controllers/content_controller.rb:18:in `index'
I, [2019-01-29T13:34:05.821064 #6289]  INFO -- omniauth: (gds) Callback phase initiated.
I, [2019-01-29T13:34:15.104641 #6286]  INFO -- omniauth: (gds) Callback phase initiated.
I, [2019-01-29T13:34:59.767084 #6289]  INFO -- omniauth: (gds) Callback phase initiated.
```

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
