### PR TITLE
Change colour to de-emphasise response values.

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -1,3 +1,4 @@
+$govuk-tertiary-text-colour: #6a7276;
 $sort-link-active-colour: govuk-colour("white");
 $sort-link-arrow-size: 14px;
 $sort-link-arrow-size-small: 8px;
@@ -152,6 +153,10 @@ $sort-link-arrow-spacing: 4px;
     min-width: 900px;
     background-color: $white;
     @include govuk-responsive-padding(6, "right");
+  }
+
+  .satisfaction-column__responses {
+    color: $govuk-tertiary-text-colour;
   }
 
   .filter-form {

--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -2,27 +2,35 @@ class ContentRowPresenter
   include ActionView::Helpers::NumberHelper
   include ActiveSupport::Inflector
 
-  attr_reader :title, :base_path, :document_type, :upviews,
-              :user_satisfaction, :searches, :raw_document_type
+  attr_reader :title, :base_path, :document_type, :upviews, :searches,
+    :raw_document_type, :satisfaction_percentage, :satisfaction_responses
+
   def initialize(data)
     @title = data[:title]
     @base_path = format_base_path(data[:base_path])
     @raw_document_type = data[:document_type]
     @document_type = humanize(data[:document_type])
     @upviews = number_with_delimiter(data[:upviews], delimiter: ',')
-    @user_satisfaction = format_satisfaction(
-      data[:satisfaction], data[:useful_yes], data[:useful_no]
-    )
+    @satisfaction_percentage = format_satisfaction_percentage(data[:satisfaction])
+    @satisfaction_responses = format_satisfaction_responses(data[:useful_yes], data[:useful_no])
+
     @searches = number_with_delimiter(data[:searches], delimiter: ',')
   end
 
 private
 
-  def format_satisfaction(score, yes_responses, no_responses)
-    return 'No responses' unless score
+  def format_satisfaction_percentage(score)
+    "#{(score * 100).round(0)}%" if score
+  end
 
+  def format_satisfaction_responses(yes_responses, no_responses)
     total_responses = yes_responses + no_responses
-    "#{(score * 100).round(0)}% (#{number_with_delimiter(total_responses)} responses)"
+
+    if total_responses.positive?
+      "#{number_with_delimiter(total_responses)} responses"
+    else
+      "No responses"
+    end
   end
 
   def format_base_path(base_path)

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -10,8 +10,6 @@
           <a href="" class="govuk-link filters-control__link filters-control__link--show">Show filters</a>&nbsp;&#x25BC;</span>
       </div>
 
-
-
       <div class="filter-form">
         <%= form_tag content_path,
           method: 'get',
@@ -65,8 +63,6 @@
             <a href="/content" class="govuk-link govuk-body-s filter-form__clear-link" data-gtm-id="clear-filters">Clear all filters</a>
           <% end %>
         </div>
-
-
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 <!--
@@ -134,7 +130,14 @@
               </td>
               <td class="govuk-table__cell govuk-table__cell--shaded" data-gtm-id="document_type-column"><%= item.document_type %></td>
               <td class="govuk-table__cell govuk-table__cell--numeric" data-gtm-id="upviews-column"><%= item.upviews %></td>
-              <td class="govuk-table__cell govuk-table__cell--shaded" data-gtm-id="satisfaction-column"><%= item.user_satisfaction %></td>
+              <td class="govuk-table__cell govuk-table__cell--shaded" data-gtm-id="satisfaction-column">
+                <% if item.satisfaction_percentage %>
+                    <%= item.satisfaction_percentage %>
+                    <span class="satisfaction-column__responses"> (<%= item.satisfaction_responses %>) </span>
+                <% else %>
+                   <%= item.satisfaction_responses %>
+                <% end %>
+              </td>
               <td class="govuk-table__cell govuk-table__cell--numeric" data-gtm-id="searches-column"><%= item.searches %></td>
             </tr>
           <% end %>

--- a/spec/features/index_page/index_filter_by_title_spec.rb
+++ b/spec/features/index_page/index_filter_by_title_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe '/content' do
 
   let(:items) do
     [
-      { base_path: '/path/1', title: 'The title' },
-      { base_path: '/path/2', title: 'Another title' }
+      { base_path: '/path/1', title: 'The title', satisfaction: nil, useful_yes: 0, useful_no: 0 },
+      { base_path: '/path/2', title: 'Another title', satisfaction: nil, useful_yes: 0, useful_no: 0 }
     ]
   end
 

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -26,7 +26,33 @@ RSpec.describe ContentRowPresenter do
     expect(subject.document_type).to eq('News story')
   end
 
-  it 'formats user_satifaction_score correctly' do
-    expect(subject.user_satisfaction).to eq('80% (1,000 responses)')
+  it 'formats user_satifaction_percentage correctly' do
+    expect(subject.satisfaction_percentage).to eq('80%')
+  end
+
+  it 'formats user_satifaction_responses correctly' do
+    expect(subject.satisfaction_responses).to eq('1,000 responses')
+  end
+
+  context 'when there is no satisfaction score' do
+    let(:row_hash) do
+      {
+        base_path: '/some/base_path',
+        document_type: 'news_story',
+        title: 'a title',
+        upviews: '200,001',
+        satisfaction: nil,
+        useful_yes: 0,
+        useful_no: 0,
+      }
+    end
+
+    it 'returns nil for percentage' do
+      expect(subject.satisfaction_percentage).to eq(nil)
+    end
+
+    it 'returns "no responses" for responses' do
+      expect(subject.satisfaction_responses).to eq("No responses")
+    end
   end
 end


### PR DESCRIPTION
# What
This splits the satisfaction data in two at the presenter level,
adds tests for the correct responses, then presents the section in brackets
in a paler colour than previously (The colour has been checked for contrast/accessibility).
https://trello.com/c/RHEteDvs/1173-1-change-the-colour-of-the-number-of-responses-text-inside-the-table

# Why
De-emphasise response numbers

# Screenshots

## Before
![screen shot 2019-03-04 at 09 20 11](https://user-images.githubusercontent.com/31649453/53723090-db622100-3e5e-11e9-8a09-3ed2d1aaf62c.png)

## After
![screen shot 2019-03-04 at 09 19 06](https://user-images.githubusercontent.com/31649453/53723104-e452f280-3e5e-11e9-8cdf-ed976bd2c92f.png)

-
