### PR TITLE
Remove table helper

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -69,10 +69,11 @@
   .table-wrapper {
     min-width: 900px;
     background-color: $white;
+    @include govuk-responsive-padding(6, "right");
   }
 
   .filter-form {
-    @include govuk-responsive-padding(3, "left");
+    @include govuk-responsive-padding(6, "left");
 
     .govuk-radios__hint {
       @include govuk-font(16);

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -60,41 +60,50 @@
     </div>
     <div class="govuk-grid-column-three-quarters">
       <div class="table-wrapper">
-        <%= GovukPublishingComponents::AppHelpers::TableHelper.helper(
-            self,
-            render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter),
-            sortable: false
-          ) do |t| %>
-            <%= t.head do %>
-              <!-- TODO: Once sorting is supported, fill in the href and sort_direction header arguments with proper values -->
-              <%# t.header("Page title", href: '#', sort_direction: nil) %>
-              <%= t.header("Page title") %>
-              <%= t.header("Content type") %>
-              <%= t.header("Unique pageviews<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.upviews.summary"}")}".html_safe) %>
-              <%= t.header("User satisfaction score<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.satisfaction.summary"}")}".html_safe) %>
-              <%= t.header("Searches from page<br> #{image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.searches.summary"}")}".html_safe) %>
-            <% end %>
-
-            <%= t.body do %>
-              <% @presenter.content_items.each do |item| %>
-                <%= t.row do %>
-                  <%= t.cell(
-                    render(
-                      partial: 'page_title',
-                      locals: {
-                        item: item,
-                        date_range: @presenter.time_period
-                      }
-                    )
-                  ) %>
-                  <%= t.cell item.document_type %>
-                  <%= t.cell item.upviews, format: 'numeric' %>
-                  <%= t.cell item.user_satisfaction %>
-                  <%= t.cell item.searches, format: 'numeric' %>
-                <% end %>
-              <% end %>
-            <% end %>
+        <table class="govuk-table">
+          <caption class="govuk-table__caption">
+            <%= render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter) %>
+          </caption>
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th class="govuk-table__header" scope="col">Page title</th>
+              <th class="govuk-table__header" scope="col">Content type</th>
+              <th class="govuk-table__header" scope="col">
+                Unique pageviews<br>
+                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.upviews.summary"}") %>
+              </th>
+              <th class="govuk-table__header" scope="col">
+                User satisfaction score<br>
+                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.satisfaction.summary"}") %>
+              </th>
+              <th class="govuk-table__header" scope="col">
+                Searches from page<br>
+                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.searches.summary"}") %>
+              </th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+          <% @presenter.content_items.each do |item| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell">
+                <%=
+                  render(
+                    partial: 'page_title',
+                    locals: {
+                      item: item,
+                      date_range: @presenter.time_period
+                    }
+                ) %>
+              </td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.document_type %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.upviews %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.user_satisfaction %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.searches %></td>
+            </tr>
           <% end %>
+          </tbody>
+   </table>
+
         </div>
         <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
     </div>


### PR DESCRIPTION
# What

https://trello.com/c/Rz0I7Byy/1110-3-re-write-the-table-without-the-helper

Stop using the helper
Give the table more breathing space

We should use the translations file for the table headers instead of hard coding them but I haven't addressed that here because there's a card in to potentially change them and they may need to diverge from headings used elsewhere.

# Why
The table helper isn't offering any advantage and it makes it more difficult to put html into the cells, which is a necessity to meet the layout we will need when we start sorting the table.

Jeremy and I took the opportunity to adjust the spacing so the content doesn't run as close to the edges as previously based on user feedback.

# Screenshots

## Before
![screen shot 2019-01-31 at 10 18 35](https://user-images.githubusercontent.com/31649453/52047771-a3a34900-2541-11e9-8464-6737f1895b42.png)

## After
![screen shot 2019-01-31 at 10 18 21](https://user-images.githubusercontent.com/31649453/52047781-a9992a00-2541-11e9-95be-725f62116218.png)
