### PR TITLE
Add HTML data attributes for GTM

### DIFF
--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -10,7 +10,7 @@
 %>
 <% if name && figure && context %>
   <div class="app-c-info-metric govuk-body">
-    <h3 class="app-c-info-metric__heading"><%= name %></h3>
+    <h3 class="app-c-info-metric__heading" data-gtm-id="metric-section-heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
     <% if about %>
       <div class="app-c-info-metric__about govuk-body-s">

--- a/app/views/components/_time-select.html.erb
+++ b/app/views/components/_time-select.html.erb
@@ -15,7 +15,7 @@
   end
 %>
 <% if dates.length > 1 && current_selection %>
-  <div class="app-c-time-select <% if compact %> app-c-time-select--compact<% end %>">
+  <div class="app-c-time-select <% if compact %> app-c-time-select--compact<% end %>" data-gtm-id="time-period-options">
     <%if compact %>
       <h2 class="govuk-heading-s app-c-time-select__heading"><%= t '.title_compact', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
     <% else %>

--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -1,3 +1,8 @@
-<%= link_to item.title, metrics_path(item.base_path, date_range: date_range), data: { gtm: item.raw_document_type } %>
+<%= link_to item.title,
+  metrics_path(item.base_path, date_range: date_range),
+  data: {
+    'gtm-id': 'content-item-link',
+    'gtm-item-document-type': item.raw_document_type
+  } %>
 <br>
 <span class="base-path">/<%= item.base_path %></span>

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -5,9 +5,9 @@
             <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
             <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
         <% end %>
-        <span class="table-header__param" data-gtm-pagination-total-results="<%= pagination.total_results %>"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
+        <span class="table-header__param" ><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
     <% else %>
-        <span class="table-header__param" data-gtm-pagination-total-results="0"><%= I18n.t('no_matching_results') %></span>
+        <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>
     <% if filter.search_terms? %>
         for "<span class="table-header__param"><%= filter.search_terms %></span>"

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -13,7 +13,11 @@
 
 
       <div class="filter-form">
-        <%= form_tag content_path, method: 'get', name: 'organisation-picker', id: 'filter-form' do %>
+        <%= form_tag content_path,
+          method: 'get',
+          name: 'organisation-picker',
+          id: 'filter-form',
+          data: { 'gtm-id': 'filters-form' } do %>
           <input type="hidden" name="submitted" value="true" >
           <%= render "components/time-select", {
             current_selection: @presenter.time_period,
@@ -60,13 +64,12 @@
           <% end %>
         </div>
 
-            <p><a href="/content" class="govuk-link govuk-body-s">Clear all filters</a></p>
+            <p><a href="/content" class="govuk-link govuk-body-s" data-gtm-id="clear-filters">Clear all filters</a></p>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
             <p>
               <a href="<%= content_path(@presenter.search_parameters.merge(format: :csv)) %>"
-                 class="govuk-link govuk-body-s download-link"
-              >
+                 class="govuk-link govuk-body-s download-link" data-gtm-id="csv-download-link">
                 Download all data in CSV format
               </a>
             </p>
@@ -74,25 +77,37 @@
     </div>
     <div class="govuk-grid-column-three-quarters">
       <div class="table-wrapper">
-        <table class="govuk-table">
+        <table class="govuk-table"
+          data-gtm-total-results="<%= @presenter.pagination.total_results %>"
+          data-gtm-page="<%= @presenter.pagination.page %>"
+          >
           <caption class="govuk-table__caption">
             <%= render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter) %>
           </caption>
-          <thead class="govuk-table__head">
+          <thead class="govuk-table__head" data-gtm-id="table-header">
             <tr class="govuk-table__row">
-              <th class="govuk-table__header" scope="col">Page title</th>
-              <th class="govuk-table__header" scope="col">Content type</th>
-              <th class="govuk-table__header" scope="col">
+              <th class="govuk-table__header" scope="col" data-gtm-id="title-column">Page title</th>
+              <th class="govuk-table__header" scope="col" data-gtm-id="document-type-column">Content type</th>
+              <th class="govuk-table__header" scope="col" data-gtm-id="upviews-column">
                 Unique pageviews<br>
-                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.upviews.summary"}") %>
+                <%= image_tag 'question_mark_default.svg',
+                  alt: 'Help',
+                  title: "#{t "metrics.upviews.summary"}",
+                  data: { 'gtm-id': 'help-icon' } %>
               </th>
-              <th class="govuk-table__header" scope="col">
+              <th class="govuk-table__header" scope="col" data-gtm-id="satisfaction-column">
                 User satisfaction score<br>
-                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.satisfaction.summary"}") %>
+                <%= image_tag 'question_mark_default.svg',
+                  alt: 'Help',
+                  title: "#{t "metrics.satisfaction.summary"}",
+                  data: { 'gtm-id': 'help-icon' } %>
               </th>
-              <th class="govuk-table__header" scope="col">
+              <th class="govuk-table__header" scope="col" data-gtm-id="searches-column">
                 Searches from page<br>
-                <%= image_tag('question_mark_default.svg', alt: 'Help', title: "#{t "metrics.searches.summary"}") %>
+                <%= image_tag 'question_mark_default.svg',
+                  alt: 'Help',
+                  title: "#{t "metrics.searches.summary"}",
+                  data: { 'gtm-id': 'help-icon' } %>
               </th>
             </tr>
           </thead>
@@ -119,6 +134,8 @@
    </table>
 
         </div>
-        <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
+        <div data-gtm-id="pagination-links">
+          <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
+        </div>
     </div>
 </div>

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -29,7 +29,7 @@
   end
 %>
 <div class="govuk-grid-row">
-  <div class="metric">
+  <div class="metric" data-gtm-id="metric-summary">
     <%= render "components/info-metric", options %>
   </div>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,14 +1,14 @@
 <% content_for :title, t('.browser_title', content_title: @performance_data.title) %>
 <% content_for :local_nav do %>
   <div class="local-nav govuk-grid-column-one-quarter">
-    <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm="back-link">Search</a>
+    <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
   </div>
 <% end %>
 <% current_selection = @performance_data.date_range.time_period || 'past-30-days' %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <span class="govuk-caption-xl"><%= t ".page_kicker" %></span>
+    <span class="govuk-caption-xl" data-gtm-id="page-kicker"><%= t ".page_kicker" %></span>
   </div>
 </div>
 <div class="govuk-grid-row">
@@ -42,7 +42,11 @@
       } %>
   </div>
 </div>
-<%= form_for("date", url: "/metrics#{@performance_data.base_path}", method: :get, html: { id: 'filter-form' }) do %>
+<%= form_for "date",
+  url: "/metrics#{@performance_data.base_path}",
+  method: :get,
+  html: { id: 'filter-form' },
+  data: { 'gtm-id': 'time-period-form' } do %>
   <%= render "components/time-select", {
     render_button: true,
     current_selection: current_selection,
@@ -50,7 +54,7 @@
   } %>
 <% end %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-gtm-id="glance-metrics">
   <%= render "glance_metric",
       metric_name: "upviews",
       total: @performance_data.total_upviews,

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "Results pagination" do
     end
 
     it 'has GTM data attributes' do
-      expect(page).to have_css('span[data-gtm-pagination-total-results]')
+      expect(page).to have_css('[data-gtm-total-results]')
 
-      total_results = page.find('span[data-gtm-pagination-total-results]')['data-gtm-pagination-total-results']
+      total_results = page.find('[data-gtm-total-results]')['data-gtm-total-results']
       expect(total_results).to eq('0')
     end
   end
@@ -103,9 +103,9 @@ RSpec.describe "Results pagination" do
     end
 
     it 'has GTM data attributes' do
-      expect(page).to have_css('span[data-gtm-pagination-total-results]')
+      expect(page).to have_css('[data-gtm-total-results]')
 
-      total_results = page.find('span[data-gtm-pagination-total-results]')['data-gtm-pagination-total-results']
+      total_results = page.find('[data-gtm-total-results]')['data-gtm-total-results']
       expect(total_results).to eq('102')
     end
   end

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -1,0 +1,47 @@
+RSpec.feature 'user analytics' do
+  include RequestStubs
+  before do
+    stub_content_page(time_period: 'past-30-days', organisation_id: 'all')
+    visit '/content'
+  end
+
+  scenario 'tracks clear all filters button' do
+    expect(page).to have_selector('[data-gtm-id="clear-filters"]')
+  end
+
+  scenario 'tracks filter form submit' do
+    expect(page).to have_selector('[data-gtm-id="filters-form"]')
+  end
+
+  scenario 'tracks total number of results' do
+    expect(page).to have_selector('[data-gtm-total-results]')
+  end
+
+  scenario 'tracks prev and next pagination links' do
+    expect(page).to have_selector('[data-gtm-id="pagination-links"]')
+  end
+
+  scenario 'tracks content item page links' do
+    expect(page).to have_selector('[data-gtm-id="content-item-link"][data-gtm-item-document-type]')
+  end
+
+  help_icon_columns = %w(upviews satisfaction searches)
+
+  help_icon_columns.each do |column|
+    scenario "tracks help icon for #{column} in table headers" do
+      expect(page).to have_selector("[data-gtm-id=\"#{column}-column\"] > [data-gtm-id=\"help-icon\"]")
+    end
+  end
+
+  scenario 'tracks table header' do
+    expect(page).to have_selector('[data-gtm-id="table-header"]')
+  end
+
+  scenario 'tracks CSV download link' do
+    expect(page).to have_selector('[data-gtm-id="csv-download-link"]')
+  end
+
+  scenario 'tracks time period reveal' do
+    expect(page).to have_selector('[data-gtm-id="time-period-options"] summary')
+  end
+end

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -1,0 +1,31 @@
+RSpec.feature 'user analytics' do
+  include RequestStubs
+  before do
+    stub_metrics_page(base_path: nil, time_period: :past_30_days)
+    visit '/metrics?date_range=past-30-days'
+  end
+
+  scenario 'tracks back link button' do
+    expect(page).to have_selector('[data-gtm-id="back-link"]')
+  end
+
+  scenario 'tracks the top of the page visability' do
+    expect(page).to have_selector('[data-gtm-id="page-kicker"]')
+  end
+
+  scenario 'tracks time period submit' do
+    expect(page).to have_selector('[data-gtm-id="time-period-form"]')
+  end
+
+  scenario 'tracks glance metrics section' do
+    expect(page).to have_selector('[data-gtm-id="glance-metrics"]')
+  end
+
+  scenario 'tracks metric section headings' do
+    expect(page).to have_selector('[data-gtm-id="metric-section-heading"]')
+  end
+
+  scenario 'tracks metric "about this data" reveal' do
+    expect(page).to have_selector('[data-gtm-id="metric-summary"] summary')
+  end
+end

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -53,9 +53,11 @@ module RequestStubs
     end
   end
 
-  def stub_content_page(time_period:, organisation_id: nil, document_type: nil, search_terms: nil, items:)
+  def stub_content_page(time_period:, organisation_id: nil, document_type: nil, search_terms: nil, items: nil)
     content_data_api_has_orgs
     content_data_api_has_document_types
+
+    items = content_response[:results] unless items != nil
 
     content_data_api_has_content_items(
       date_range: time_period,

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -3,6 +3,65 @@ require 'gds_api/content_data_api'
 module GdsApi
   module TestHelpers
     module ResponseHelpers
+      def content_response
+        {
+          total_results: 3,
+          page: 1,
+          total_pages: 1,
+          page_size: 100,
+          results: [
+            {
+              base_path: '/',
+              title: 'GOV.UK homepage',
+              organisation_id: 'org-id',
+              upviews: 1_233_018,
+              document_type: 'homepage',
+              satisfaction: 0.85,
+              satisfaction_score_responses: 2050,
+              searches: 1220,
+              pviews: 8373274,
+              feedex: 137,
+              useful_yes: 1050,
+              useful_no: 2334,
+              pdf_count: 0,
+              word_count: 0
+            },
+            {
+              base_path: '/path/1',
+              title: 'The title',
+              organisation_id: 'org-id',
+              upviews: 233_018,
+              document_type: 'news_story',
+              satisfaction: 0.81301,
+              satisfaction_score_responses: 250,
+              searches: 220,
+              pviews: 179_926,
+              feedex: 180,
+              useful_yes: 2837,
+              useful_no: 7495,
+              pdf_count: 0,
+              word_count: 0
+            },
+            {
+              base_path: '/path/2',
+              title: 'Another title',
+              organisation_id: 'org-id',
+              upviews: 100_018,
+              document_type: 'guide',
+              satisfaction: 0.68,
+              satisfaction_score_responses: 42,
+              searches: 12,
+              pviews: 95_232,
+              feedex: 72,
+              useful_yes: 1530,
+              useful_no: 1255,
+              pdf_count: 0,
+              word_count: 170
+            }
+          ]
+        }
+      end
+
       def single_page_response(base_path, from, to, publishing_app = 'whitehall')
         day1 = from.to_s
         day2 = (from + 1.day).to_s


### PR DESCRIPTION
# What
Adding HTML data attributes to be using by Google Tag Manager and feature tests.

# Why
We use GTM to collect user analytics, data attributes and feature tests help make sure we don't break user tracking in future development.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.