### PR TITLE
Refactor request stubs

### DIFF
--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'date selection', type: :feature do
-  include GdsApi::TestHelpers::ContentDataApi
+  include RequestStubs
   include TableDataSpecHelpers
   let(:base_path) { 'base/path' }
   let(:page_uri) { "/metrics/#{base_path}" }

--- a/spec/features/index_page/index_filter_by_title_spec.rb
+++ b/spec/features/index_page/index_filter_by_title_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe '/content' do
-  include GdsApi::TestHelpers::ContentDataApi
+  include RequestStubs
   include TableDataSpecHelpers
 
   let(:items) do
@@ -12,16 +12,15 @@ RSpec.describe '/content' do
   before do
     GDS::SSO.test_user = build(:user, organisation_content_id: 'org-id')
 
-    content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', items: items)
-    content_data_api_has_orgs
-    content_data_api_has_document_types
+    stub_content_page(time_period: 'last-month', organisation_id: 'org-id', items: items)
 
     visit '/content?submitted=true&date_range=last-month&organisation_id=org-id'
   end
 
   describe 'Filter by title / url' do
     before do
-      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', search_term: 'title', items: items)
+      stub_content_page(time_period: 'last-month', organisation_id: 'org-id', search_terms: 'title', items: items)
+
       fill_in 'Search for a title or URL', with: 'title'
       click_on 'Filter'
     end

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe '/content' do
   include GdsApi::TestHelpers::ContentDataApi
+  include RequestStubs
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
   let(:items) do

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -1,5 +1,4 @@
 RSpec.describe '/content' do
-  include GdsApi::TestHelpers::ContentDataApi
   include RequestStubs
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
@@ -40,10 +39,8 @@ RSpec.describe '/content' do
 
   before do
     stub_metrics_page(base_path: 'path/1', time_period: :last_month)
-    content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', items: items)
+    stub_content_page(time_period: 'last-month', organisation_id: 'org-id', items: items)
     GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
-    content_data_api_has_orgs
-    content_data_api_has_document_types
 
     visit "/content?submitted=true&date_range=last-month&organisation_id=org-id"
   end
@@ -77,7 +74,7 @@ RSpec.describe '/content' do
 
     it 'respects the date filter' do
       stub_metrics_page(base_path: 'path/1', time_period: :past_year)
-      content_data_api_has_content_items(date_range: 'past-year', organisation_id: 'org-id', items: items)
+      stub_content_page(time_period: 'past-year', organisation_id: 'org-id', items: items)
 
       visit "/content?date_range=past-year&organisation_id=org-id"
       click_link 'The title'
@@ -88,7 +85,7 @@ RSpec.describe '/content' do
 
   context 'filter by organisation' do
     before do
-      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'another-org-id', items: items)
+      stub_content_page(time_period: 'last-month', organisation_id: 'another-org-id', items: items)
       select 'another org', from: 'organisation_id'
       click_on 'Filter'
     end
@@ -112,7 +109,7 @@ RSpec.describe '/content' do
 
     it 'respects date range' do
       stub_metrics_page(base_path: 'path/1', time_period: :past_year)
-      content_data_api_has_content_items(date_range: 'past-year', organisation_id: 'another-org-id', items: items)
+      stub_content_page(time_period: 'past-year', organisation_id: 'another-org-id', items: items)
 
       visit "/content?date_range=past-year&organisation_id=another-org-id"
 
@@ -124,8 +121,8 @@ RSpec.describe '/content' do
 
     context 'when no organisation_id in params' do
       before do
-        content_data_api_has_content_items(
-          date_range: 'last-month',
+        stub_content_page(
+          time_period: 'last-month',
           organisation_id: 'all',
           items: [
             items[0].merge(title: 'Content from all-orgs')
@@ -147,13 +144,13 @@ RSpec.describe '/content' do
 
     context 'with all organisations' do
       before do
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'users-org-id',
           items: items
         )
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'all',
           items: [items[0].merge(title: 'Content from all orgs')]
         )
@@ -170,13 +167,13 @@ RSpec.describe '/content' do
 
     context 'with no organisations' do
       before do
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'users-org-id',
           items: items
         )
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'none',
           items: [items[0].merge(title: 'Content with no primary org')]
         )
@@ -193,15 +190,15 @@ RSpec.describe '/content' do
 
     context 'filter by title or slug' do
       before do
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'all',
           items: items
         )
-        content_data_api_has_content_items(
-          date_range: 'past-30-days',
+        stub_content_page(
+          time_period: 'past-30-days',
           organisation_id: 'all',
-          search_term: 'Relevant',
+          search_terms: 'Relevant',
           items: [items[0].merge(title: 'Relevant content article')]
         )
         visit '/content?date_range=past-30-days'
@@ -221,7 +218,7 @@ RSpec.describe '/content' do
 
   context 'filter by document_type' do
     before do
-      content_data_api_has_content_items(date_range: 'last-month', organisation_id: 'org-id', document_type: 'news_story', items: [items.second])
+      stub_content_page(time_period: 'last-month', organisation_id: 'org-id', document_type: 'news_story', items: [items.second])
       select 'News story', from: 'document_type'
       click_on 'Filter'
     end
@@ -253,7 +250,7 @@ RSpec.describe '/content' do
 
   describe 'no results returned' do
     before do
-      content_data_api_has_no_matching_items(date_range: 'past-3-months', organisation_id: 'org-id')
+      stub_content_page(time_period: 'past-3-months', organisation_id: 'org-id', items: [])
       visit "/content?date_range=past-3-months&organisation_id=org-id"
     end
 
@@ -264,12 +261,12 @@ RSpec.describe '/content' do
 
   describe 'large set of results' do
     before do
-      content_data_api_has_many_matching_items(date_range: 'past-3-months', organisation_id: 'org-id', page: 200)
+      stub_content_page(time_period: 'past-3-months', organisation_id: 'org-id', items: items * 50)
       visit "/content?date_range=past-3-months&organisation_id=org-id"
     end
 
     it 'formats the page numbers correctly in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 19,901 to 20,000 of 30,000 results from org (OI)')
+      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 150 results from org (OI)')
     end
   end
 
@@ -279,18 +276,17 @@ RSpec.describe '/content' do
     let(:csv_items) { items * 11 }
 
     it 'it provides a CSV file respecting all filters' do
-      content_data_api_has_content_items(
-        date_range: 'last-month',
+      stub_content_page(
+        time_period: 'last-month',
         organisation_id: 'org-id',
         items: csv_items,
-        search_term: 'find this'
+        search_terms: 'find this'
       )
-      content_data_api_has_content_items(
-        date_range: 'last-month',
+      stub_content_page_csv_download(
+        time_period: 'last-month',
         organisation_id: 'org-id',
         items: csv_items,
-        page_size: 5000,
-        search_term: 'find this'
+        search_terms: 'find this'
       )
       visit "/content?date_range=last-month&organisation_id=org-id&search_term=find+this"
       click_link 'Download all data in CSV format'

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -1,18 +1,12 @@
 RSpec.describe "Results pagination" do
-  include GdsApi::TestHelpers::ContentDataApi
+  include RequestStubs
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
 
   context 'has no results' do
     before do
       GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
-      content_data_api_has_orgs
-      content_data_api_has_document_types
-
-      content_data_api_has_no_matching_items(
-        date_range: 'last-month',
-        organisation_id: 'org-id',
-      )
+      stub_content_page(time_period: 'last-month', organisation_id: 'org-id', items: [])
 
       visit "/content?date_range=last-month&organisation_id=org-id"
     end
@@ -85,11 +79,8 @@ RSpec.describe "Results pagination" do
 
     before do
       GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
-      content_data_api_has_orgs
-      content_data_api_has_document_types
-
-      content_data_api_has_content_items(
-        date_range: 'last-month',
+      stub_content_page(
+        time_period: 'last-month',
         organisation_id: 'org-id',
         items: (items[1..-1] * 50) + other_page_items
       )

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe '/metrics/base/path', type: :feature do
   include GdsApi::TestHelpers::ContentDataApi
+  include RequestStubs
   include TableDataSpecHelpers
   let(:metrics) { %w[pviews upviews searches feedex words pdf_count satisfaction useful_yes useful_no] }
   let(:prev_from) { Time.zone.yesterday - 59.days }

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -1,8 +1,17 @@
 RSpec.describe ContentItemsCSVPresenter do
-  include GdsApi::TestHelpers::ContentDataApi
+  let(:document_types) do
+    [{ id: 'case_study', name: 'Case study' },
+     { id: 'guide', name: 'Guide' },
+     { id: 'news_story', name: 'News story' },
+     { id: 'html_publication', name: 'HTML publication' }]
+  end
 
-  let(:document_types) { default_document_types }
-  let(:organisations) { default_organisations }
+  let(:organisations) do
+    [{ name: 'org', id: 'org-id', acronym: 'OI', },
+     { name: 'another org', id: 'another-org-id', },
+     { name: 'Users Org', id: 'users-org-id', acronym: 'UOI', }]
+  end
+
   let(:search_params) do
     {
       date_range: 'past-30-days',

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe ContentItemsPresenter do
   include GdsApi::TestHelpers::ContentDataApi
 
-  let(:document_types) { default_document_types }
-  let(:organisations) { default_organisations }
+  let(:document_types) { [] }
+  let(:organisations) { [] }
   let(:search_parameters) do
     {
       date_range: 'last-30-days',

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -1,7 +1,15 @@
 RSpec.describe FilterPresenter do
-  include GdsApi::TestHelpers::ContentDataApi
-  let(:document_types) { default_document_types }
-  let(:organisations) { default_organisations }
+  let(:document_types) do
+    [{ id: 'case_study', name: 'Case study' },
+     { id: 'guide', name: 'Guide' },
+     { id: 'news_story', name: 'News story' },
+     { id: 'html_publication', name: 'HTML publication' }]
+  end
+  let(:organisations) do
+    [{ name: 'org', id: 'org-id', acronym: 'OI', },
+     { name: 'another org', id: 'another-org-id', },
+     { name: 'Users Org', id: 'users-org-id', acronym: 'UOI', }]
+  end
   let(:search_parameters) do
     {
       document_type: 'news_story',

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe SingleContentItemPresenter do
-  include GdsApi::TestHelpers::ContentDataApi
+  include GdsApi::TestHelpers::ResponseHelpers
 
   around do |example|
     Timecop.freeze Date.new(2018, 12, 25) do
@@ -8,8 +8,8 @@ RSpec.describe SingleContentItemPresenter do
   end
 
   let(:date_range) { build(:date_range, :past_30_days) }
-  let(:current_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
-  let(:previous_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
+  let(:current_period_data) { single_page_response('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
+  let(:previous_period_data) { single_page_response('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
   let(:default_timeseries_metrics) {
     [
       {

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -67,25 +67,6 @@ module GdsApi
         end
       end
 
-      def content_data_api_has_no_matching_items(date_range:, organisation_id:, document_type: nil, search_term: nil)
-        params = {
-          date_range: date_range,
-          organisation_id: organisation_id,
-          document_type: document_type,
-          search_term: search_term,
-        }.reject { |_, v| v.blank? }
-        body = {
-          results: [],
-          total_results: 0,
-          total_pages: 0,
-          page: 1
-        }.to_json
-        url = "#{CONTENT_DATA_API_ENDPOINT}/content"
-        stub_request(:get, url)
-          .with(query: params)
-          .to_return(status: 200, body: body)
-      end
-
       def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
         url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}"
         body = payload || default_single_page_payload(base_path, from, to, publishing_app)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -1,19 +1,22 @@
 require 'gds_api/content_data_api'
+require 'support/response_helpers'
 
 module GdsApi
   module TestHelpers
     module ContentDataApi
+      include ResponseHelpers
+
       CONTENT_DATA_API_ENDPOINT = Plek.current.find('content-performance-manager')
 
       def content_data_api_has_orgs
         url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"
-        body = { organisations: default_organisations }.to_json
+        body = organisations.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_has_document_types
         url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/document_types"
-        body = { document_types: default_document_types }.to_json
+        body = document_types.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
@@ -22,6 +25,14 @@ module GdsApi
         stub_request(:get, url)
           .with(query: { from: from, to: to })
           .to_return(status: 404, body: { some: 'error' }.to_json)
+      end
+
+      def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
+        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}"
+        body = payload || single_page_response(base_path, from, to, publishing_app)
+        stub_request(:get, url)
+          .with(query: { from: from, to: to })
+          .to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_has_content_items(date_range:, organisation_id:, document_type: nil, search_term: nil, items:, page_size: nil)
@@ -65,236 +76,6 @@ module GdsApi
               .to_return(status: 200, body: body)
           end
         end
-      end
-
-      def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
-        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}"
-        body = payload || default_single_page_payload(base_path, from, to, publishing_app)
-        stub_request(:get, url)
-          .with(query: { from: from, to: to })
-          .to_return(status: 200, body: body.to_json)
-      end
-
-      def default_single_page_payload(base_path, from, to, publishing_app = 'whitehall')
-        day1 = from.to_s
-        day2 = (from + 1.day).to_s
-        day3 = to.to_s
-        {
-          metadata: {
-            title: "Content Title",
-            base_path: "/#{base_path}",
-            content_id: 'content-id',
-            first_published_at: "2018-07-17T10:35:59.000Z",
-            public_updated_at: "2018-07-17T10:35:57.000Z",
-            publishing_app: publishing_app,
-            document_type: "news_story",
-            primary_organisation_title: "The Ministry",
-            historical: false,
-            withdrawn: false,
-            parent_content_id: ''
-          },
-          time_period: {
-            to: to,
-            from: from
-          },
-          time_series_metrics: [
-            {
-              name: "upviews",
-              total: 6000,
-              time_series: [
-                { "date" => day1, "value" => 1000 },
-                { "date" => day2, "value" => 2000 },
-                { "date" => day3, "value" => 3000 }
-              ]
-            },
-            {
-              name: "pviews",
-              total: 60000,
-              time_series: [
-                { "date" => day1, "value" => 10000 },
-                { "date" => day2, "value" => 20000 },
-                { "date" => day3, "value" => 30000 }
-              ]
-            },
-            {
-              name: "searches",
-              total: 243,
-              time_series: [
-                { "date" => day1, "value" => 80 },
-                { "date" => day2, "value" => 80 },
-                { "date" => day3, "value" => 83 }
-              ]
-            },
-            {
-              name: "feedex",
-              total: 63,
-              time_series: [
-                { "date" => day1, "value" => 20 },
-                { "date" => day2, "value" => 21 },
-                { "date" => day3, "value" => 22 }
-              ]
-            },
-            {
-              name: "satisfaction",
-              total: 0.9,
-              time_series: [
-                { "date" => day1, "value" => 1.0000 },
-                { "date" => day2, "value" => 0.9000 },
-                { "date" => day3, "value" => 0.80000 }
-              ]
-            },
-            {
-              "name": "useful_yes",
-              "total": 200,
-              "time_series": []
-            },
-            {
-              "name": "useful_no",
-              "total": 500,
-              "time_series": []
-            }
-          ],
-          edition_metrics: [
-            {
-              name: "words",
-              value: 200
-            },
-            {
-              name: "pdf_count",
-              value: 3
-            }
-          ]
-        }
-      end
-
-      def default_previous_single_page_payload(base_path, from, to)
-        day1 = from.to_s
-        day2 = (from + 1.day).to_s
-        day3 = to.to_s
-        {
-          metadata: {
-            title: "Content Title",
-            base_path: "/#{base_path}",
-            first_published_at: "2018-07-17T10:35:59.000Z",
-            public_updated_at: "2018-07-17T10:35:57.000Z",
-            publishing_app: "publisher",
-            document_type: "news_story",
-            primary_organisation_title: "The Ministry",
-            historical: false,
-            withdrawn: false
-          },
-          time_period: {
-            to: to,
-            from: from
-          },
-          time_series_metrics: [
-            {
-              name: "upviews",
-              total: 1000,
-              time_series: [
-                { "date" => day1, "value" => 1000 },
-                { "date" => day2, "value" => 2000 },
-                { "date" => day3, "value" => 7000 }
-              ]
-            },
-            {
-              name: "pviews",
-              total: 30000,
-              time_series: [
-                { "date" => day1, "value" => 5 },
-                { "date" => day2, "value" => 5 },
-                { "date" => day3, "value" => 20 }
-              ]
-            },
-            {
-              name: "searches",
-              total: 48,
-              time_series: [
-                { "date" => day1, "value" => 16 },
-                { "date" => day2, "value" => 16 },
-                { "date" => day3, "value" => 16 }
-              ]
-            },
-            {
-              name: "feedex",
-              total: 60,
-              time_series: [
-                { "date" => day1, "value" => 20 },
-                { "date" => day2, "value" => 20 },
-                { "date" => day3, "value" => 20 }
-              ]
-            },
-            {
-              name: "satisfaction",
-              total: 0.6,
-              time_series: [
-                { "date" => day1, "value" => 0.6000 },
-                { "date" => day2, "value" => 0.6000 },
-                { "date" => day3, "value" => 0.6000 }
-              ]
-            },
-            {
-              "name": "useful_yes",
-              "total": 600,
-              "time_series": []
-            },
-            {
-              "name": "useful_no",
-              "total": 400,
-              "time_series": []
-            }
-          ],
-          edition_metrics: [
-            {
-              name: "words",
-              value: 300
-            },
-            {
-              name: "pdf_count",
-              value: 5
-            }
-          ]
-        }
-      end
-
-      def default_organisations
-        [
-          {
-            name: 'org',
-            id: 'org-id',
-            acronym: 'OI',
-          },
-          {
-            name: 'another org',
-            id: 'another-org-id',
-          },
-          {
-            name: 'Users Org',
-            id: 'users-org-id',
-            acronym: 'UOI',
-          }
-        ]
-      end
-
-      def default_document_types
-        [
-          {
-            id: 'case_study',
-            name: 'Case study'
-          },
-          {
-            id: 'guide',
-            name: 'Guide'
-          },
-          {
-            id: 'news_story',
-            name: 'News story'
-          },
-          {
-            id: 'html_publication',
-            name: 'HTML publication'
-          }
-        ]
       end
     end
   end

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -3,6 +3,8 @@ require 'gds_api/content_data_api'
 module GdsApi
   module TestHelpers
     module ContentDataApi
+      CONTENT_DATA_API_ENDPOINT = Plek.current.find('content-performance-manager')
+
       def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall')
         dates = build(:date_range, time_period)
         prev_dates = dates.previous
@@ -30,10 +32,10 @@ module GdsApi
           payload: previous_period_data
         )
       end
-
+      
       def content_data_api_does_not_have_base_path(base_path:, from:, to:)
         query = query(from: from, to: to)
-        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}#{query}"
         stub_request(:get, url).to_return(status: 404, body: { some: 'error' }.to_json)
       end
 
@@ -57,13 +59,13 @@ module GdsApi
           }.to_json
 
           params_plus_page = params.merge(page: page)
-          url = "#{content_data_api_endpoint}/content#{query(params_plus_page)}"
+          url = "#{CONTENT_DATA_API_ENDPOINT}/content#{query(params_plus_page)}"
           stub_request(:get, url).to_return(status: 200, body: body)
 
           if page == 1
             # The 0'th page can be requested without specifying a page
             # number, so stub that request as well
-            url = "#{content_data_api_endpoint}/content#{query(params)}"
+            url = "#{CONTENT_DATA_API_ENDPOINT}/content#{query(params)}"
             stub_request(:get, url).to_return(status: 200, body: body)
           end
         end
@@ -82,7 +84,7 @@ module GdsApi
           total_pages: 0,
           page: 1
         }.to_json
-        url = "#{content_data_api_endpoint}/content#{query(params)}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/content#{query(params)}"
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
@@ -97,45 +99,41 @@ module GdsApi
           total_pages: 3000,
           page: page
         }.to_json
-        url = "#{content_data_api_endpoint}/content#{query(params)}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/content#{query(params)}"
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_has_single_page(base_path:, from:, to:, payload: nil, publishing_app: 'whitehall')
         query = query(from: from, to: to)
-        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}#{query}"
         body = payload || default_single_page_payload(base_path, from, to, publishing_app)
         stub_request(:get, url).to_return(status: 200, body: body.to_json)
       end
 
       def content_data_api_has_single_page_missing_data(base_path:, from:, to:)
         query = query(from: from, to: to)
-        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}#{query}"
         body = no_data_single_page_payload(base_path, from, to).to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_has_single_page_with_nil_values(base_path:, from:, to:)
         query = query(from: from, to: to)
-        url = "#{content_data_api_endpoint}/single_page/#{base_path}#{query}"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}#{query}"
         body = nil_values_in_single_page_payload(base_path, from, to).to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_has_orgs
-        url = "#{content_data_api_endpoint}/api/v1/organisations"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"
         body = { organisations: default_organisations }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_has_document_types
-        url = "#{content_data_api_endpoint}/api/v1/document_types"
+        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/document_types"
         body = { document_types: default_document_types }.to_json
         stub_request(:get, url).to_return(status: 200, body: body)
-      end
-
-      def content_data_api_endpoint
-        Plek.current.find('content-performance-manager').to_s
       end
 
       def query(params)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -5,32 +5,16 @@ module GdsApi
     module ContentDataApi
       CONTENT_DATA_API_ENDPOINT = Plek.current.find('content-performance-manager')
 
-      def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall')
-        dates = build(:date_range, time_period)
-        prev_dates = dates.previous
+      def content_data_api_has_orgs
+        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"
+        body = { organisations: default_organisations }.to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
+      end
 
-        current_period_data = default_single_page_payload(
-          base_path, dates.from, dates.to
-        )
-        previous_period_data = default_previous_single_page_payload(
-          base_path, prev_dates.from, prev_dates.to
-        )
-
-        current_period_data[:metadata][:publishing_app] = publishing_app
-        previous_period_data[:metadata][:publishing_app] = publishing_app
-
-        content_data_api_has_single_page(
-          base_path: base_path,
-          from: dates.from,
-          to: dates.to,
-          payload: current_period_data
-        )
-        content_data_api_has_single_page(
-          base_path: base_path,
-          from: prev_dates.from,
-          to: prev_dates.to,
-          payload: previous_period_data
-        )
+      def content_data_api_has_document_types
+        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/document_types"
+        body = { document_types: default_document_types }.to_json
+        stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def content_data_api_does_not_have_base_path(base_path:, from:, to:)
@@ -132,18 +116,6 @@ module GdsApi
         stub_request(:get, url)
           .with(query: { from: from, to: to })
           .to_return(status: 200, body: body)
-      end
-
-      def content_data_api_has_orgs
-        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"
-        body = { organisations: default_organisations }.to_json
-        stub_request(:get, url).to_return(status: 200, body: body)
-      end
-
-      def content_data_api_has_document_types
-        url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/document_types"
-        body = { document_types: default_document_types }.to_json
-        stub_request(:get, url).to_return(status: 200, body: body)
       end
 
       def default_single_page_payload(base_path, from, to, publishing_app = 'whitehall')

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -75,22 +75,6 @@ module GdsApi
           .to_return(status: 200, body: body.to_json)
       end
 
-      def content_data_api_has_single_page_missing_data(base_path:, from:, to:)
-        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}"
-        body = no_data_single_page_payload(base_path, from, to).to_json
-        stub_request(:get, url)
-          .with(query: { from: from, to: to })
-          .to_return(status: 200, body: body)
-      end
-
-      def content_data_api_has_single_page_with_nil_values(base_path:, from:, to:)
-        url = "#{CONTENT_DATA_API_ENDPOINT}/single_page/#{base_path}"
-        body = nil_values_in_single_page_payload(base_path, from, to).to_json
-        stub_request(:get, url)
-          .with(query: { from: from, to: to })
-          .to_return(status: 200, body: body)
-      end
-
       def default_single_page_payload(base_path, from, to, publishing_app = 'whitehall')
         day1 = from.to_s
         day2 = (from + 1.day).to_s
@@ -269,66 +253,6 @@ module GdsApi
               name: "pdf_count",
               value: 5
             }
-          ]
-        }
-      end
-
-      def no_data_single_page_payload(base_path, from, to)
-        {
-          metadata: {
-            title: "Content Title",
-            base_path: "/#{base_path}",
-            first_published_at: "2018-07-17T10:35:59.000Z",
-            public_updated_at: "2018-07-17T10:35:57.000Z",
-            publishing_app: "publisher",
-            document_type: "news_story",
-            primary_organisation_title: "The Ministry",
-            historical: false,
-            withdrawn: false
-          },
-          time_period: { to: to, from: from },
-          time_series_metrics: [
-            { name: "upviews", total: 0, time_series: [] },
-            { name: "pviews", total: 0, time_series: [] },
-            { name: "searches", total: 0, time_series: [] },
-            { name: "feedex", total: 0, time_series: [] },
-            { name: "satisfaction", total: 0.0, time_series: [] },
-            { name: "useful_yes", total: 0, time_series: [] },
-            { name: "useful_no", total: 0, time_series: [] }
-          ],
-          edition_metrics: [
-            { name: "words", value: 0 },
-            { name: "pdf_count", value: 0 }
-          ]
-        }
-      end
-
-      def nil_values_in_single_page_payload(base_path, from, to)
-        {
-          metadata: {
-            title: "Content Title",
-            base_path: "/#{base_path}",
-            first_published_at: "2018-07-17T10:35:59.000Z",
-            public_updated_at: "2018-07-17T10:35:57.000Z",
-            publishing_app: "publisher",
-            document_type: "news_story",
-            primary_organisation_title: "The Ministry",
-            historical: false,
-            withdrawn: false
-          },
-          time_period: { to: to, from: from },
-          time_series_metrics: [
-            { name: "upviews", total: nil, time_series: [] },
-            { name: "pviews", total: nil, time_series: [] },
-            { name: "searches", total: nil, time_series: [] },
-            { name: "feedex", total: nil, time_series: [] },
-            { name: "satisfaction", total: nil, time_series: [] },
-            { name: "useful_yes", total: nil, time_series: [] },
-            { name: "useful_no", total: nil, time_series: [] }
-          ],
-          edition_metrics: [
-            { name: "words", value: nil },
-            { name: "pdf_count", value: nil }
           ]
         }
       end

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -1,16 +1,18 @@
 require 'support/content_data_api'
+require 'support/response_helpers'
 
 module RequestStubs
   include GdsApi::TestHelpers::ContentDataApi
+  include GdsApi::TestHelpers::ResponseHelpers
 
   def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall', content_item_missing: false, current_data_missing: false, comparision_data_missing: false)
     dates = build(:date_range, time_period)
     prev_dates = dates.previous
 
-    current_period_data = default_single_page_payload(
+    current_period_data = single_page_response(
       base_path, dates.from, dates.to
     )
-    previous_period_data = default_previous_single_page_payload(
+    previous_period_data = older_single_page_response(
       base_path, prev_dates.from, prev_dates.to
     )
 

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -30,4 +30,28 @@ module RequestStubs
       payload: previous_period_data
     )
   end
+
+  def stub_content_page(time_period:, organisation_id: nil, document_type: nil, search_terms: nil, items:)
+    content_data_api_has_orgs
+    content_data_api_has_document_types
+
+    content_data_api_has_content_items(
+      date_range: time_period,
+      organisation_id: organisation_id,
+      document_type: document_type,
+      search_term: search_terms,
+      items: items
+    )
+  end
+
+  def stub_content_page_csv_download(time_period:, organisation_id: nil, document_type: nil, search_terms: nil, items:)
+    content_data_api_has_content_items(
+      date_range: time_period,
+      organisation_id: organisation_id,
+      document_type: document_type,
+      search_term: search_terms,
+      items: items,
+      page_size: 5000
+    )
+  end
 end

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -1,0 +1,33 @@
+require 'support/content_data_api'
+
+module RequestStubs
+  include GdsApi::TestHelpers::ContentDataApi
+
+  def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall')
+    dates = build(:date_range, time_period)
+    prev_dates = dates.previous
+
+    current_period_data = default_single_page_payload(
+      base_path, dates.from, dates.to
+    )
+    previous_period_data = default_previous_single_page_payload(
+      base_path, prev_dates.from, prev_dates.to
+    )
+
+    current_period_data[:metadata][:publishing_app] = publishing_app
+    previous_period_data[:metadata][:publishing_app] = publishing_app
+
+    content_data_api_has_single_page(
+      base_path: base_path,
+      from: dates.from,
+      to: dates.to,
+      payload: current_period_data
+    )
+    content_data_api_has_single_page(
+      base_path: base_path,
+      from: prev_dates.from,
+      to: prev_dates.to,
+      payload: previous_period_data
+    )
+  end
+end

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -1,0 +1,233 @@
+require 'gds_api/content_data_api'
+
+module GdsApi
+  module TestHelpers
+    module ResponseHelpers
+      def single_page_response(base_path, from, to, publishing_app = 'whitehall')
+        day1 = from.to_s
+        day2 = (from + 1.day).to_s
+        day3 = to.to_s
+        {
+          metadata: {
+            title: "Content Title",
+            base_path: "/#{base_path}",
+            content_id: 'content-id',
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: publishing_app,
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
+            historical: false,
+            withdrawn: false,
+            parent_content_id: ''
+          },
+          time_period: {
+            to: to,
+            from: from
+          },
+          time_series_metrics: [
+            {
+              name: "upviews",
+              total: 6000,
+              time_series: [
+                { "date" => day1, "value" => 1000 },
+                { "date" => day2, "value" => 2000 },
+                { "date" => day3, "value" => 3000 }
+              ]
+            },
+            {
+              name: "pviews",
+              total: 60000,
+              time_series: [
+                { "date" => day1, "value" => 10000 },
+                { "date" => day2, "value" => 20000 },
+                { "date" => day3, "value" => 30000 }
+              ]
+            },
+            {
+              name: "searches",
+              total: 243,
+              time_series: [
+                { "date" => day1, "value" => 80 },
+                { "date" => day2, "value" => 80 },
+                { "date" => day3, "value" => 83 }
+              ]
+            },
+            {
+              name: "feedex",
+              total: 63,
+              time_series: [
+                { "date" => day1, "value" => 20 },
+                { "date" => day2, "value" => 21 },
+                { "date" => day3, "value" => 22 }
+              ]
+            },
+            {
+              name: "satisfaction",
+              total: 0.9,
+              time_series: [
+                { "date" => day1, "value" => 1.0000 },
+                { "date" => day2, "value" => 0.9000 },
+                { "date" => day3, "value" => 0.80000 }
+              ]
+            },
+            {
+              "name": "useful_yes",
+              "total": 200,
+              "time_series": []
+            },
+            {
+              "name": "useful_no",
+              "total": 500,
+              "time_series": []
+            }
+          ],
+          edition_metrics: [
+            {
+              name: "words",
+              value: 200
+            },
+            {
+              name: "pdf_count",
+              value: 3
+            }
+          ]
+        }
+      end
+
+      def older_single_page_response(base_path, from, to)
+        day1 = from.to_s
+        day2 = (from + 1.day).to_s
+        day3 = to.to_s
+        {
+          metadata: {
+            title: "Content Title",
+            base_path: "/#{base_path}",
+            first_published_at: "2018-07-17T10:35:59.000Z",
+            public_updated_at: "2018-07-17T10:35:57.000Z",
+            publishing_app: "publisher",
+            document_type: "news_story",
+            primary_organisation_title: "The Ministry",
+            historical: false,
+            withdrawn: false
+          },
+          time_period: {
+            to: to,
+            from: from
+          },
+          time_series_metrics: [
+            {
+              name: "upviews",
+              total: 1000,
+              time_series: [
+                { "date" => day1, "value" => 1000 },
+                { "date" => day2, "value" => 2000 },
+                { "date" => day3, "value" => 7000 }
+              ]
+            },
+            {
+              name: "pviews",
+              total: 30000,
+              time_series: [
+                { "date" => day1, "value" => 5 },
+                { "date" => day2, "value" => 5 },
+                { "date" => day3, "value" => 20 }
+              ]
+            },
+            {
+              name: "searches",
+              total: 48,
+              time_series: [
+                { "date" => day1, "value" => 16 },
+                { "date" => day2, "value" => 16 },
+                { "date" => day3, "value" => 16 }
+              ]
+            },
+            {
+              name: "feedex",
+              total: 60,
+              time_series: [
+                { "date" => day1, "value" => 20 },
+                { "date" => day2, "value" => 20 },
+                { "date" => day3, "value" => 20 }
+              ]
+            },
+            {
+              name: "satisfaction",
+              total: 0.6,
+              time_series: [
+                { "date" => day1, "value" => 0.6000 },
+                { "date" => day2, "value" => 0.6000 },
+                { "date" => day3, "value" => 0.6000 }
+              ]
+            },
+            {
+              "name": "useful_yes",
+              "total": 600,
+              "time_series": []
+            },
+            {
+              "name": "useful_no",
+              "total": 400,
+              "time_series": []
+            }
+          ],
+          edition_metrics: [
+            {
+              name: "words",
+              value: 300
+            },
+            {
+              name: "pdf_count",
+              value: 5
+            }
+          ]
+        }
+      end
+
+      def organisations
+        {
+          organisations: [
+            {
+              name: 'org',
+              id: 'org-id',
+              acronym: 'OI',
+            },
+            {
+              name: 'another org',
+              id: 'another-org-id',
+            },
+            {
+              name: 'Users Org',
+              id: 'users-org-id',
+              acronym: 'UOI',
+            }
+          ]
+        }
+      end
+
+      def document_types
+        {
+          document_types: [
+            {
+              id: 'case_study',
+              name: 'Case study'
+            },
+            {
+              id: 'guide',
+              name: 'Guide'
+            },
+            {
+              id: 'news_story',
+              name: 'News story'
+            },
+            {
+              id: 'html_publication',
+              name: 'HTML publication'
+            }
+          ]
+        }
+      end
+    end
+  end
+end

--- a/spec/support/shared/metadata.rb
+++ b/spec/support/shared/metadata.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'Metadata presentation' do
-  include GdsApi::TestHelpers::ContentDataApi
+  include GdsApi::TestHelpers::ResponseHelpers
 
   around do |example|
     Timecop.freeze Date.new(2018, 12, 25) do
@@ -8,8 +8,8 @@ RSpec.shared_examples 'Metadata presentation' do
   end
 
   let(:date_range) { build(:date_range, :past_30_days) }
-  let(:current_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
-  let(:previous_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
+  let(:current_period_data) { single_page_response('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
+  let(:previous_period_data) { single_page_response('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
 
   subject do
     SingleContentItemPresenter.new(current_period_data, previous_period_data, date_range)

--- a/spec/support/shared/trend_percentages.rb
+++ b/spec/support/shared/trend_percentages.rb
@@ -1,5 +1,5 @@
 RSpec.shared_examples 'Trend percentages presentation' do
-  include GdsApi::TestHelpers::ContentDataApi
+  include GdsApi::TestHelpers::ResponseHelpers
 
   around do |example|
     Timecop.freeze Date.new(2018, 12, 25) do
@@ -8,8 +8,8 @@ RSpec.shared_examples 'Trend percentages presentation' do
   end
 
   let(:date_range) { build(:date_range, :past_30_days) }
-  let(:current_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
-  let(:previous_period_data) { default_single_page_payload('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
+  let(:current_period_data) { single_page_response('the/base/path', Date.new(2018, 11, 25), Date.new(2018, 12, 24)) }
+  let(:previous_period_data) { single_page_response('the/base/path', Date.new(2018, 10, 26), Date.new(2018, 11, 24)) }
 
   subject do
     SingleContentItemPresenter.new(current_period_data, previous_period_data, date_range)


### PR DESCRIPTION
# What
This refactors the request stubbing for content performance manager. GdsApi::TestHelpers::ContentDataApi module now only contains methods concerned with individual requests that can be made to the content-performance-manager. A new module RequestStubs contains methods to stub out all requests per each page in content-data-admin. All feature test should now use RequestStubs module instead of the ContentDataApi. Example responses have also been separated out into a separate module ResponseHelpers.

# Why
This simplifies the request stubbing in our feature tests. Will make it easier to make changes to the requests made by each pages in content-data-admin.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.