### PR TITLE
Add user-uid to value to GTM

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,8 @@
     <script>
       dataLayer = [
         { 'gtm.blacklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] },
-        { 'user-organisation': '<%= current_user.organisation_slug %>' }
+        { 'user-organisation': '<%= current_user.organisation_slug %>' },
+        { 'cd-uid': '<%= current_user.uid %>' }
       ];
     </script>
     <%= render "govuk_publishing_components/components/google_tag_manager_script", {


### PR DESCRIPTION
# What
Send the User ID from Signon to Google Analytics

# Why
This is so we can monitor session behaviour of particular users and see when they're using different browsers/devices.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
