### PR TITLE
Add CSV download via email link

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "~> 5.2"
 
 gem "bootsnap", "~> 1"
 gem "chartkick"
+gem 'fog-aws', '~> 3'
 gem "gds-api-adapters", "~> 57"
 gem "gds-sso", "~> 14"
 gem "govuk_app_config", "~> 1"

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "gds-api-adapters", "~> 57"
 gem "gds-sso", "~> 14"
 gem "govuk_app_config", "~> 1"
 gem "govuk_publishing_components", "~> 16.6"
+gem 'govuk_sidekiq', '~> 3'
 gem 'kaminari'
 gem 'logstasher'
 gem "pg", "~> 1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,7 @@ GEM
       nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
+    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -142,6 +143,13 @@ GEM
       rake
       rouge
       sass-rails (>= 5.0.4)
+    govuk_sidekiq (3.0.3)
+      gds-api-adapters (>= 19.1.0)
+      govuk_app_config (>= 1.1)
+      redis-namespace (~> 1.6)
+      sidekiq (>= 5, < 6)
+      sidekiq-logging-json (~> 0.0)
+      sidekiq-statsd (~> 0.1)
     govuk_test (0.4.1)
       capybara
       chromedriver-helper
@@ -242,6 +250,8 @@ GEM
     rack (2.0.6)
     rack-cache (1.9.0)
       rack (>= 0.4)
+    rack-protection (2.0.5)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.2.1)
@@ -274,6 +284,9 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
+    redis (4.1.0)
+    redis-namespace (1.6.0)
+      redis (>= 3.0.4)
     regexp_parser (1.3.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -337,6 +350,17 @@ GEM
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
+    sidekiq (5.2.5)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
+    sidekiq-logging-json (0.0.18)
+      sidekiq (>= 3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -399,6 +423,7 @@ DEPENDENCIES
   govuk-lint (~> 3)
   govuk_app_config (~> 1)
   govuk_publishing_components (~> 16.6)
+  govuk_sidekiq (~> 3)
   govuk_test
   kaminari
   listen (~> 3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,6 +86,7 @@ GEM
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.8.0)
+    excon (0.62.0)
     execjs (2.7.0)
     factory_bot (5.0.0)
       activesupport (>= 4.2.0)
@@ -95,6 +96,23 @@ GEM
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     ffi (1.10.0)
+    fog-aws (3.4.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.1.2)
+      builder
+      excon (~> 0.58)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.2.5)
     gds-api-adapters (57.5.0)
       addressable
       link_header
@@ -164,6 +182,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    ipaddress (0.8.3)
     jaro_winkler (1.5.2)
     json (2.1.0)
     jwt (2.1.0)
@@ -418,6 +437,7 @@ DEPENDENCIES
   capybara
   chartkick
   factory_bot_rails
+  fog-aws (~> 3)
   gds-api-adapters (~> 57)
   gds-sso (~> 14)
   govuk-lint (~> 3)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/app/controllers/concerns/file_storage.rb
+++ b/app/controllers/concerns/file_storage.rb
@@ -1,0 +1,26 @@
+module FileStorage
+  def upload_csv_to_s3(basename, body)
+    connection = Fog::Storage.new(
+      provider: 'AWS',
+      region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    )
+
+    directory = connection.directories.get(ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
+
+    timestamp = Time.now.utc.strftime('%Y-%m-%d-%H-%M-%S')
+    filename = "#{basename}.csv"
+    key = "#{timestamp}/#{filename}"
+
+    file = directory.files.create(
+      key: key,
+      body: body,
+      public: true,
+      content_disposition: "attachment; filename=\"#{filename}\"",
+      content_type: 'text/csv'
+    )
+
+    file.public_url
+  end
+end

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -5,7 +5,7 @@ class ContentController < ApplicationController
   DEFAULT_ORGANISATION_ID = 'all'.freeze
 
   layout 'application'
-  before_action :set_constants
+  before_action :set_constants, only: [:index]
 
   def set_constants
     @fullwidth = true
@@ -20,6 +20,12 @@ class ContentController < ApplicationController
     @presenter = ContentItemsPresenter.new(
       search_results, search_params, document_types, organisations,
     )
+  end
+
+  def export_csv
+    recipient = current_user.email
+
+    CsvExportWorker.perform_async(search_params, recipient)
   end
 
 private

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -15,25 +15,11 @@ class ContentController < ApplicationController
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]
 
-    respond_to do |format|
-      format.html do
-        search_results = FindContent.call(search_params)
+    search_results = FindContent.call(search_params)
 
-        @presenter = ContentItemsPresenter.new(
-          search_results, search_params, document_types, organisations,
-        )
-      end
-      format.csv do
-        presenter = ContentItemsCSVPresenter.new(
-          FindContent.enum(search_params),
-          search_params,
-          document_types,
-          organisations
-        )
-
-        export_to_csv(enum: presenter.csv_rows, filename: presenter.filename)
-      end
-    end
+    @presenter = ContentItemsPresenter.new(
+      search_results, search_params, document_types, organisations,
+    )
   end
 
 private

--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -23,9 +23,9 @@ class ContentController < ApplicationController
   end
 
   def export_csv
-    recipient = current_user.email
+    @recipient = current_user.email
 
-    CsvExportWorker.perform_async(search_params, recipient)
+    CsvExportWorker.perform_async(search_params, @recipient)
   end
 
 private

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,0 +1,4 @@
+class ApplicationMailer < ActionMailer::Base
+  default from: 'Content Data <no-reply-content-data@digital.cabinet-office.gov.uk>'
+  layout false
+end

--- a/app/mailers/content_csv_mailer.rb
+++ b/app/mailers/content_csv_mailer.rb
@@ -1,0 +1,6 @@
+class ContentCsvMailer < ApplicationMailer
+  def content_csv_email(recipient, csv_link)
+    @file_url = csv_link
+    mail(to: recipient, subject: "Your GOV.UK Content Data export")
+  end
+end

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -66,7 +66,7 @@ class ContentItemsCSVPresenter
   end
 
   def filename
-    "content-data-export-from-%<from>s-to-%<to>s-from-%<org>s%<document_type>s.csv" % {
+    "content-data-export-from-%<from>s-to-%<to>s-from-%<org>s%<document_type>s" % {
       from: @date_range.from,
       to: @date_range.to,
       org: organisation_title(@organisations, @organisation_id).parameterize,

--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -56,13 +56,11 @@ class ContentItemsCSVPresenter
       end
     }
 
-    Enumerator.new do |yielder|
-      yielder << CSV.generate_line(fields.keys)
+    CSV.generate do |csv|
+      csv << fields.keys
 
       @data_enum.each do |result_row|
-        yielder << CSV.generate_line(
-          fields.values.map { |value_callable| value_callable.call(result_row) }
-        )
+        csv << fields.values.map { |value_callable| value_callable.call(result_row) }
       end
     end
   end

--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -1,0 +1,12 @@
+<% content_for :title, "Sending CSV export" %>
+<% content_for :page_class, "content-data__index" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/back_link", {
+      href: "/content",
+      text: "Back to search"
+    } %>
+    <h1 class="govuk-heading-xl">Sending CSV export</h1>
+    <p>An email will be sent to example@example.com with the CSV attachment.</p>
+  </div>
+</div>

--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -1,12 +1,15 @@
 <% content_for :title, "Sending CSV export" %>
-<% content_for :page_class, "content-data__index" %>
+<% content_for :page_class, "content-data__metrics" %>
+<% content_for :local_nav do %>
+  <div class="local-nav govuk-grid-column-one-quarter">
+    <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
+  </div>
+<% end %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/back_link", {
-      href: "/content",
-      text: "Back to search"
-    } %>
-    <h1 class="govuk-heading-xl">Sending CSV export</h1>
-    <p>An email will be sent to example@example.com with the CSV attachment.</p>
+    <h1 class="govuk-heading-l">Sending the CSV export</h1>
+    <p>The data you exported is on its way. We'll send an email to <%= @recipient %> with a link to download the CSV.</p>
+    <p>Most emails should arrive within 15 mins. If you don't recieve an email within 30 mins, contact 
+    <a href="mailto:content-data-feedback@digital.cabinet-office.gov.uk">content-data-feedback@digital.cabinet-office.gov.uk</a>.</p>
   </div>
 </div>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -65,14 +65,12 @@
         </div>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
-<!--
             <p>
-              <a href="<%#= content_path(@presenter.search_parameters.merge(format: :csv)) %>"
+              <a href="<%= content_export_csv_path(@presenter.search_parameters) %>"
                  class="govuk-link govuk-body-s download-link" data-gtm-id="csv-download-link">
                 Download all data in CSV format
               </a>
             </p>
--->
         </div>
     </div>
     <div class="govuk-grid-column-three-quarters">

--- a/app/views/content_csv_mailer/content_csv_email.text.erb
+++ b/app/views/content_csv_mailer/content_csv_email.text.erb
@@ -1,0 +1,7 @@
+The data you exported from Content Data is available from the link below:
+
+<%= @file_url %>
+
+If you have feedback on the Content Data tool or problems downloading the CSV, email content-data-feedback@digital.cabinet-office.gov.uk.
+
+Do not reply to this message.

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -7,7 +7,7 @@ class CsvExportWorker
 
   def perform(search_params, recipient_address)
     search_params = search_params.symbolize_keys
-    presenter = get_csv_presenter(search_params)
+    presenter = build_csv_presenter(search_params)
 
     basename = presenter.filename
     csv_string = presenter.csv_rows
@@ -18,7 +18,7 @@ class CsvExportWorker
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
   end
 
-  def get_csv_presenter(search_params)
+  def build_csv_presenter(search_params)
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]
 

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -2,6 +2,7 @@ class CsvExportWorker
   include Sidekiq::Worker
 
   def perform(search_params, recipient_address)
+    search_params = search_params.symbolize_keys
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]
 

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -2,6 +2,8 @@ require 'fog/aws'
 
 class CsvExportWorker
   include Sidekiq::Worker
+  sidekiq_options retry: 0
+  sidekiq_options queue: 'export_csv'
 
   def perform(search_params, recipient_address)
     search_params = search_params.symbolize_keys

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -1,23 +1,47 @@
+require 'fog/aws'
+
 class CsvExportWorker
   include Sidekiq::Worker
 
   def perform(search_params, recipient_address)
     search_params = search_params.symbolize_keys
+    presenter = get_csv_presenter(search_params)
+
+    timestamp = Time.now.utc.strftime('%Y-%m-%d-%H-%M-%S')
+    basename = presenter.filename
+    csv_string = presenter.csv_rows
+
+    file_url = upload_to_s3("#{timestamp}/#{basename}.csv", csv_string)
+
+    # Send email with link
+    ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
+  end
+
+  def get_csv_presenter(search_params)
     document_types = FetchDocumentTypes.call[:document_types]
     organisations = FetchOrganisations.call[:organisations]
 
     content_items = FindContent.enum(search_params)
-    presenter = ContentItemsCSVPresenter.new(
+    ContentItemsCSVPresenter.new(
       content_items,
       search_params,
       document_types,
       organisations
     )
+  end
 
-    csv_string = presenter.csv_rows
-    file_url = 'https://somelink.com'
+  def upload_to_s3(key, body)
+    connection = Fog::Storage.new(
+      provider: 'AWS',
+      region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    )
 
-    # Send email with link
-    ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
+    directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME'])
+
+    file = directory.files.create(key: key, body: body, public: true)
+
+    file.public_url
   end
 end

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -38,7 +38,7 @@ class CsvExportWorker
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
     )
 
-    directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME'])
+    directory = connection.directories.get(ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
 
     file = directory.files.create(key: key, body: body, public: true)
 

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -1,0 +1,22 @@
+class CsvExportWorker
+  include Sidekiq::Worker
+
+  def perform(search_params, recipient_address)
+    document_types = FetchDocumentTypes.call[:document_types]
+    organisations = FetchOrganisations.call[:organisations]
+
+    content_items = FindContent.enum(search_params)
+    presenter = ContentItemsCSVPresenter.new(
+      content_items,
+      search_params,
+      document_types,
+      organisations
+    )
+
+    csv_string = presenter.csv_rows
+    file_url = 'https://somelink.com'
+
+    # Send email with link
+    ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -47,6 +47,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
+  # Save emails to files from ActionMailer
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :file
+  config.action_mailer.raise_delivery_errors = true
+
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # This not used as evented file updates are not supported via VM

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,4 +36,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Perform sidekiq jobs immediately
+  config.active_job.queue_adapter = :sidekiq
+  require 'govuk_sidekiq/testing'
+  Sidekiq::Testing.inline!
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,5 +1,8 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.delivery_method = :test
+  config.action_mailer.raise_delivery_errors = true
 
   # The test environment is used exclusively to run your application's
   # test suite. You never need to work with it otherwise. Remember that

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
 
   get '/metrics/(*base_path)', to: 'metrics#show', as: :metrics, format: false
   get '/content', to: 'content#index'
+  get '/content/export_csv', to: 'content#export_csv'
   get '/help', to: 'help#show', as: :show, format: false
   mount GovukPublishingComponents::Engine, at: "/component-guide"
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:concurrency:  6
+:queues:
+  - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,3 @@
 :concurrency:  6
 :queues:
-  - default
+  - export_csv

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe 'Exporting CSV' do
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
     expect(page).to have_content('Sending the CSV export')
+    expect(page).to have_content('to@example.com')
   end
 
   it 'uploads the file' do

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -1,6 +1,6 @@
 require 'govuk_sidekiq/testing'
 
-RSpec.feature 'Exporting CSV' do
+RSpec.describe 'Exporting CSV' do
   include RequestStubs
   let(:items) do
     [
@@ -43,10 +43,26 @@ RSpec.feature 'Exporting CSV' do
     ]
   end
 
-  before do
+  before(:each) do
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: items)
     stub_content_page_csv_download(time_period: 'past-30-days', organisation_id: 'all', items: items)
     GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id', email: 'to@example.com')
+
+    Fog.mock!
+    ENV['AWS_REGION'] = 'eu-west-1'
+    ENV['AWS_ACCESS_KEY_ID'] = 'test'
+    ENV['AWS_SECRET_ACCESS_KEY'] = 'test'
+    ENV['AWS_S3_BUCKET_NAME'] = 'test-bucket'
+
+    # Create an S3 bucket so the code being tested can find it
+    connection = Fog::Storage.new(
+      provider: 'AWS',
+      region: ENV['AWS_REGION'],
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+    )
+    connection.directories.each(&:destroy)
+    @directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME']) || connection.directories.create(key: ENV['AWS_S3_BUCKET_NAME'])
 
     visit "/content"
     click_link('Download all data in CSV format')
@@ -54,12 +70,21 @@ RSpec.feature 'Exporting CSV' do
 
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
-    expect(page).to have_content('Sending Content Data CSV export')
+    expect(page).to have_content('Sending the CSV export')
+  end
+
+  it 'uploads the file' do
+    csv = CSV.parse(@directory.files.first.body)
+    expect(csv.length).to eq(4)
   end
 
   it 'sends a email with link to CSV export' do
     mail = ActionMailer::Base.deliveries.last
     expect(mail.to[0]).to eq('to@example.com')
-    expect(mail.body).to match('https://somelink.com')
+    expect(mail.body.to_s).to match(@directory.files.first.public_url)
+  end
+
+  after(:each) do
+    Fog::Mock.reset
   end
 end

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -1,0 +1,65 @@
+require 'govuk_sidekiq/testing'
+
+RSpec.feature 'Exporting CSV' do
+  include RequestStubs
+  let(:items) do
+    [
+      {
+        base_path: '/',
+        title: 'GOV.UK homepage',
+  organisation_id: 'org-id',
+        upviews: 1_233_018,
+        document_type: 'homepage',
+        satisfaction: 0.85,
+        useful_yes: 85,
+        useful_no: 15,
+        searches: 1220,
+        reading_time: 50
+      },
+      {
+        base_path: '/path/1',
+        title: 'The title',
+  organisation_id: 'org-id',
+        upviews: 233_018,
+        document_type: 'news_story',
+        satisfaction: 0.813,
+        useful_yes: 813,
+        useful_no: 187,
+        searches: 220,
+        reading_time: 50
+      },
+      {
+        base_path: '/path/2',
+        title: 'Another title',
+  organisation_id: 'org-id',
+        upviews: 100_018,
+        document_type: 'guide',
+        satisfaction: 0.68,
+        useful_yes: 34,
+        useful_no: 16,
+        searches: 12,
+        reading_time: 50
+      }
+    ]
+  end
+
+  before do
+    stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: items)
+    stub_content_page_csv_download(time_period: 'past-30-days', organisation_id: 'all', items: items)
+    GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id', email: 'to@example.com')
+
+    visit "/content"
+    click_link('Download all data in CSV format')
+  end
+
+  it 'renders the page without error' do
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content('Sending Content Data CSV export')
+  end
+
+  it 'sends a email with link to CSV export' do
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail.to[0]).to eq('to@example.com')
+    expect(mail.body).to match('https://somelink.com')
+  end
+end

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'Exporting CSV' do
     ENV['AWS_REGION'] = 'eu-west-1'
     ENV['AWS_ACCESS_KEY_ID'] = 'test'
     ENV['AWS_SECRET_ACCESS_KEY'] = 'test'
-    ENV['AWS_S3_BUCKET_NAME'] = 'test-bucket'
+    ENV['AWS_CSV_EXPORT_BUCKET_NAME'] = 'test-bucket'
 
     # Create an S3 bucket so the code being tested can find it
     connection = Fog::Storage.new(
@@ -62,7 +62,7 @@ RSpec.describe 'Exporting CSV' do
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
     )
     connection.directories.each(&:destroy)
-    @directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME']) || connection.directories.create(key: ENV['AWS_S3_BUCKET_NAME'])
+    @directory = connection.directories.create(key: ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
 
     visit "/content"
     click_link('Download all data in CSV format')

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -275,31 +275,4 @@ RSpec.describe '/content' do
       expect(page).to have_css('h1.table-caption', exact_text: 'Showing 150 results from org (OI)')
     end
   end
-
-  context 'CSV export' do
-    # Use lots of items to test getting a couple of full pages, plus a
-    # partial page back from the Content Performance Manager.
-    let(:csv_items) { items * 11 }
-
-    it 'it provides a CSV file respecting all filters' do
-      pending('Feature temporarily disabled')
-
-      stub_content_page(
-        time_period: 'last-month',
-        organisation_id: 'org-id',
-        items: csv_items,
-        search_terms: 'find this'
-      )
-      stub_content_page_csv_download(
-        time_period: 'last-month',
-        organisation_id: 'org-id',
-        items: csv_items,
-        search_terms: 'find this'
-      )
-      visit "/content?date_range=last-month&organisation_id=org-id&search_term=find+this"
-      click_link 'Download all data in CSV format'
-
-      expect(CSV.parse(page.body).length).to be(csv_items.length + 1)
-    end
-  end
 end

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -53,8 +53,6 @@ RSpec.feature 'user analytics' do
   end
 
   scenario 'tracks CSV download link' do
-    pending('Feature temporarily disabled')
-
     expect(page).to have_selector('[data-gtm-id="csv-download-link"]')
   end
 

--- a/spec/mailers/content_csv_mailer_spec.rb
+++ b/spec/mailers/content_csv_mailer_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ContentCsvMailer, type: :mailer do
+  describe 'content_csv_email' do
+    let(:mail) { ContentCsvMailer.content_csv_email('to@example.org', 'https://link-to-file.com') }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq('Your GOV.UK Content Data export')
+      expect(mail.from).to eq(['no-reply-content-data@digital.cabinet-office.gov.uk'])
+      expect(mail.to).to eq(["to@example.org"])
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('The data you exported from Content Data is available')
+    end
+
+    it 'contains the link' do
+      expect(mail.body.encoded).to match("https://link-to-file.com")
+    end
+  end
+end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe ContentItemsCSVPresenter do
     it 'includes the organisation and document_type' do
       expect(
         subject.filename
-      ).to include('from-org-in-news-story.csv')
+      ).to include('from-org-in-news-story')
     end
   end
 
@@ -194,7 +194,7 @@ RSpec.describe ContentItemsCSVPresenter do
     it 'includes all-organisations in filename' do
       expect(
         subject.filename
-      ).to include('from-all-organisations-in-news-story.csv')
+      ).to include('from-all-organisations-in-news-story')
     end
   end
 
@@ -204,7 +204,7 @@ RSpec.describe ContentItemsCSVPresenter do
     it 'includes no-organisation in filename' do
       expect(
         subject.filename
-      ).to include('from-no-organisation-in-news-story.csv')
+      ).to include('from-no-organisation-in-news-story')
     end
   end
 end

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe ContentItemsCSVPresenter do
       document_type: 'news_story'
     }
   end
+
   let(:data_enum) do
     [
       {
@@ -63,14 +64,14 @@ RSpec.describe ContentItemsCSVPresenter do
   describe '#csv_rows' do
     let(:presenter) { described_class.new(data_enum, search_params, document_types, organisations) }
 
-    subject { presenter.csv_rows }
+    subject { CSV.parse(presenter.csv_rows) }
 
     it 'returns the right number of rows' do
       expect(subject.count).to eq(3)
     end
 
     describe 'headers' do
-      subject { presenter.csv_rows.first }
+      subject { CSV.parse(presenter.csv_rows).first }
 
       expected_headers = [
         'Title',
@@ -98,12 +99,12 @@ RSpec.describe ContentItemsCSVPresenter do
       end
 
       it 'returns correct number of columns' do
-        expect(CSV.parse_line(subject).length).to be(expected_headers.length)
+        expect(subject.length).to be(expected_headers.length)
       end
     end
 
     describe 'values' do
-      subject { CSV.parse_line(presenter.csv_rows.to_a[1]) }
+      subject { CSV.parse(presenter.csv_rows)[1] }
 
       it 'has a title' do
         expect(subject[0]).to eq('GOV.UK homepage')

--- a/spec/routing/content_routing_spec.rb
+++ b/spec/routing/content_routing_spec.rb
@@ -3,6 +3,10 @@ RSpec.describe 'routes for Content' do
     expect(get('/content')).to route_to('content#index')
   end
 
+  it 'routes /content/export_csv' do
+    expect(get('/content/export_csv')).to route_to('content#export_csv')
+  end
+
   it 'does not route /content/<id>' do
     expect(get('/content/1')).not_to be_routable
   end

--- a/spec/workers/concerns/file_storage_spec.rb
+++ b/spec/workers/concerns/file_storage_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe 'FileStorage' do
+  include FileStorage
+  describe '#upload_csv_to_s3' do
+    before do
+      Timecop.freeze(Time.new(2019, 5, 4, 3, 2, 1, "+00:00"))
+      Fog.mock!
+
+      ENV['AWS_REGION'] = 'eu-west-1'
+      ENV['AWS_ACCESS_KEY_ID'] = 'test'
+      ENV['AWS_SECRET_ACCESS_KEY'] = 'test'
+      ENV['AWS_CSV_EXPORT_BUCKET_NAME'] = 'test-bucket'
+
+      # Create an S3 bucket so the code being tested can find it
+      connection = Fog::Storage.new(
+        provider: 'AWS',
+        region: ENV['AWS_REGION'],
+        aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+        aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
+      )
+      @directory = connection.directories.create(key: ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
+    end
+
+    after do
+      Fog::Mock.reset
+      Timecop.return
+    end
+
+    it 'uploads a file to s3' do
+      upload_csv_to_s3("basename", "body")
+
+      expect(@directory.files.first.key).to eq("2019-05-04-03-02-01/basename.csv")
+      expect(@directory.files.first.body).to eq("body")
+    end
+
+    it 'returns the public url' do
+      url = upload_csv_to_s3("basename", "")
+
+      expect(url).to eq('https://test-bucket.s3-eu-west-1.amazonaws.com/2019-05-04-03-02-01/basename.csv')
+    end
+  end
+end

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe CsvExportWorker do
 
   subject { described_class.new.perform(search_params, 'to@example.com') }
 
+  it 'uploads the file to S3' do
+    subject
+
+    expect(@directory.files.count).to eq(1)
+
+    csv = CSV.parse(@directory.files.first.body)
+    expect(csv.length).to eq(3)
+  end
+
   it 'emails a link of the uploaded file' do
     subject
 

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -1,0 +1,81 @@
+require 'govuk_sidekiq/testing'
+
+RSpec.describe CsvExportWorker do
+  let(:search_params) do
+    {
+      date_range: 'past-30-days',
+      organisation_id: 'org-id',
+      document_type: 'news_story'
+    }
+  end
+
+  let(:document_types) do
+    [{ id: 'case_study', name: 'Case study' },
+     { id: 'guide', name: 'Guide' },
+     { id: 'news_story', name: 'News story' },
+     { id: 'html_publication', name: 'HTML publication' }]
+  end
+
+  let(:organisations) do
+    [{ name: 'org', id: 'org-id', acronym: 'OI', },
+     { name: 'another org', id: 'another-org-id', },
+     { name: 'Users Org', id: 'users-org-id', acronym: 'UOI', }]
+  end
+
+  let(:content_items) do
+    [
+      {
+        title: 'GOV.UK homepage',
+        base_path: '/',
+        organisation_id: nil,
+        document_type: 'homepage',
+        upviews: 15,
+        pviews: 25,
+        satisfaction: 0.25,
+        useful_yes: 100,
+        useful_no: 300,
+        searches: 14,
+        feedex: 24,
+        word_count: 50,
+        reading_time: 50,
+        pdf_count: 0
+      },
+      {
+        title: 'Title 1',
+        base_path: '/base-path-1',
+        organisation_id: 'another-org-id',
+        document_type: 'guide',
+        upviews: 15,
+        pviews: 25,
+        satisfaction: 0.6,
+        useful_yes: 300,
+        useful_no: 200,
+        searches: 14,
+        feedex: 24,
+        word_count: 100,
+        reading_time: 100,
+        pdf_count: 3
+      }
+    ]
+  end
+
+  before do
+    Sidekiq::Worker.clear_all
+  end
+
+  subject { described_class.new.perform(search_params, 'to@example.com') }
+
+  it 'mails a csv' do
+    expect(FetchDocumentTypes).to receive(:call).and_return(document_types: document_types)
+    expect(FetchOrganisations).to receive(:call).and_return(organisations: organisations)
+    expect(FindContent).to receive(:enum)
+      .with(search_params)
+      .and_return(content_items)
+
+    subject
+
+    mail = ActionMailer::Base.deliveries.last
+    expect(mail.to[0]).to eq('to@example.com')
+    expect(mail.body).to match('https://somelink.com')
+  end
+end

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CsvExportWorker do
     ENV['AWS_REGION'] = 'eu-west-1'
     ENV['AWS_ACCESS_KEY_ID'] = 'test'
     ENV['AWS_SECRET_ACCESS_KEY'] = 'test'
-    ENV['AWS_S3_BUCKET_NAME'] = 'test-bucket'
+    ENV['AWS_CSV_EXPORT_BUCKET_NAME'] = 'test-bucket'
 
     # Create an S3 bucket so the code being tested can find it
     connection = Fog::Storage.new(
@@ -83,7 +83,7 @@ RSpec.describe CsvExportWorker do
       aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
       aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY']
     )
-    @directory = connection.directories.get(ENV['AWS_S3_BUCKET_NAME']) || connection.directories.create(key: ENV['AWS_S3_BUCKET_NAME'])
+    @directory = connection.directories.create(key: ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
   end
 
   subject { described_class.new.perform(search_params, 'to@example.com') }
@@ -94,5 +94,9 @@ RSpec.describe CsvExportWorker do
     mail = ActionMailer::Base.deliveries.last
     expect(mail.to[0]).to eq('to@example.com')
     expect(mail.body).to match(/https:\/\/test-bucket.s3-eu-west-1.amazonaws.com/)
+  end
+
+  after(:each) do
+    Fog::Mock.reset
   end
 end


### PR DESCRIPTION
# What
This adds the ability to download CSV of the data on the content page via an link emailed to the user.
Changes include:
- Adding CSV download link on content page
- Add Sidekiq process and worker support
- Add CSV export Sidekiq worker that generate the CSV file, uploads to S3 and emails the user.
- Add ActionMailer to mail the user
- Add download request confirmation page when user clicks on download CSV

# Why
This is to provide CSV format of the data on the content page. Previously the user could download the file by streaming the download as it was generated. However, this had issues with server timeouts and quirks in browsers behaviours around streaming files. 

This approach aims to generate the file before making it available for the user to download. The CSV is generated asynchronously as it is a long blocking process. The file is then uploaded to S3, as the file is too large to attach to the email directly. The user is then sent an email, to alert them that the data is ready to download. This should provide a more stable experience for downloading the data and be more consistent with other apps in GOV.UK that also use this workflow.

# Screenshots

## After
<img width="984" alt="image" src="https://user-images.githubusercontent.com/11051676/54752548-720c3d00-4bd6-11e9-83cb-7d702b043dca.png">

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.