### PR TITLE
Move clear link next to filter button on desktop

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -195,13 +195,37 @@ $sort-link-arrow-spacing: 4px;
 
   }
 
+  .filter-form__clear-link {
+    display: block;
+    @include govuk-responsive-padding(2, "top");
+    @include govuk-responsive-margin(4, "top");
+
+    @include govuk-media-query($from: desktop) {
+      float: left;
+      @include govuk-responsive-margin(4, "left");
+      @include govuk-responsive-margin(0, "top");
+    }
+  }
+
   .filters-control {
     display: block;
     @include govuk-responsive-padding(3, "bottom");
   }
 
+
+  .gem-c-button {
+    @include govuk-media-query($from: desktop) {
+      float: left;
+    }
+
+  }
+
   .gem-c-phase-banner {
     @include govuk-responsive-padding(3, "left");
+  }
+
+  .govuk-section-break {
+    clear: left;
   }
 
   .download-link {

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -61,10 +61,12 @@
           %>
 
             <%= render "govuk_publishing_components/components/button", {text: "Filter"} %>
+
+            <a href="/content" class="govuk-link govuk-body-s filter-form__clear-link" data-gtm-id="clear-filters">Clear all filters</a>
           <% end %>
         </div>
 
-            <p><a href="/content" class="govuk-link govuk-body-s" data-gtm-id="clear-filters">Clear all filters</a></p>
+
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 <!--


### PR DESCRIPTION
# What
Move clear link next to filter button on desktop
https://trello.com/c/AN09DD4T/1170-2-place-clear-all-filters-link-alongside-the-filter-cta

# Why
Visually better, gives more of a target.

# Screenshots
## Before
![screen shot 2019-02-21 at 11 45 56](https://user-images.githubusercontent.com/31649453/53166858-58bfa300-35ce-11e9-8ef6-5a7d2ebdd1f3.png)
## After
![screen shot 2019-02-21 at 11 46 09](https://user-images.githubusercontent.com/31649453/53166882-62490b00-35ce-11e9-840f-9cfff73f6800.png)


