### PR TITLE
Handle unknown organisations during CSV download

### DIFF
--- a/app/helpers/organisations_helper.rb
+++ b/app/helpers/organisations_helper.rb
@@ -1,0 +1,15 @@
+module OrganisationsHelper
+  ALL_ORGANISATIONS = 'all'.freeze
+  NO_ORGANISATION = 'none'.freeze
+
+  def organisation_title(organisations, id)
+    return 'No organisation' if [NO_ORGANISATION, nil].include?(id)
+    return 'All organisations' if id == ALL_ORGANISATIONS
+
+    organisation = organisations.find { |o| o[:id] == id }
+
+    return 'Unknown organisation' if organisation == nil
+
+    organisation[:name]
+  end
+end

--- a/spec/helpers/organisations_helper_spec.rb
+++ b/spec/helpers/organisations_helper_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe OrganisationsHelper do
+  let(:organisations) do
+    [
+      { id: '6667cce2-e809-4e21-ae09-cb0bdc1ddda3', name: 'HM Revenue & Customs', acryonm: 'HMRC' },
+      { id: 'e3b07496-d133-4a87-abcc-9e2f45d570e4', name: 'Dental Practice Board', acryonm: nil },
+      { id: 'cb0a039c-a89d-4143-8277-67e18c16c6bf', name: 'Welsh Government', acryonm: nil }
+    ]
+  end
+
+  describe '#organisation_title' do
+    it 'returns title for all organisations' do
+      id = 'all'
+      expect(organisation_title([], id)).to eq('All organisations')
+    end
+
+    it 'returns title for no organisation' do
+      id = 'none'
+      expect(organisation_title([], id)).to eq('No organisation')
+    end
+
+    it 'returns title for known organisation' do
+      id = 'e3b07496-d133-4a87-abcc-9e2f45d570e4'
+      expect(organisation_title(organisations, id)).to eq('Dental Practice Board')
+    end
+
+    it 'returns title for unknown organisation' do
+      id = 'ccc9dff8-87b7-4d0f-8d78-b8339063b440'
+      expect(organisation_title(organisations, id)).to eq('Unknown organisation')
+    end
+  end
+end


### PR DESCRIPTION
## What
Abstracts logic out for searching for organisation titles into OrganisationHelper module. Adds check for unknown organisation id and returns 'Unknown organisation' as name. Adds test cases.

## Why
Currently the content-performance-manager is returning content-items with organisation ids that are not returned by the `/api/v1/organisations` endpoint. Leads to errors when determining the organisation name when generating the CSV. The abstract allows for better testing of this behaviour.

---
## Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.