### PR TITLE
Add reading time metric to interface

### DIFF
--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -29,7 +29,14 @@
   @include govuk-responsive-margin(1, "top");
 }
 
+.app-c-info-metric__words {
+  @include govuk-responsive-margin(1, "top");
+}
+
 .app-c-info-metric {
+
+  @include govuk-responsive-margin(3, "left");
+  @include govuk-responsive-margin(3, "right");
 
   .govuk-details__summary-text {
     @include govuk-font(16);
@@ -39,4 +46,11 @@
     @include govuk-font(16);
   }
 
+}
+
+.govuk-grid-column-one-third {
+
+  .app-c-info-metric {
+    @include govuk-responsive-margin(1, "left");
+  }
 }

--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -33,15 +33,19 @@
 }
 
 .metric-summary__words {
-  padding: 0 !important;
 
   @include media-down(mobile) {
+    width: 95%;
     border-bottom: 1px solid $govuk-border-colour;
   }
 }
 
-.metric-summary__pdf-count {
-  padding: 0 !important;
+.metric-summary__reading-time {
+
+  @include media-down(mobile) {
+    width: 95%;
+    border-bottom: 1px solid $govuk-border-colour;
+  }
 }
 
 .banner {

--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -9,4 +9,9 @@ module MetricsFormatterHelper
       figure
     end
   end
+
+  def format_duration(minutes)
+    dur = ActiveSupport::Duration.build(minutes * 60)
+    Time.at(dur).utc.to_s(:reading_time)
+  end
 end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -48,7 +48,8 @@ class SingleContentItemPresenter
   end
 
   def reading_time
-    "1hr 50m"
+    dur = ActiveSupport::Duration.build(@metrics['reading_time'][:value] * 60)
+    Time.at(dur).utc.strftime("%kh %-Mm")
   end
 
   def upviews_context

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -47,6 +47,10 @@ class SingleContentItemPresenter
     number_with_delimiter value_for('pageviews_per_visit')
   end
 
+  def reading_time
+    "1hr 50m"
+  end
+
   def upviews_context
     I18n.t("metrics.upviews.context", percent_org_views: 2.74)
   end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -48,8 +48,7 @@ class SingleContentItemPresenter
   end
 
   def reading_time
-    dur = ActiveSupport::Duration.build(@metrics['reading_time'][:value] * 60)
-    Time.at(dur).utc.strftime("%kh %-Mm")
+    format_duration(@metrics['reading_time'][:value])
   end
 
   def upviews_context

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -1,12 +1,17 @@
 <%
   show_trend ||= false
   short_context ||= false
+  if defined?(context_value)
+    context = t("metrics.#{metric_name}.summary", context_value)
+  else
+    context = t("metrics.#{metric_name}.summary")
+  end
   data_source = t("metrics.#{metric_name}.data_source")
   time_period = @performance_data.date_range.time_period
   options = {
     name: t("metrics.#{metric_name}.title"),
     figure: number_with_delimiter(value, delimiter: ','),
-    context: t("metrics.#{metric_name}.summary"),
+    context: context,
     data_source: t("data_sources.#{data_source}"),
     about: t("metrics.#{metric_name}.about"),
     about_label: @performance_data.metric_about_label(metric_name)
@@ -24,7 +29,7 @@
   end
 %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="metric">
     <%= render "components/info-metric", options %>
   </div>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -134,10 +134,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full section-content section-content__quality">
     <h2 class="section-content__header"><%= t ".section_headings.content" %></h2>
-    <div class="govuk-grid-column-one-half metric-summary metric-summary__words">
+    <div class="govuk-grid-column-one-third metric-summary metric-summary__reading-time">
+      <%= render 'metric_header', metric_name: 'reading_time', value: @performance_data.reading_time, show_trend: false, context_value: {number_of_words: @performance_data.total_words} %>
+    </div>
+    <div class="govuk-grid-column-one-third metric-summary metric-summary__words">
       <%= render 'metric_header', metric_name: 'words', value: @performance_data.total_words, show_trend: false %>
     </div>
-    <div class="govuk-grid-column-one-half metric-summary metric-summary__pdf-count">
+    <div class="govuk-grid-column-one-third metric-summary metric-summary__pdf-count">
       <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.total_pdf_count, show_trend: false %>
     </div>
   </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,3 +1,3 @@
 Date::DATE_FORMATS[:param] = '%Y-%m-%d'
 Date::DATE_FORMATS[:long_date] = '%-d %B %Y'
-Time::DATE_FORMATS[:reading_time] = ->(time) { time.strftime("%kh %-Mm").strip }
+Time::DATE_FORMATS[:reading_time] = '%-kh %-Mm'

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,2 +1,3 @@
-Time::DATE_FORMATS[:param] = '%Y-%m-%d'
+Date::DATE_FORMATS[:param] = '%Y-%m-%d'
 Date::DATE_FORMATS[:long_date] = '%-d %B %Y'
+Time::DATE_FORMATS[:reading_time] = ->(time) { time.strftime("%kh %-Mm").strip }

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -102,6 +102,20 @@ en:
         Lots of words on a page can make content difficult for users to read online. The longer the
         page is, the less usable it is likely to be. You could investigate whether this content could
         be shorter. Otherwise, does it have headings and bulletpoints to help users scan?
+    reading_time:
+      title: 'Reading time'
+      short_title: 'Reading time'
+      summary: 'Typical time to read all %{number_of_words} words'
+      context: ''
+      unit: ''
+      data_source: none
+      external_link: ''
+      about_title: 'About reading time'
+      about: >
+        Reading time is calculated by dividing the word count for the page by an average reading speed
+        of 200 words per minute. The time it takes to read the page is rounded up to the nearest minute.
+        This calculation doesn’t take into account how complicated the content is or any of the page’s
+        attachments.
     pdf_count:
       title: 'Number of PDFs'
       short_title: 'Number of PDFs'
@@ -112,7 +126,7 @@ en:
       external_link: ''
       about_title: 'About number of PDFs'
       about: >
-        Compared with HTML content, information published in a PDF is harder to find, use and 
+        Compared with HTML content, information published in a PDF is harder to find, use and
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
         Several PDFs on one page may indicate that too many users needs are being met by them.
         <a href="https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/">Read more about why to avoid PDFs</a>.

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include RequestStubs
   include TableDataSpecHelpers
-  let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
+  let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no reading_time] }
   let(:prev_from) { Time.zone.yesterday - 59.days }
   let(:prev_to) { Time.zone.yesterday - 30.days }
   let(:from) { Time.zone.yesterday - 29.days }
@@ -158,14 +158,24 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector(".metric-summary__pdf-count .govuk-details__summary-text", text: label)
       end
 
-      it 'renders a metric for words count' do
+      it 'renders a metric for word count' do
         expect(page).to have_selector '.metric-summary__words', text: '200'
       end
 
-      it 'renders about label for  words count' do
+      it 'renders about label for word count' do
         label = 'About word count'
         expect(page).to have_selector(".metric-summary__words .govuk-details__summary-text", text: label)
       end
+
+      it 'renders a metric for time to read' do
+        expect(page).to have_selector '.metric-summary__reading-time', text: '200'
+      end
+
+      it 'renders about label for time to read' do
+        label = 'About reading time'
+        expect(page).to have_selector(".metric-summary__reading-time .govuk-details__summary-text", text: label)
+      end
+
 
       it 'renders the page title' do
         expect(page).to have_selector 'h1.govuk-heading-xl', text: 'Content Title'

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -1,22 +1,37 @@
 RSpec.describe MetricsFormatterHelper do
-  context 'metric needs to be rendered as a percentage' do
-    it 'displays value as a percentage' do
-      value = format_metric_value('satisfaction', 0.9000)
-      expect(value).to eq '90%'
+  describe '#format_metric_value' do
+    context 'metric needs to be rendered as a percentage' do
+      it 'displays value as a percentage' do
+        value = format_metric_value('satisfaction', 0.9000)
+        expect(value).to eq '90%'
+      end
+    end
+
+    context 'metric does not need to be rendered as a percentage' do
+      it 'displays value as an integer' do
+        value = format_metric_value('pviews', 90)
+        expect(value).to eq 90
+      end
+    end
+
+    context 'if figure for percentage metric is not supplied' do
+      it 'does not raise an error' do
+        expect { format_metric_value('satisfaction', nil) }.to_not raise_error
+      end
     end
   end
 
-
-  context 'metric does not need to be rendered as a percentage' do
-    it 'displays value as an integer' do
-      value = format_metric_value('pviews', 90)
-      expect(value).to eq 90
+  describe '#format_duration' do
+    it 'formats duration for reading time of a few minutes' do
+      expect(format_duration(5)).to eq('0h 5m')
     end
-  end
 
-  context 'if figure for percentage metric is not supplied' do
-    it 'does not raise an error' do
-      expect { format_metric_value('satisfaction', nil) }.to_not raise_error
+    it 'formats duration for reading time less than an hour' do
+      expect(format_duration(50)).to eq('0h 50m')
+    end
+
+    it 'formats duration for reading time of several hours and minutes' do
+      expect(format_duration(150)).to eq('2h 30m')
     end
   end
 end

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -90,6 +90,10 @@ module GdsApi
             {
               name: "pdf_count",
               value: 3
+            },
+            {
+              name: "reading_time",
+              value: 20
             }
           ]
         }
@@ -180,6 +184,10 @@ module GdsApi
             {
               name: "pdf_count",
               value: 5
+            },
+            {
+              name: "reading_time",
+              value: 20
             }
           ]
         }


### PR DESCRIPTION
# What
https://trello.com/c/fNfu8Vl7/1122-3-add-reading-time-to-interface-front-end

This shouldn't be merged because we don't have the reading time metric yet, so it is faked here, but this PR:

- Adds reading time to the view
- Tests for it
- Adjusts CSS to make layout accommodate the new column

# Why
Helps users understand word count in a less abstract way

# Screenshots

## Before
![screen shot 2019-01-30 at 13 15 27](https://user-images.githubusercontent.com/31649453/51983725-5b2c5280-2491-11e9-8f50-7c54358f2f7c.png)

## After
![screen shot 2019-01-30 at 13 14 53](https://user-images.githubusercontent.com/31649453/51983728-5f587000-2491-11e9-89ec-2c930e1e9927.png)
