### PR TITLE
Add helper to generate time-select options

### DIFF
--- a/app/helpers/time_select_helper.rb
+++ b/app/helpers/time_select_helper.rb
@@ -1,0 +1,18 @@
+module TimeSelectHelper
+  METRIC_PAGE_TIME_PERIODS = ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year', 'past-2-years'].freeze
+  CONTENT_PAGE_TIME_PERIODS = ['past-30-days', 'last-month', 'past-3-months', 'past-6-months', 'past-year'].freeze
+
+  def time_select_options(time_periods)
+    time_periods.map do |time_period|
+      date_range = DateRange.new(time_period)
+      start_date = date_range.from.to_s(:long_date)
+      end_date = date_range.to.to_s(:long_date)
+
+      {
+        value: time_period,
+        text: I18n.t("metrics.show.time_periods.#{time_period}.leading"),
+        hint_text: "#{start_date} to #{end_date}",
+      }
+    end
+  end
+end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -17,33 +17,7 @@
             current_selection: @presenter.time_period,
             compact: true,
             base_path: "/",
-            dates: [
-              {
-                value: "past-30-days",
-                text: t("metrics.show.time_periods.past-30-days.leading"),
-                hint_text: "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "last-month",
-                text: t("metrics.show.time_periods.last-month.leading"),
-                hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "past-3-months",
-                text: t("metrics.show.time_periods.past-3-months.leading"),
-                hint_text: "#{(3.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "past-6-months",
-                text: t("metrics.show.time_periods.past-6-months.leading"),
-                hint_text: "#{(6.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              },
-              {
-                value: "past-year",
-                text: t("metrics.show.time_periods.past-year.leading"),
-                hint_text: "#{(1.year.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-              }
-            ]
+            dates: time_select_options(TimeSelectHelper::CONTENT_PAGE_TIME_PERIODS)
           } %>
           <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -42,43 +42,11 @@
       } %>
   </div>
 </div>
-
 <%= form_for("date", url: "/metrics#{@performance_data.base_path}", method: :get, html: { id: 'filter-form' }) do %>
   <%= render "components/time-select", {
     render_button: true,
     current_selection: current_selection,
-    dates: [
-      {
-        value: "past-30-days",
-        text: t(".time_periods.past-30-days.leading"),
-        hint_text:  "#{30.days.ago.strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "last-month",
-        text: t(".time_periods.last-month.leading"),
-        hint_text: "#{Date.today.last_month.beginning_of_month.strftime("%-d %B %Y")} to #{Date.today.last_month.end_of_month.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "past-3-months",
-        text: t(".time_periods.past-3-months.leading"),
-        hint_text: "#{(3.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "past-6-months",
-        text: t(".time_periods.past-6-months.leading"),
-        hint_text: "#{(6.months.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "past-year",
-        text: t(".time_periods.past-year.leading"),
-        hint_text: "#{(1.year.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      },
-      {
-        value: "past-2-years",
-        text: t(".time_periods.past-2-years.leading"),
-        hint_text: "#{(2.years.ago).strftime("%-d %B %Y")} to #{Date.yesterday.strftime("%-d %B %Y")}"
-      }
-    ]
+    dates: time_select_options(TimeSelectHelper::METRIC_PAGE_TIME_PERIODS)
   } %>
 <% end %>
 

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,1 +1,2 @@
 Time::DATE_FORMATS[:param] = '%Y-%m-%d'
+Date::DATE_FORMATS[:long_date] = '%-d %B %Y'

--- a/spec/helpers/time_select_helper_spec.rb
+++ b/spec/helpers/time_select_helper_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe TimeSelectHelper do
+  around do |example|
+    Timecop.freeze Date.new(2018, 12, 31) do
+      example.run
+    end
+  end
+
+  context 'metrics page' do
+    let(:time_periods) { TimeSelectHelper::METRIC_PAGE_TIME_PERIODS }
+
+    describe '#time_select_options' do
+      it 'returns options for time select' do
+        options = time_select_options(time_periods)
+        expect(options).to eq([
+          {
+            value: "past-30-days",
+            text: I18n.t("metrics.show.time_periods.past-30-days.leading"),
+            hint_text: "1 December 2018 to 30 December 2018"
+          },
+          {
+            value: "last-month",
+            text: I18n.t("metrics.show.time_periods.last-month.leading"),
+            hint_text: "1 November 2018 to 30 November 2018"
+          },
+          {
+            value: "past-3-months",
+            text: I18n.t("metrics.show.time_periods.past-3-months.leading"),
+            hint_text: "1 October 2018 to 30 December 2018"
+          },
+          {
+            value: "past-6-months",
+            text: I18n.t("metrics.show.time_periods.past-6-months.leading"),
+            hint_text: "1 July 2018 to 30 December 2018"
+          },
+          {
+            value: "past-year",
+            text: I18n.t("metrics.show.time_periods.past-year.leading"),
+            hint_text: "31 December 2017 to 30 December 2018"
+          },
+          {
+            value: "past-2-years",
+            text: I18n.t("metrics.show.time_periods.past-2-years.leading"),
+            hint_text: "31 December 2016 to 30 December 2018"
+          }
+        ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What
Adds the TimeSelectHelper to create the time select options for both the metrics and content page. 

# Why
Too much logic embedded within the views. Helper removes duplicate code in the metric and content views and allows us to test it.

A presenter wasn't used as this relatively static code and presenters require more logic added to controllers.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.