### PR TITLE
Add icon and styles for results table sorting

### DIFF
--- a/app/assets/images/question_mark_default.svg
+++ b/app/assets/images/question_mark_default.svg
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 51 (57462) - http://www.bohemiancoding.com/sketch -->
-    <title>Default state</title>
-    <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="Default-state" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <g id="Group-Copy-6">

--- a/app/assets/images/question_mark_inverse.svg
+++ b/app/assets/images/question_mark_inverse.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs></defs>
+    <g id="Default-state" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Group-Copy-6">
+            <circle id="Oval-3" fill="#FFFFFF" fill-rule="nonzero" cx="12" cy="12" r="12"></circle>
+            <text id="?" font-family="GDSTransportWebsite-Bold, GDS Transport Website" font-size="16" font-weight="bold" fill="#005EA5">
+                <tspan x="8" y="18">?</tspan>
+            </text>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -1,3 +1,9 @@
+$sort-link-active-colour: govuk-colour("white");
+$sort-link-arrow-size: 14px;
+$sort-link-arrow-size-small: 8px;
+$sort-link-arrow-spacing: 4px;
+
+
 .content-data__index {
   .gem-c-pagination {
 
@@ -6,19 +12,94 @@
     }
   }
 
-  .table-header {
+  .table-caption {
     @include govuk-font(16);
     @include media(mobile) {
       @include govuk-responsive-padding(3, "left");
     }
+
   }
 
-  .govuk-table--sortable {
-    outline: none;
-  }
-
-  .table-header__param {
+  .table-caption__param {
     @include govuk-font($size: 16, $weight: bold);
+  }
+
+  .govuk-table__header {
+    white-space: nowrap;
+    vertical-align: top;
+  }
+
+  .table__header-title {
+    display: inline-block;
+    height: 100%;
+  }
+
+  .table__header-help {
+    display: inline-block;
+    height: 100%;
+    margin-left: 10px;
+    margin-right: 5px;
+    @include govuk-responsive-margin(2, "left");
+    @include govuk-responsive-margin(1, "right");
+  }
+
+
+  .table__sort-link {
+    @include govuk-link-style-no-visited-state;
+    @include govuk-focusable-fill;
+    position: relative;
+    padding-right: $sort-link-arrow-size;
+    color: $govuk-link-colour;
+    text-decoration: none;
+
+
+    &::after {
+      content: "";
+      position: absolute;
+      top: 0;
+      right: 0;
+
+      @include govuk-shape-arrow($direction: up, $base: $sort-link-arrow-size-small, $display: block);
+    }
+
+    &::before {
+      content: "";
+      position: absolute;
+      top: 8px;
+      right: 0;
+
+      @include govuk-shape-arrow($direction: down, $base: $sort-link-arrow-size-small, $display: block);
+    }
+  }
+
+  .table__sort-link--ascending,
+  .table__sort-link--descending {
+    .table__header-title {
+      @include govuk-responsive-padding(1, "right");
+    }
+  }
+
+  .table__sort-link--ascending::before,
+  .table__sort-link--descending::before {
+    content: none;
+  }
+
+  .table__sort-link--ascending::after {
+    content: "";
+    position: absolute;
+    top: $sort-link-arrow-spacing;
+    right: 0;
+
+    @include govuk-shape-arrow($direction: up, $base: $sort-link-arrow-size, $display: inline-block);
+  }
+
+  .table__sort-link--descending::after {
+    content: "";
+    position: absolute;
+    top: $sort-link-arrow-spacing;
+    right: 0;
+
+    @include govuk-shape-arrow($direction: down, $base: $sort-link-arrow-size, $display: inline-block);
   }
 
   .govuk-table {
@@ -41,6 +122,10 @@
     @include govuk-responsive-padding(2);
   }
 
+  .govuk-table__cell--shaded {
+    background-color: govuk-colour("grey-4");
+  }
+
   .govuk-table__cell--numeric {
     @include govuk-font($size: 14, $tabular: true);
     @include govuk-responsive-padding(2);
@@ -54,9 +139,17 @@
     color: $govuk-text-colour;
     position: sticky;
     top: 0;
+
+    &.govuk-table__header--sorted {
+      background-color: govuk-colour("blue");
+
+      .table__sort-link {
+        color: $white;
+      }
+    }
   }
 
-  .govuk-table .govuk-table__header {
+  .govuk-table__header {
     @include govuk-responsive-padding(2);
     background-color: $grey-3;
     font-weight: normal;

--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,19 +1,19 @@
-<h1 class="table-header">
+<h1 class="table-caption">
     <% if pagination.total_results > 0 %>
         Showing
         <% if pagination.total_pages > 1 %>
-            <span class="table-header__param"><%= pagination.formatted_first_record %></span> to
-            <span class="table-header__param"><%= pagination.formatted_last_record %></span> of
+            <span class="table-caption__param"><%= pagination.formatted_first_record %></span> to
+            <span class="table-caption__param"><%= pagination.formatted_last_record %></span> of
         <% end %>
-        <span class="table-header__param" ><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
+        <span class="table-caption__param"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
     <% else %>
-        <span class="table-header__param"><%= I18n.t('no_matching_results') %></span>
+        <span class="table-caption__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>
     <% if filter.search_terms? %>
-        for "<span class="table-header__param"><%= filter.search_terms %></span>"
+        for "<span class="table-caption__param"><%= filter.search_terms %></span>"
     <% end %>
     <% if filter.document_type? && filter.document_type_id != "all" %>
-        in <span class="table-header__param"><%= filter.document_type_name %></span>
+        in <span class="table-caption__param"><%= filter.document_type_name %></span>
     <% end %>
-    from <span class="table-header__param"><%= filter.organisation_name %></span>
+    from <span class="table-caption__param"><%= filter.organisation_name %></span>
 </h1>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -86,24 +86,31 @@
           </caption>
           <thead class="govuk-table__head" data-gtm-id="table-header">
             <tr class="govuk-table__row">
-              <th class="govuk-table__header" scope="col" data-gtm-id="title-column">Page title</th>
-              <th class="govuk-table__header" scope="col" data-gtm-id="document-type-column">Content type</th>
+              <th class="govuk-table__header" scope="col" data-gtm-id="title-column">
+                <%= t('.table.headers.title') %>
+              </th>
+              <th class="govuk-table__header" scope="col" data-gtm-id="document-type-column">
+                <%= t('.table.headers.document_type') %>
+              </th>
               <th class="govuk-table__header" scope="col" data-gtm-id="upviews-column">
-                Unique pageviews<br>
+                <%= t('metrics.upviews.title') %>
+                <br>
                 <%= image_tag 'question_mark_default.svg',
                   alt: 'Help',
                   title: "#{t "metrics.upviews.summary"}",
                   data: { 'gtm-id': 'help-icon' } %>
               </th>
               <th class="govuk-table__header" scope="col" data-gtm-id="satisfaction-column">
-                User satisfaction score<br>
+                <%= t('metrics.satisfaction.title') %>
+                <br>
                 <%= image_tag 'question_mark_default.svg',
                   alt: 'Help',
                   title: "#{t "metrics.satisfaction.summary"}",
                   data: { 'gtm-id': 'help-icon' } %>
               </th>
               <th class="govuk-table__header" scope="col" data-gtm-id="searches-column">
-                Searches from page<br>
+                <%= t('metrics.searches.title') %>
+                <br>
                 <%= image_tag 'question_mark_default.svg',
                   alt: 'Help',
                   title: "#{t "metrics.searches.summary"}",

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -77,10 +77,9 @@
     </div>
     <div class="govuk-grid-column-three-quarters">
       <div class="table-wrapper">
-        <table class="govuk-table"
+        <table class="table govuk-table"
           data-gtm-total-results="<%= @presenter.pagination.total_results %>"
-          data-gtm-page="<%= @presenter.pagination.page %>"
-          >
+          data-gtm-page="<%= @presenter.pagination.page %>">
           <caption class="govuk-table__caption">
             <%= render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter) %>
           </caption>
@@ -131,9 +130,9 @@
                     }
                 ) %>
               </td>
-              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.document_type %></td>
+              <td class="govuk-table__cell govuk-table__cell--shaded"><%= item.document_type %></td>
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.upviews %></td>
-              <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.user_satisfaction %></td>
+              <td class="govuk-table__cell govuk-table__cell--shaded"><%= item.user_satisfaction %></td>
               <td class="govuk-table__cell govuk-table__cell--numeric"><%= item.searches %></td>
             </tr>
           <% end %>

--- a/config/locales/views/content/en.yml
+++ b/config/locales/views/content/en.yml
@@ -1,0 +1,7 @@
+en:
+  content:
+    index:
+      table:
+        headers:
+          title: 'Page title'
+          document_type: 'Document type'

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe '/content' do
     table_rows = extract_table_content('.govuk-table')
     expect(table_rows).to eq(
       [
-        ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
+        ['Page title', 'Document type', 'Unique pageviews', 'User satisfaction score', 'Searches from the page'],
         ['GOV.UK homepage /', 'Homepage', '1,233,018', '85% (2,050 responses)', '1,220'],
         ['The title /path/1', 'News story', '233,018', '81% (250 responses)', '220'],
         ['Another title /path/2', 'Guide', '100,018', '68% (42 responses)', '12'],

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from another org')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results from another org')
     end
 
     it 'respects date range' do
@@ -141,7 +141,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result from All organisations')
+        expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result from All organisations')
       end
     end
 
@@ -214,7 +214,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result for "Relevant" from All organisations')
+        expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result for "Relevant" from All organisations')
       end
     end
   end
@@ -238,7 +238,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 result in News story from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result in News story from org (OI)')
     end
 
     it 'allows the filter to be cleared' do
@@ -247,7 +247,7 @@ RSpec.describe '/content' do
       expect(page).to have_select('document_type', selected: ["", "All document types"])
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 3 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results from org (OI)')
     end
   end
 
@@ -258,7 +258,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows a no data message in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: "#{I18n.t 'no_matching_results'} from org (OI)")
+      expect(page).to have_css('h1.table-caption', exact_text: "#{I18n.t 'no_matching_results'} from org (OI)")
     end
   end
 
@@ -269,7 +269,7 @@ RSpec.describe '/content' do
     end
 
     it 'formats the page numbers correctly in the table header' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 150 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 to 100 of 150 results from org (OI)')
     end
   end
 

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Results pagination" do
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
         [
-          ['Page title', 'Content type', 'Unique pageviews', 'User satisfaction score', 'Searches from page'],
+          ['Page title', 'Document type', 'Unique pageviews', 'User satisfaction score', 'Searches from the page'],
           ['third title /path/3', 'Press release', '233,018', '81% (250 responses)', '220'],
           ['forth title /path/4', 'News story', '100,018', '68% (42 responses)', '12'],
         ]

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -10,13 +10,6 @@ RSpec.describe "Results pagination" do
 
       visit "/content?date_range=last-month&organisation_id=org-id"
     end
-
-    it 'has GTM data attributes' do
-      expect(page).to have_css('[data-gtm-total-results]')
-
-      total_results = page.find('[data-gtm-total-results]')['data-gtm-total-results']
-      expect(total_results).to eq('0')
-    end
   end
 
   context 'has results' do
@@ -89,7 +82,7 @@ RSpec.describe "Results pagination" do
     end
 
     it 'shows the second page of data' do
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 1 to 100 of 102 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 to 100 of 102 results from org (OI)')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -99,14 +92,7 @@ RSpec.describe "Results pagination" do
           ['forth title /path/4', 'News story', '100,018', '68% (42 responses)', '12'],
         ]
       )
-      expect(page).to have_css('h1.table-header', exact_text: 'Showing 101 to 102 of 102 results from org (OI)')
-    end
-
-    it 'has GTM data attributes' do
-      expect(page).to have_css('[data-gtm-total-results]')
-
-      total_results = page.find('[data-gtm-total-results]')['data-gtm-total-results']
-      expect(total_results).to eq('102')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 101 to 102 of 102 results from org (OI)')
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/8STUqCTK/1111-3-rework-headers-in-the-table
https://trello.com/c/jFemNc0z/1143-3-sort-table-by-any-column-frontend

Reworks the table headers to allow each column to be sorted and the sorted
column to be highlighted visually and for screenreaders. By default it is
sorted by unique pageviews descending. On first click a column is sorted
descending, and on second click it switches to ascending.

# Why
This is the interface to allow users to access new ability to sort the table of contents

# Screenshots

## Before
![screen shot 2019-02-12 at 13 45 58](https://user-images.githubusercontent.com/31649453/52639654-a6505780-2ecc-11e9-8b09-6448cd55b1a4.png)

## After
![screen shot 2019-02-12 at 13 46 15](https://user-images.githubusercontent.com/31649453/52639673-b0725600-2ecc-11e9-975b-4442451c96df.png)
