### PR TITLE
Fix nil satisfaction score value

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -161,7 +161,7 @@ private
   end
 
   def useful_yes_no_total
-    value_for('useful_yes') + value_for('useful_no')
+    value_for('useful_yes').to_i + value_for('useful_no').to_i
   end
 
   def metadata

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -167,6 +167,19 @@ RSpec.describe SingleContentItemPresenter do
       expect(subject.satisfaction_context).to eq(expected_context)
     end
 
+    it 'does not fail when there are no metrics' do
+      current_period_data[:time_series_metrics] = [
+        { name: 'pviews', total: 5 },
+        { name: 'upviews', total: 5 },
+        { name: 'useful_yes', total: nil },
+        { name: 'useful_no', total: nil },
+      ]
+
+      expected_context = 'Users who found the page useful, out of 0 responses'
+      expect(subject.satisfaction_context).to eq(expected_context)
+    end
+  end
+
   describe '#total_feedex' do
     it 'correctly formats number for a value in the millions' do
       current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 1_000 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -154,6 +154,19 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
+  describe '#satisfaction_context' do
+    it 'returns context about the satisfaction metric' do
+      current_period_data[:time_series_metrics] = [
+        { name: 'pviews', total: 5 },
+        { name: 'upviews', total: 5 },
+        { name: 'useful_yes', total: 5 },
+        { name: 'useful_no', total: 10 },
+      ]
+
+      expected_context = 'Users who found the page useful, out of 15 responses'
+      expect(subject.satisfaction_context).to eq(expected_context)
+    end
+
   describe '#total_feedex' do
     it 'correctly formats number for a value in the millions' do
       current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 1_000 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]


### PR DESCRIPTION
[Trello](https://trello.com/c/r365wSrf/1178-3-user-satisfaction-chart-have-a-line-along-zero-rather-than-no-line-for-dates-before-data-exists)

We are getting errors in Staging when the we have no metrics for 
`useful_yes` and `useful_no`. This PR fixes this problem by converting
the metric to `0` before doing calculations.

This is consistent with the meaning of the metric as having no responses
about a particular page is the same as having 0.