### PR TITLE
Add test for sort link specific tracking

### DIFF
--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -41,6 +41,13 @@ RSpec.feature 'user analytics' do
     end
   end
 
+  sortable_columns = %w(document_type upviews satisfaction searches)
+  sortable_columns.each do |column|
+    scenario "tracks sort link for #{column}" do
+      expect(page).to have_selector("[data-gtm-id=\"#{column}-column\"] [data-gtm-id=\"sort-link\"]")
+    end
+  end
+
   scenario 'tracks table header' do
     expect(page).to have_selector('[data-gtm-id="table-header"]')
   end


### PR DESCRIPTION
With the addition of modals for help we now have two links in the table
headers and specify the type on each. This adds the test for the tracking
on the sort link. The help link tracking is already tested for, it was just
repositioned.

https://trello.com/c/CipOJ9eK/1251-placeholder-add-tests-for-newly-added-gtm-tags