### PR TITLE
Fix repetitive name/acronym combinations

### DIFF
--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -76,8 +76,11 @@ class FilterPresenter
     @organisation_options ||= begin
       additional_organisation_options +
         @organisations.map do |org|
-          name = org[:name]
-          name.concat " (#{org[:acronym]})" if org[:acronym].present?
+          name = org[:name].strip
+          if org[:acronym].present?
+            acronym = org[:acronym].strip
+            name.concat " (#{acronym})" if acronym != name
+          end
           [name, org[:id]]
         end
     end


### PR DESCRIPTION
# What
Remove repetitive organisation name/acronym combinations such as NS&I (NS&I)  or Companies House (Companies House). This removes extraneous whitespace and then compares the strings to determine whether to display the value from the acronym field.


# Why
Adds noise and no value, so needs removing

# Screenshots
## Before
![screen shot 2019-02-26 at 08 50 27](https://user-images.githubusercontent.com/31649453/53399265-8aa48100-39a3-11e9-9076-f5a3cab6313a.png)
 
## After
![screen shot 2019-02-26 at 08 50 10](https://user-images.githubusercontent.com/31649453/53399282-96904300-39a3-11e9-8f1b-0f369ebce4f1.png)
