### PR TITLE
Remove the 'X to Y' text from the table caption

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -1,10 +1,6 @@
 <h1 class="table-caption">
     <% if pagination.total_results > 0 %>
         Showing
-        <% if pagination.total_pages > 1 %>
-            <span class="table-caption__param"><%= pagination.formatted_first_record %></span> to
-            <span class="table-caption__param"><%= pagination.formatted_last_record %></span> of
-        <% end %>
         <span class="table-caption__param"><%= pagination.formatted_total_results %></span> <%= 'result'.pluralize(pagination.total_results) %>
     <% else %>
         <span class="table-caption__param"><%= I18n.t('no_matching_results') %></span>

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -272,7 +272,7 @@ RSpec.describe '/content' do
     end
 
     it 'formats the page numbers correctly in the table header' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 to 100 of 150 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 150 results from org (OI)')
     end
   end
 

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Results pagination" do
     end
 
     it 'shows the second page of data' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 to 100 of 102 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results from org (OI)')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -97,7 +97,7 @@ RSpec.describe "Results pagination" do
           ['forth title /path/4', 'News story', '100,018', '68% (50 responses)', '12'],
         ]
       )
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 101 to 102 of 102 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results from org (OI)')
     end
   end
 end


### PR DESCRIPTION
# What
Remove text from results spanning paginated pages
https://trello.com/c/gs3bac3N/1172-1-remove-1-to-100-of-text-from-the-table-summary

# Why
Reduce clutter

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
![screen shot 2019-02-21 at 08 40 40](https://user-images.githubusercontent.com/31649453/53155268-9ca5ae80-35b4-11e9-80e6-3b9f16be08e7.png)
## After
![screen shot 2019-02-21 at 08 41 08](https://user-images.githubusercontent.com/31649453/53155256-97486400-35b4-11e9-9702-f0cde6c09a4a.png)

