### PR TITLE
Unescape foreign characters on slugs

### DIFF
--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -5,4 +5,4 @@
     'gtm-item-document-type': item.raw_document_type
   } %>
 <br>
-<span class="base-path">/<%= item.base_path %></span>
+<span class="base-path">/<%= CGI::unescape(item.base_path) %></span>


### PR DESCRIPTION
# What
Fix display bug by decoding unusual characters encoded in slugs
https://trello.com/c/EHrM18LF/1548-bug-some-foreign-language-slugs-stretch-the-page-title-column-width-in-the-table-and-link-to-page-not-found

# Why
Page currently stretches and slugs are incomprehensible

# Screenshots

## Before
![screen shot 2019-02-25 at 09 16 23](https://user-images.githubusercontent.com/31649453/53326848-79457100-38de-11e9-9b9b-a3e7dea689b0.png)

## After
![screen shot 2019-02-25 at 09 16 38](https://user-images.githubusercontent.com/31649453/53326860-806c7f00-38de-11e9-8f7e-b65547d5f48a.png)
