### PR TITLE
Hide download CSV link

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -67,12 +67,14 @@
             <p><a href="/content" class="govuk-link govuk-body-s" data-gtm-id="clear-filters">Clear all filters</a></p>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
+<!--
             <p>
-              <a href="<%= content_path(@presenter.search_parameters.merge(format: :csv)) %>"
+              <a href="<%#= content_path(@presenter.search_parameters.merge(format: :csv)) %>"
                  class="govuk-link govuk-body-s download-link" data-gtm-id="csv-download-link">
                 Download all data in CSV format
               </a>
             </p>
+-->
         </div>
     </div>
     <div class="govuk-grid-column-three-quarters">

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -279,6 +279,8 @@ RSpec.describe '/content' do
     let(:csv_items) { items * 11 }
 
     it 'it provides a CSV file respecting all filters' do
+      pending('Feature temporarily disabled')
+
       stub_content_page(
         time_period: 'last-month',
         organisation_id: 'org-id',

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -38,6 +38,8 @@ RSpec.feature 'user analytics' do
   end
 
   scenario 'tracks CSV download link' do
+    pending('Feature temporarily disabled')
+
     expect(page).to have_selector('[data-gtm-id="csv-download-link"]')
   end
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/iZIdDLSt/1164-1-hide-the-link-download-csv-from-content-data-admin)

# What

Hides the link to download a CSV from the Index Page

# Why

We have a few issues with the way we currently download the file, so
we are disabling it until we find a better solution, or improve the current
one.

# Screenshots

## Before

![image](https://user-images.githubusercontent.com/227328/53013537-efa92580-343d-11e9-8e40-1b3ea3cd9452.png)

## After

![image](https://user-images.githubusercontent.com/227328/53013551-f8016080-343d-11e9-921a-ba6e1e6fc832.png)
