### PR TITLE
Add reading time to csv

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -51,6 +51,9 @@ class ContentItemsCSVPresenter
       end,
       I18n.t('metrics.words.short_title') => raw_field(:word_count),
       I18n.t('metrics.pdf_count.short_title') => raw_field(:pdf_count),
+      I18n.t('metrics.reading_time.short_title') => lambda do |result_row|
+        format_duration(result_row[:reading_time])
+      end
     }
 
     Enumerator.new do |yielder|

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe '/content' do
         document_type: 'homepage',
         satisfaction: 0.85,
         satisfaction_score_responses: 2050,
-        searches: 1220
+        searches: 1220,
+        reading_time: 50
       },
       {
         base_path: '/path/1',
@@ -22,7 +23,8 @@ RSpec.describe '/content' do
         document_type: 'news_story',
         satisfaction: 0.81301,
         satisfaction_score_responses: 250,
-        searches: 220
+        searches: 220,
+        reading_time: 50
       },
       {
         base_path: '/path/2',
@@ -32,7 +34,8 @@ RSpec.describe '/content' do
         document_type: 'guide',
         satisfaction: 0.68,
         satisfaction_score_responses: 42,
-        searches: 12
+        searches: 12,
+        reading_time: 50
       }
     ]
   end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe ContentItemsCSVPresenter do
         searches: 14,
         feedex: 24,
         word_count: 50,
+        reading_time: 50,
         pdf_count: 0
       },
       {
@@ -49,6 +50,7 @@ RSpec.describe ContentItemsCSVPresenter do
         searches: 14,
         feedex: 24,
         word_count: 100,
+        reading_time: 100,
         pdf_count: 3
       }
     ]
@@ -88,6 +90,7 @@ RSpec.describe ContentItemsCSVPresenter do
         'Link to feedback comments',
         I18n.t('metrics.words.short_title'),
         I18n.t('metrics.pdf_count.short_title'),
+        I18n.t('metrics.reading_time.short_title')
       ]
 
       expected_headers.each do |header_name|
@@ -168,6 +171,10 @@ RSpec.describe ContentItemsCSVPresenter do
 
       it 'has pdf count' do
         expect(subject[16]).to eq('0')
+      end
+
+      it 'has reading time' do
+        expect(subject[17]).to eq('0h 50m')
       end
     end
   end


### PR DESCRIPTION
# What
Adding reading time column to the CSV of search results. Formatted in the `0h 0m` style.

# Why
Allows this data to be exported.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.