### PR TITLE
Revert gtm data attributes single page

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -83,7 +83,7 @@
       <% end %>
       <%= line_chart(chart_format_data, library: chart_library_options, defer: true) %>
     </div>
-    <div class="app-c-chart__table" id="<%= table_id %>" data-gtm="view-table-reveal">
+    <div class="app-c-chart__table" id="<%= table_id %>" data-gtm="view-table-reveal" data-gtm-id="view-table-reveal">
       <%= render(
         "govuk_publishing_components/components/details",
         title: t(".table_dropdown", metric_name: chart_label)

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -13,8 +13,12 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="page-kicker"]')
   end
 
-  scenario 'tracks view table reveal section' do
+  scenario 'tracks view table reveal section (old way)' do
     expect(page).to have_selector('[data-gtm="view-table-reveal"]')
+  end
+
+  scenario 'tracks view table reveal section' do
+    expect(page).to have_selector('[data-gtm-id="view-table-reveal"]')
   end
 
   scenario 'tracks time period submit' do

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -13,6 +13,10 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="page-kicker"]')
   end
 
+  scenario 'tracks view table reveal section' do
+    expect(page).to have_selector('[data-gtm="view-table-reveal"]')
+  end
+
   scenario 'tracks time period submit' do
     expect(page).to have_selector('[data-gtm-id="time-period-form"]')
   end


### PR DESCRIPTION
[Trello card](https://trello.com/c/u8vri6WC/1149-3-data-attributes-for-gtm-for-the-content-item-page)

### What

Make the name of the data attribute used by GTM more consistent with other HTML 
components. The old way will be reverted once GTM is deployed to production.