### PR TITLE
Adjust spacing on data page

### DIFF
--- a/app/assets/stylesheets/components/_chart.scss
+++ b/app/assets/stylesheets/components/_chart.scss
@@ -11,7 +11,7 @@
 
 .app-c-chart__table {
 
-  max-height: 350px;
+  max-height: 300px;
   margin-top: govuk-spacing(3);
 
   @include media(mobile) {

--- a/app/assets/stylesheets/components/_glance-metric.scss
+++ b/app/assets/stylesheets/components/_glance-metric.scss
@@ -2,6 +2,7 @@
 @import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
 
 .app-c-glance-metric {
+  @include govuk-responsive-margin(6, "bottom");
   border-top: 1px solid $govuk-border-colour;
   border-bottom: 1px solid $govuk-border-colour;
 
@@ -12,7 +13,8 @@
 
 .app-c-glance-metric__heading {
   @include govuk-responsive-margin(3, "top");
-  @include govuk-responsive-margin(2, "bottom");
+  @include govuk-responsive-margin(1, "bottom");
+  @include govuk-responsive-padding(3, "top");
   min-height: 2.6em;
 
 
@@ -27,6 +29,7 @@
 
 .app-c-glance-metric__figure {
   @include govuk-font($size: 36, $weight: bold);
+  @include govuk-responsive-margin(1, "bottom");
 
   @include media-down(mobile) {
     @include govuk-font($size: 48, $weight: bold);
@@ -64,6 +67,7 @@
 }
 
 .app-c-glance-metric__period {
+  @include govuk-responsive-margin(6, "bottom");
 
   @include media-down(mobile) {
     @include govuk-font(16);

--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -2,6 +2,7 @@
 @import "../../../node_modules/govuk-frontend/helpers/visually-hidden";
 
 .app-c-info-metric__heading {
+  @include govuk-responsive-margin(6, "top");
   @include govuk-responsive-margin(1, "bottom");
 }
 
@@ -37,6 +38,7 @@
 
   @include govuk-responsive-margin(3, "left");
   @include govuk-responsive-margin(3, "right");
+  @include govuk-responsive-margin(2, "bottom");
 
   .govuk-details__summary-text {
     @include govuk-font(16);

--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -1,6 +1,6 @@
 .app-c-time-select {
-  @include govuk-responsive-padding(3, "top");
-  @include govuk-responsive-padding(6, "bottom");
+  @include govuk-responsive-padding(6, "top");
+  @include govuk-responsive-padding(3, "bottom");
   border-top: 1px solid $govuk-border-colour;
 }
 

--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -1,64 +1,76 @@
-.section-performance {
+.content-data__metrics {
 
-  @include media-down(mobile) {
-    border-top: 1px solid $govuk-border-colour;
+  .govuk-heading-xl {
+    @include govuk-responsive-margin(7, "bottom");
   }
-}
 
-.section-performance__header {
-  @include govuk-font($size: 36, $weight: bold);
-  margin: 0;
+  .section-performance {
 
-  @include media-down(mobile) {
-    @include govuk-responsive-margin(3, "top");
+    @include media-down(mobile) {
+      border-top: 1px solid $govuk-border-colour;
+    }
   }
-}
 
-.section-content {
-  padding: 0;
-}
+  .section-performance__header {
+    @include govuk-font($size: 36, $weight: bold);
+    margin: 0;
 
-.section-content__header {
-  @include govuk-font($size: 36, $weight: bold);
-  margin: 0;
-}
-
-.section-content__quality {
-  @include govuk-responsive-margin(2, "left");
-  @include govuk-responsive-margin(2, "right");
-}
-
-.govuk-section-break--visible {
-  border-width: 1px;
-}
-
-.metric-summary__words {
-
-  @include media-down(mobile) {
-    width: 95%;
-    border-bottom: 1px solid $govuk-border-colour;
+    @include media-down(mobile) {
+      @include govuk-responsive-margin(3, "top");
+    }
   }
-}
 
-.metric-summary__reading-time {
-
-  @include media-down(mobile) {
-    width: 95%;
-    border-bottom: 1px solid $govuk-border-colour;
+  .local-nav__search-link {
+    display: block;
+    @include govuk-responsive-margin(2, "top");
   }
-}
 
-.banner {
-  margin: 0;
-  @include govuk-responsive-margin(2, "bottom");
-  border-bottom: 1px solid $govuk-border-colour;
-
-  .govuk-grid-column-three-quarters {
+  .section-content {
     padding: 0;
   }
-}
 
-.govuk-width-container .local-nav {
-  text-align: right;
-  @include govuk-responsive-margin(2, "top");
+  .section-content__header {
+    @include govuk-font($size: 36, $weight: bold);
+    margin: 0;
+  }
+
+  .section-content__quality {
+    @include govuk-responsive-margin(2, "left");
+    @include govuk-responsive-margin(2, "right");
+  }
+
+  .govuk-section-break--visible {
+    border-width: 1px;
+  }
+
+  .metric-summary__words {
+
+    @include media-down(mobile) {
+      width: 95%;
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  }
+
+  .metric-summary__reading-time {
+
+    @include media-down(mobile) {
+      width: 95%;
+      border-bottom: 1px solid $govuk-border-colour;
+    }
+  }
+
+  .banner {
+    margin: 0;
+    @include govuk-responsive-margin(2, "bottom");
+    border-bottom: 1px solid $govuk-border-colour;
+
+    .govuk-grid-column-three-quarters {
+      padding: 0;
+    }
+  }
+
+  .govuk-width-container .local-nav {
+    text-align: right;
+    @include govuk-responsive-margin(2, "top");
+  }
 }

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -42,7 +42,7 @@
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
     legend: 'none',
-    chartArea: { width: chart_width, height: '80%' },
+    chartArea: { width: chart_width, height: '95%' },
     curveType: 'none',
     tooltip: { showColorCode: true, isHtml: true, trigger: 'both'},
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for :title, t('.browser_title', content_title: @performance_data.title) %>
+<% content_for :page_class, "content-data__metrics" %>
 <% content_for :local_nav do %>
   <div class="local-nav govuk-grid-column-one-quarter">
     <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
@@ -11,7 +12,7 @@
     <span class="govuk-caption-xl" data-gtm-id="page-kicker"><%= t ".page_kicker" %></span>
   </div>
 </div>
-<div class="govuk-grid-row">
+<div class="govuk-grid-row section-metadata">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-xl"><%= @performance_data.title %></h1>
     <div class="page-metadata">


### PR DESCRIPTION
# What
https://trello.com/c/OUCjbciM/1204-2-spacing-adjustments-for-the-page-data-page
Change spacing on the data page for tidier visuals.
- This wraps the data page in a class so shared styles won't leak (seems to have been lost when it was present previously) and applies adjusted padding and margins to the page. 
- Makes a minor adjustment to the chart size as we no longer need to accommodate the legend so the space at the top is wasted.

# Why
Tidier page.

## Before
![screencapture-content-data-admin-publishing-service-gov-uk-metrics-vehicle-tax-2019-03-07-11_04_09](https://user-images.githubusercontent.com/31649453/53952522-db655980-40c8-11e9-9fa8-fa28b9c952f6.png)


## After
# Screenshots
![screencapture-content-data-admin-dev-gov-uk-metrics-vehicle-tax-2019-03-07-10_26_37](https://user-images.githubusercontent.com/31649453/53950271-b3bfc280-40c3-11e9-9d1a-e5728cfaecf7.png)



