### PR TITLE
Add GTM data attribute to sort links

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -95,6 +95,7 @@
                 data-gtm-id="<%= header %>-column">
                 <% if header.in? TableHeaderHelper::HEADERS_WITH_SORT_ENABLED %>
                   <a href="<%= url_for(request.params.merge(sort: sort_param(header, sort_direction))) %>"
+                    data-gtm-id="sort-link"
                     class="table__sort-link <% if sort_direction.present? %> table__sort-link--<%= sort_direction %> <% end %>">
                     <%= t(".table.headers.#{header}", default: :"metrics.#{header}.title") %>
                   </a>


### PR DESCRIPTION
A final tweak to support the modals as per
https://trello.com/c/D1sGgrBa/1144-5-view-help-text-in-table-frontend

This adds an attribute to make it easier to differentiate between clicks on the sort link and the help link inside the table header.