### PR TITLE
Change route for metrics to ignore format

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,7 @@ Rails.application.routes.draw do
     get '/dev' => 'development#index'
   end
 
-  get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics
+  get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics, format: false
   get '/content', to: 'content#index'
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/spec/routing/single_page_routing_spec.rb
+++ b/spec/routing/single_page_routing_spec.rb
@@ -13,4 +13,12 @@ RSpec.describe 'routes for Single Data Page' do
       action: 'show'
     )
   end
+
+  it 'routes /metrics/base/path.cy' do
+    expect(get: '/metrics/base/path.cy').to route_to(
+      controller: 'metrics',
+      action: 'show',
+      base_path: 'base/path.cy'
+    )
+  end
 end


### PR DESCRIPTION
# What
Changes route config to prevent rails from parsing and removing the `.<format>` from the url. 

# Why
This fixes an issue whereby base paths with locale extensions are removed from the result. i.e. `base/path.cy` => `base/path`

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.