### PR TITLE
Fix chart height

### DIFF
--- a/app/assets/stylesheets/components/_chart.scss
+++ b/app/assets/stylesheets/components/_chart.scss
@@ -75,7 +75,7 @@
   #chart-5,
   #chart-6,
   #chart-7 {
-    height: 350px;
+    height: 250px;
   }
 
   @include media(mobile) {

--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -42,7 +42,7 @@
   # config options are here: https://developers.google.com/chart/interactive/docs/gallery/linechart
   chart_library_options = {
     legend: 'none',
-    chartArea: { width: chart_width, height: '95%' },
+    chartArea: { width: chart_width, height: '85%' },
     curveType: 'none',
     tooltip: { showColorCode: true, isHtml: true, trigger: 'both'},
     crosshair: { orientation: 'vertical', trigger: 'both', color: '#ccc' },


### PR DESCRIPTION
# What
This reduces the height of the charts to reduce the page length.
It also reverts a previously introduced bug and gives the chart
enough height within its container to show the X axis value again.

https://trello.com/c/Y0SNB7jW/1246-1-adjust-the-height-of-the-chart-area

# Why
Bugfix & optimising page length

# Screenshots

## Before
![Screen Shot 2019-03-14 at 10 49 06](https://user-images.githubusercontent.com/31649453/54351168-cc415700-4646-11e9-9fc5-67e710e1d22d.png)

## After
![Screen Shot 2019-03-14 at 10 49 16](https://user-images.githubusercontent.com/31649453/54351179-d400fb80-4646-11e9-9881-04c63c22943a.png)
