### PR TITLE
Move help text into modals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ group :development, :test do
   gem "capybara"
   gem "factory_bot_rails"
   gem "govuk-lint", "~> 3"
+  gem "govuk_test"
   gem 'pry'
   gem "rspec-rails", "~> 3"
   gem "spring-commands-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.6.0)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.12.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     aws-xray-sdk (0.10.2)
@@ -67,6 +69,11 @@ GEM
       regexp_parser (~> 1.2)
       xpath (~> 3.2)
     chartkick (3.0.2)
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (2.1.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crack (0.4.3)
@@ -135,6 +142,11 @@ GEM
       rake
       rouge
       sass-rails (>= 5.0.4)
+    govuk_test (0.3.1)
+      capybara
+      chromedriver-helper
+      puma
+      selenium-webdriver
     hashdiff (0.3.7)
     hashie (3.6.0)
     htmlentities (4.3.4)
@@ -142,6 +154,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.2)
     json (2.1.0)
     jwt (2.1.0)
@@ -223,6 +236,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
+    puma (3.12.0)
     rack (2.0.6)
     rack-cache (1.9.0)
       rack (>= 0.4)
@@ -296,6 +310,7 @@ GEM
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (5.0.0)
       crass (~> 1.0.2)
@@ -315,6 +330,9 @@ GEM
     scss_lint (0.57.1)
       rake (>= 0.9, < 13)
       sass (~> 3.5, >= 3.5.5)
+    selenium-webdriver (3.141.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     simplecov (0.16.1)
@@ -379,6 +397,7 @@ DEPENDENCIES
   govuk-lint (~> 3)
   govuk_app_config (~> 1)
   govuk_publishing_components (~> 16.5)
+  govuk_test
   kaminari
   listen (~> 3)
   logstasher

--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class HelpController < ApplicationController
+  layout 'application'
+
+  def show
+    @hkey = params[:hkey]
+  end
+end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -103,13 +103,12 @@
                 <% end %>
                 <br>
                 <% if include_help_icon?(header) %>
-                  <span class="table__header-help">
-                    <%= image_tag(
-                      (sort_direction.present? ? 'question_mark_inverse.svg' : 'question_mark_default.svg'),
-                      alt: 'Help',
-                      title: t("metrics.#{header}.summary"),
-                      data: { 'gtm-id': 'help-icon' }) %>
-                  </span>
+                  <a href="/help/?hkey=<%= header %>" data-toggle="modal" data-target="modal-<%= header %>" class="table__header-help">
+                      <%= image_tag(
+                        (sort_direction.present? ? 'question_mark_inverse.svg' : 'question_mark_default.svg'),
+                        alt: 'Help',
+                        data: { 'gtm-id': 'help-icon' }) %>
+                  </a>
                 <% end %>
               </th>
             <% end %>
@@ -150,3 +149,17 @@
         </div>
     </div>
 </div>
+
+<% content_for :modals do %>
+  <% TableHeaderHelper::HEADER_NAMES.each do |header| %>
+    <% if include_help_icon?(header) %>
+      <%= render "govuk_publishing_components/components/modal_dialogue", {
+        id: "modal-#{header}",
+        wide: true
+      } do %>
+        <h1 class="govuk-heading-l"><%= t(".table.headers.#{header}", default: :"metrics.#{header}.title") %></h1>
+        <p class="govuk-body"><%= t(".table.headers.#{header}", default: :"metrics.#{header}.about") %></p>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -155,7 +155,7 @@
     <% if include_help_icon?(header) %>
       <%= render "govuk_publishing_components/components/modal_dialogue", {
         id: "modal-#{header}",
-        wide: true
+        wide: false
       } do %>
         <h1 class="govuk-heading-l"><%= t(".table.headers.#{header}", default: :"metrics.#{header}.title") %></h1>
         <p class="govuk-body"><%= t(".table.headers.#{header}", default: :"metrics.#{header}.about") %></p>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -103,11 +103,11 @@
                 <% end %>
                 <br>
                 <% if include_help_icon?(header) %>
-                  <a href="/help/?hkey=<%= header %>" data-toggle="modal" data-target="modal-<%= header %>" class="table__header-help">
+                  <a href="/help/?hkey=<%= header %>" data-toggle="modal" data-target="modal-<%= header %>" data-gtm-id="help-icon" class="table__header-help">
                       <%= image_tag(
                         (sort_direction.present? ? 'question_mark_inverse.svg' : 'question_mark_default.svg'),
-                        alt: 'Help',
-                        data: { 'gtm-id': 'help-icon' }) %>
+                        alt: 'Help')
+                      %>
                   </a>
                 <% end %>
               </th>

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -6,6 +6,9 @@
     <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
   </div>
 <% end %>
-
-<h1 class="govuk-heading-l"><%= t("metrics.#{@hkey}.title", default: :"help.title.default") %></h1>
-<p class="govuk-body"><%= t("metrics.#{@hkey}.about", default: :"help.about.default") %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l"><%= t("metrics.#{@hkey}.title", default: :"help.title.default") %></h1>
+    <p class="govuk-body"><%= t("metrics.#{@hkey}.about", default: :"help.about.default") %></p>
+  </div>
+</div>

--- a/app/views/help/show.html.erb
+++ b/app/views/help/show.html.erb
@@ -1,0 +1,11 @@
+<% content_for :title, t("help.page_title") + " - " + t("metrics.#{@hkey}.title", default: :"metrics.upviews.title") %>
+
+<% content_for :page_class, "content-data__help" %>
+<% content_for :local_nav do %>
+  <div class="local-nav govuk-grid-column-one-quarter">
+    <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
+  </div>
+<% end %>
+
+<h1 class="govuk-heading-l"><%= t("metrics.#{@hkey}.title", default: :"help.title.default") %></h1>
+<p class="govuk-body"><%= t("metrics.#{@hkey}.about", default: :"help.about.default") %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,5 +67,7 @@
   </main>
 </div>
 
+  <%= yield(:modals) %>
+
   <%= render "govuk_publishing_components/components/layout_footer" %>
 <% end %>

--- a/config/locales/views/help/en.yml
+++ b/config/locales/views/help/en.yml
@@ -1,0 +1,7 @@
+en:
+  help:
+    page_title: 'Help'
+    title:
+      default: 'Help page'
+    about:
+      default: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,6 @@ Rails.application.routes.draw do
 
   get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics, format: false
   get '/content', to: 'content#index'
+  get '/help', to: 'help#show', as: :show, format: false
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/spec/features/index_page/index_filter_by_title_spec.rb
+++ b/spec/features/index_page/index_filter_by_title_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe '/content' do
     GDS::SSO.test_user = build(:user, organisation_content_id: 'org-id')
 
     stub_content_page(time_period: 'last-month', organisation_id: 'org-id', items: items)
-
     visit '/content?submitted=true&date_range=last-month&organisation_id=org-id'
   end
 
@@ -36,6 +35,14 @@ RSpec.describe '/content' do
 
     it 'populates the search field with the current filter' do
       expect(page).to have_selector('input[name=search_term][value=title]')
+    end
+
+    it 'launches help text in a modal', js: true do
+      help_string = I18n.t('metrics.upviews.about')
+      expect(page).to_not have_text(help_string)
+      click_link(href: "/help/?hkey=upviews")
+      expect(page).to have_selector('.gem-c-modal-dialogue__box')
+      expect(page).to have_text(help_string)
     end
   end
 end

--- a/spec/features/index_page/sorting_spec.rb
+++ b/spec/features/index_page/sorting_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Sort results" do
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: items)
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: sorted_items, sort: 'satisfaction:desc')
     visit "/content"
-    find('th[data-gtm-id="satisfaction-column"] > a').click
+    find('th[data-gtm-id="satisfaction-column"] > .table__sort-link').click
 
     values = extract_table_column_values('satisfaction')
     expect(values).to eq(['75% (100 responses)', '50% (10 responses)', '25% (100 responses)'])
@@ -85,7 +85,7 @@ RSpec.feature "Sort results" do
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: items)
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: sorted_items, sort: 'searches:desc')
     visit "/content"
-    find('th[data-gtm-id="searches-column"] > a').click
+    find('th[data-gtm-id="searches-column"] > .table__sort-link').click
 
     values = extract_table_column_values('searches')
     expect(values).to eq(%w[3 2 1])

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,6 +2,8 @@ require "byebug"
 require 'capybara/rspec'
 require 'webmock/rspec'
 
+WebMock.disable_net_connect!(allow_localhost: true)
+
 ENV["RAILS_ENV"] ||= "test"
 require File.expand_path('../config/environment', __dir__)
 require "rspec/rails"
@@ -11,6 +13,8 @@ if ENV["TEST_COVERAGE"] == "true"
   require "simplecov"
   SimpleCov.start
 end
+
+GovukTest.configure
 
 RSpec.configure do |config|
   config.expose_dsl_globally = false

--- a/spec/routing/help_routing_spec.rb
+++ b/spec/routing/help_routing_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe 'routes for Help' do
+  it 'routes /help to Help' do
+    expect(get('/help')).to route_to('help#show')
+  end
+
+  it 'does not route /help/<id>' do
+    expect(get('/help/1')).not_to be_routable
+  end
+end


### PR DESCRIPTION
# What

https://trello.com/c/D1sGgrBa/1144-5-view-help-text-in-table-frontend
- Move the help text into modals that appear on click
- Offer a non-js experience (also allows user to right click and open in new window)
- Support testing page elements that rely on js and add a test for modals

# Why
Title text was an interim measure, users have been seen struggling with it in testing as it only appears on hover, and even then is patchy. This is way better for accessibility and general usability.

# Screenshots

## Before
![Screen Shot 2019-03-12 at 11 39 37](https://user-images.githubusercontent.com/31649453/54197507-0a5e3f80-44bc-11e9-8cff-4a6db0a26039.png)

## After
![Screen Shot 2019-03-12 at 11 39 56](https://user-images.githubusercontent.com/31649453/54197521-12b67a80-44bc-11e9-9f0a-ec188a306852.png)
