### PR TITLE
Set target so external links open in a new tab

### DIFF
--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -12,7 +12,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <% if external_link %>
-      <a href="<%= external_link %>" class="govuk-link govuk-body-s"><%= t "metrics.#{metric_name}.external_link" %></a>
+      <a href="<%= external_link %>" class="govuk-link govuk-body-s" target="_blank"><%= t "metrics.#{metric_name}.external_link" %></a>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
# What
Open new windows for external links. Desired behaviour is to spawn a new tab each time, not to re-use the same one, hence the _blank target.

# Why
Some users are getting lost when entering a different app

