### PR TITLE
Fix document type handling in find content

### DIFF
--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -18,7 +18,13 @@ class FindContent
   end
 
   def call
-    api.content(date_range: @date_range, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
+    api.content(
+      date_range: @date_range,
+      organisation_id: @organisation,
+      document_type: @document_type,
+      page: @page,
+      search_term: @search_term
+    )
   end
 
   def enum

--- a/app/services/find_content.rb
+++ b/app/services/find_content.rb
@@ -12,15 +12,12 @@ class FindContent
   def initialize(params)
     @date_range = params[:date_range]
     @organisation = params[:organisation_id]
-    @document_type = params[:document_type]
+    @document_type = params[:document_type] unless params[:document_type] == 'all'
     @page = params[:page]
     @search_term = params[:search_term]
   end
 
   def call
-    if @document_type == "all"
-      @document_type = ""
-    end
     api.content(date_range: @date_range, organisation_id: @organisation, document_type: @document_type, page: @page, search_term: @search_term)
   end
 


### PR DESCRIPTION
I'm looking at this, as it led to a subtle issue where the CSV files
would be empty, if you filtered by all document types. FindContent is
used for both the HTML pages, and the CSV download, but this
conditional being removed only applied to the HTML page data.

To keep the Content Data API in the Content Performance Manager
consistent, this has been extended [1] to support 'all' as a special
value for document_type, similar to how 'all' is handled for
organisation_id.

With that change, the issue should be resolved, but also move the
special case for document_type in the Content Data Admin for
completeness and to make the code paths more consistent.

1: https://github.com/alphagov/content-performance-manager/commit/477bfea231de72892bae3fd213ae66acc93ca6b2