### PR TITLE
Change DateRange to return Time objects

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -47,8 +47,8 @@ module ExternalLinksHelper
   end
 
   def google_analytics_url(from:, to:, base_path:)
-    from = from.delete('-')
-    to = to.delete('-')
+    from = from.to_s(:number)
+    to = to.to_s(:number)
     base_path = base_path.gsub(%r((\/)(?!\z)), '~2F')
     "https://analytics.google.com/analytics/web/?hl=en&pli=1"\
     "#/report/content-site-search-pages/a26179049w50705554p53872948/"\

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -10,8 +10,8 @@ class DateRange
   end
 
   def previous
-    relative_date = Date.parse(@from)
-    relative_date = relative_date - 1.day unless @time_period == 'last-month'
+    relative_date = @from
+    relative_date -= 1.day unless @time_period == 'last-month'
     DateRange.new(time_period, relative_date)
   end
 
@@ -21,33 +21,33 @@ private
     case time_period
     when 'last-month'
       {
-        from: relative_date.last_month.beginning_of_month.to_s,
-        to: relative_date.last_month.end_of_month.to_s
+        from: relative_date.last_month.beginning_of_month,
+        to: relative_date.last_month.end_of_month
       }
     when 'past-3-months'
       {
-        from: ((relative_date - 3.months) + 1.day).to_s,
-        to: relative_date.to_s
+        from: (relative_date - 3.months) + 1.day,
+        to: relative_date
       }
     when 'past-6-months'
       {
-        from: ((relative_date - 6.months) + 1.day).to_s,
-        to: relative_date.to_s
+        from: (relative_date - 6.months) + 1.day,
+        to: relative_date
       }
     when 'past-year'
       {
-        from: ((relative_date - 1.year) + 1.day).to_s,
-        to: relative_date.to_s
+        from: (relative_date - 1.year) + 1.day,
+        to: relative_date
       }
     when 'past-2-years'
       {
-        from: ((relative_date - 2.years) + 1.day).to_s,
-        to: relative_date.to_s
+        from: (relative_date - 2.years) + 1.day,
+        to: relative_date
       }
     else
       {
-        from: (relative_date - 29.days).to_s,
-        to: relative_date.to_s
+        from: relative_date - 29.days,
+        to: relative_date
       }
     end
   end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -228,11 +228,11 @@ RSpec.describe '/metrics/base/path', type: :feature do
     context 'when the data-api has no comparison data' do
       it 'returns trend as `no comparison data`' do
         content_data_api_has_single_page(base_path: 'base/path',
-                                         from: from.to_s,
-                                         to: to.to_s)
+                                         from: from,
+                                         to: to)
         content_data_api_has_single_page_with_nil_values(base_path: 'base/path',
-                                                         from: prev_from.to_s,
-                                                         to: prev_to.to_s)
+                                                         from: prev_from,
+                                                         to: prev_to)
         visit '/metrics/base/path'
         expect(page.status_code).to eq(200)
         expect(page).to have_selector '.upviews .app-c-glance-metric__trend', text: 'no comparison data'
@@ -242,8 +242,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
     context 'when the data-api has an error' do
       it 'returns a 404 for a Gds::NotFound' do
         content_data_api_does_not_have_base_path(base_path: 'base/path',
-                                                 from: from.to_s,
-                                                 to: to.to_s)
+                                                 from: from,
+                                                 to: to)
         visit '/metrics/base/path'
         expect(page.status_code).to eq(404)
         expect(page).to have_content "Page not found"
@@ -252,8 +252,8 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     context 'no time series from the data-api' do
       before do
-        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: from.to_s, to: to.to_s)
-        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: prev_from.to_s, to: prev_to.to_s)
+        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: from, to: to)
+        content_data_api_has_single_page_missing_data(base_path: 'base/path', from: prev_from, to: prev_to)
         visit '/metrics/base/path'
       end
 

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -149,8 +149,8 @@ RSpec.describe ExternalLinksHelper do
       expected_link = "#{host}/anonymous_feedback?from=2018-11-25&to=2018-12-24&paths=%2Fthe%2Fbase%2Fpath"
 
       expect(feedex_url(
-               from: '2018-11-25',
-               to: '2018-12-24',
+               from: Date.new(2018, 11, 25),
+               to: Date.new(2018, 12, 24),
                base_path: '/the/base/path'
       )).to eq(expected_link)
     end
@@ -161,8 +161,8 @@ RSpec.describe ExternalLinksHelper do
       expected_link = 'https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181125&_u.date01=20181224&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath'
 
       expect(google_analytics_url(
-               from: '2018-11-25',
-               to: '2018-12-24',
+               from: Date.new(2018, 11, 25),
+               to: Date.new(2018, 12, 24),
                base_path: '/the/base/path'
       )).to eq(expected_link)
     end

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-11-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 11, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
@@ -20,8 +20,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2018-05-27') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 25)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 5, 27)) }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
 
@@ -29,8 +29,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-11-24') }
-      it { is_expected.to have_attributes(from: '2018-10-26') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 11, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 10, 26)) }
       it { is_expected.to have_attributes(time_period: 'past-30-days') }
     end
   end
@@ -41,8 +41,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-11-30') }
-      it { is_expected.to have_attributes(from: '2018-11-01') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 11, 30)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 11, 1)) }
       it { is_expected.to have_attributes(time_period: 'last-month') }
     end
 
@@ -50,8 +50,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-05-31') }
-      it { is_expected.to have_attributes(from: '2018-05-01') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 5, 31)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 5, 1)) }
       it { is_expected.to have_attributes(time_period: 'last-month') }
     end
 
@@ -59,8 +59,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-10-31') }
-      it { is_expected.to have_attributes(from: '2018-10-01') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 10, 31)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 10, 1)) }
       it { is_expected.to have_attributes(time_period: 'last-month') }
     end
   end
@@ -71,8 +71,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-09-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 9, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
@@ -80,8 +80,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2018-03-26') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 25)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 3, 26)) }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
 
@@ -89,8 +89,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-09-24') }
-      it { is_expected.to have_attributes(from: '2018-06-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 9, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 6, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-3-months') }
     end
   end
@@ -101,8 +101,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2018-06-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 6, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
@@ -110,8 +110,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2017-12-26') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 25)) }
+      it { is_expected.to have_attributes(from: Date.new(2017, 12, 26)) }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
 
@@ -119,8 +119,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2018-06-24') }
-      it { is_expected.to have_attributes(from: '2017-12-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2017, 12, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-6-months') }
     end
   end
@@ -131,8 +131,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2017-12-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2017, 12, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
@@ -140,8 +140,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2017-06-26') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 25)) }
+      it { is_expected.to have_attributes(from: Date.new(2017, 6, 26)) }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
 
@@ -149,8 +149,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2017-12-24') }
-      it { is_expected.to have_attributes(from: '2016-12-25') }
+      it { is_expected.to have_attributes(to: Date.new(2017, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2016, 12, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-year') }
     end
   end
@@ -161,8 +161,8 @@ RSpec.describe DateRange do
     describe 'relative to yesterday' do
       subject { DateRange.new(time_period) }
 
-      it { is_expected.to have_attributes(to: '2018-12-24') }
-      it { is_expected.to have_attributes(from: '2016-12-25') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2016, 12, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
@@ -170,8 +170,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period, specified_date) }
       let(:specified_date) { Date.new(2018, 6, 25) }
 
-      it { is_expected.to have_attributes(to: '2018-06-25') }
-      it { is_expected.to have_attributes(from: '2016-06-26') }
+      it { is_expected.to have_attributes(to: Date.new(2018, 6, 25)) }
+      it { is_expected.to have_attributes(from: Date.new(2016, 6, 26)) }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
 
@@ -179,8 +179,8 @@ RSpec.describe DateRange do
       subject { DateRange.new(time_period).previous }
 
       it { is_expected.to be_an_instance_of(DateRange) }
-      it { is_expected.to have_attributes(to: '2016-12-24') }
-      it { is_expected.to have_attributes(from: '2014-12-25') }
+      it { is_expected.to have_attributes(to: Date.new(2016, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2014, 12, 25)) }
       it { is_expected.to have_attributes(time_period: 'past-2-years') }
     end
   end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe SingleContentItemPresenter do
   end
 
   let(:date_range) { build(:date_range, :past_30_days) }
-  let(:current_period_data) { default_single_page_payload('the/base/path', '2018-11-25', '2018-12-24') }
-  let(:previous_period_data) { default_single_page_payload('the/base/path', '2018-10-26', '2018-11-24') }
+  let(:current_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
+  let(:previous_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
   let(:default_timeseries_metrics) {
     [
       {

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -154,9 +154,9 @@ module GdsApi
       end
 
       def default_single_page_payload(base_path, from, to, publishing_app = 'whitehall')
-        day1 = from
-        day2 = (Date.parse(from) + 1.day).to_s
-        day3 = to
+        day1 = from.to_s
+        day2 = (from + 1.day).to_s
+        day3 = to.to_s
         {
           metadata: {
             title: "Content Title",
@@ -246,9 +246,9 @@ module GdsApi
       end
 
       def default_previous_single_page_payload(base_path, from, to)
-        day1 = from
-        day2 = (Date.parse(from) + 1.day).to_s
-        day3 = to
+        day1 = from.to_s
+        day2 = (from + 1.day).to_s
+        day3 = to.to_s
         {
           metadata: {
             title: "Content Title",


### PR DESCRIPTION
## What
Changes `to` and `from` methods of the DateRange model to return `Time` objects rather than strings. 

## Why
The date values are often manipulated before being used as strings and allows us to specify the format of the date string without re-parsing.

---
## Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.