### PR TITLE
Remove the document_type special case for 'all' in FindContent

### DIFF
--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -18,9 +18,6 @@ class FindContent
   end
 
   def call
-    if @document_type == "all"
-      @document_type = ""
-    end
     api.content(date_range: @date_range, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
   end
 


### PR DESCRIPTION
I'm looking at this, as it led to a subtle issue where the CSV files
would be empty, if you filtered by all document types. FindContent is
used for both the HTML pages, and the CSV download, but this
conditional being removed only applied to the HTML page data.

To keep the Content Data API in the Content Performance Manager
consistent, this has been extended [1] to support 'all' as a special
value for document_type, similar to how 'all' is handled for
organisation_id.

With that change, this conditional becomes redundant, as the 'all'
value is supported by the Content Performance Manager.

1: https://github.com/alphagov/content-performance-manager/commit/477bfea231de72892bae3fd213ae66acc93ca6b2
