### PR TITLE
Add puma to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'kaminari'
 gem 'logstasher'
 gem "pg", "~> 1"
 gem "plek", "~> 2"
+gem "puma"
 gem "uglifier", "~> 4"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -227,6 +227,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.6)
     rack-cache (1.8.0)
       rack (>= 0.4)
@@ -389,6 +390,7 @@ DEPENDENCIES
   pg (~> 1)
   plek (~> 2)
   pry
+  puma
   rails (~> 5.2)
   rspec-rails (~> 3)
   simplecov (~> 0.16)
@@ -401,4 +403,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.1
+   1.17.2


### PR DESCRIPTION
# What
Add puma to gemfile to enable use of puma as webserver.

# Why
Needed as development environment defaults to [WEBrick which doesn't support streaming responses](https://guides.rubyonrails.org/action_controller_overview.html#streaming-considerations) required for CSV streaming download. 

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.