### PR TITLE
Restore GTM attributes to prevent deployment issues

### DIFF
--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -2,7 +2,8 @@
   metrics_path(item.base_path, date_range: date_range),
   data: {
     'gtm-id': 'content-item-link',
-    'gtm-item-document-type': item.raw_document_type
+    'gtm-item-document-type': item.raw_document_type,
+    'gtm': item.raw_document_type
   } %>
 <br>
 <span class="base-path">/<%= item.base_path %></span>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -83,6 +83,7 @@
       <div class="table-wrapper">
         <table class="table govuk-table"
           data-gtm-total-results="<%= @presenter.pagination.total_results %>"
+          data-gtm-pagination-total-results="<%= @presenter.pagination.total_results %>"
           data-gtm-page="<%= @presenter.pagination.page %>">
           <caption class="govuk-table__caption">
             <%= render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter) %>

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -29,6 +29,10 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="content-item-link"][data-gtm-item-document-type]')
   end
 
+  scenario 'tracks content item page links (old way)' do
+    expect(page).to have_selector('[data-gtm-id="content-item-link"][data-gtm]')
+  end
+
   help_icon_columns = %w(upviews satisfaction searches)
 
   help_icon_columns.each do |column|

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -17,6 +17,10 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-total-results]')
   end
 
+  scenario 'tracks total number of results (old way)' do
+    expect(page).to have_selector('[data-gtm-pagination-total-results]')
+  end
+
   scenario 'tracks prev and next pagination links' do
     expect(page).to have_selector('[data-gtm-id="pagination-links"]')
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/diMjPcK3/1136-3-data-attributes-for-gtm-for-the-index-page)

### What

Restore old data attributes in order to deploy GTM to production
without losing any data.

We will revert these commits once the latest version to GTM is deployed.