### PR TITLE
Fix reading time for no words

### DIFF
--- a/app/helpers/metrics_formatter_helper.rb
+++ b/app/helpers/metrics_formatter_helper.rb
@@ -11,6 +11,8 @@ module MetricsFormatterHelper
   end
 
   def format_duration(minutes)
+    return nil unless minutes
+
     dur = ActiveSupport::Duration.build(minutes * 60)
     Time.at(dur).utc.to_s(:reading_time)
   end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe '/metrics/base/path', type: :feature do
     end
   end
 
+  context 'when the page has no edition metrics' do
+    before do
+      GDS::SSO.test_user = build(:user)
+      stub_metrics_page(base_path: nil, time_period: :last_month, edition_metrics_missing: true)
+      visit '/metrics?date_range=last-month'
+    end
+
+    it 'renders the page without errors' do
+      expect(page.status_code).to eq(200)
+    end
+
+    it 'does not display reading time' do
+      label = 'About reading time'
+      expect(page).to_not have_selector("metric-summary__reading-time .govuk-details__summary-text", text: label)
+    end
+  end
+
   context 'successful request' do
     before do
       GDS::SSO.test_user = build(:user)

--- a/spec/helpers/metrics_formatter_helper_spec.rb
+++ b/spec/helpers/metrics_formatter_helper_spec.rb
@@ -33,5 +33,9 @@ RSpec.describe MetricsFormatterHelper do
     it 'formats duration for reading time of several hours and minutes' do
       expect(format_duration(150)).to eq('2h 30m')
     end
+
+    it 'return nil if minutes is nil' do
+      expect(format_duration(nil)).to be_nil
+    end
   end
 end

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -5,7 +5,7 @@ module RequestStubs
   include GdsApi::TestHelpers::ContentDataApi
   include GdsApi::TestHelpers::ResponseHelpers
 
-  def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall', content_item_missing: false, current_data_missing: false, comparision_data_missing: false)
+  def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall', content_item_missing: false, current_data_missing: false, comparision_data_missing: false, edition_metrics_missing: false)
     dates = build(:date_range, time_period)
     prev_dates = dates.previous
 
@@ -20,11 +20,17 @@ module RequestStubs
     previous_period_data[:metadata][:publishing_app] = publishing_app
 
     if current_data_missing
-      set_content_item_metrics_to_missing(current_period_data)
+      set_time_series_metrics_to_missing(current_period_data)
+      set_edition_metrics_to_missing(current_period_data)
     end
 
     if comparision_data_missing
-      set_content_item_metrics_to_missing(previous_period_data)
+      set_time_series_metrics_to_missing(previous_period_data)
+      set_edition_metrics_to_missing(current_period_data)
+    end
+
+    if edition_metrics_missing
+      set_edition_metrics_to_missing(current_period_data)
     end
 
     if content_item_missing
@@ -71,12 +77,14 @@ module RequestStubs
     )
   end
 
-  def set_content_item_metrics_to_missing(response)
+  def set_time_series_metrics_to_missing(response)
     response[:time_series_metrics].each do |metric|
       metric[:total] = nil
       metric[:time_series] = []
     end
+  end
 
+  def set_edition_metrics_to_missing(response)
     response[:edition_metrics].each do |metric|
       metric[:value] = nil
     end


### PR DESCRIPTION
# What
For some pages that do not have a word count, such as the Home page, we
are seeing a 500 error. This fix will trigger the component to not
render (as it does for no word count value).

# Why
Bug

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
https://content-data-admin.staging.publishing.service.gov.uk/metrics?date_range=past-30-days
![screenshot at feb 11 2-09-23 pm](https://user-images.githubusercontent.com/424772/52568445-a7b74c80-2e06-11e9-8e08-09e3a64efbfb.png)


## After
![screenshot at feb 11 2-08-26 pm](https://user-images.githubusercontent.com/424772/52568383-848c9d00-2e06-11e9-8cb9-4c5e2b84d3b1.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
