### PR TITLE
Hide satisfaction score chart

### DIFF
--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -126,11 +126,14 @@
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
-    <%= render 'metric_section',
-        metric_name: 'satisfaction',
-        total: @performance_data.total_satisfaction,
-        short_context: @performance_data.satisfaction_short_context,
-        external_link: nil %>
+    <div class="metric-summary__satisfaction">
+      <%= render 'metric_header', {
+          metric_name: 'satisfaction',
+          value: @performance_data.total_satisfaction,
+          show_trend: true,
+          short_context: @performance_data.satisfaction_short_context
+      }%>
+    </div>
   </div>
 </div>
 

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -234,12 +234,10 @@ RSpec.describe '/metrics/base/path', type: :feature do
         expect(page).to have_selector('.govuk-link', text: I18n.t("metrics.searches.external_link"))
       end
 
-      it 'renders the metric timeseries for satisfaction' do
-        satisfaction_rows = extract_table_content(".chart.satisfaction table")
-        expect(satisfaction_rows).to match_array([
-          expected_table_dates,
-          ["User satisfaction score", "100%", "90%", "80%"]
-        ])
+      it 'renders the satisfaction score' do
+        within '.section-performance' do
+          expect(page).to have_selector('.metric-summary__satisfaction', text: '90% (700 responses) +50.00%')
+        end
       end
 
       it 'renders the metric timeseries for ' do


### PR DESCRIPTION
# What
Hides the graph and table for User Satisfaction on the Page Metrics page.

# Why
User research shows that this is not useful at the moment. Hiding for
now until we can do some more thinking on it.

# Screenshots

## Before
![Screenshot at Mar 20 4-50-50 pm](https://user-images.githubusercontent.com/424772/54703310-741bc080-4b30-11e9-9ef4-9a2d08338673.png)


## After
![Screenshot at Mar 20 4-50-27 pm](https://user-images.githubusercontent.com/424772/54703336-81d14600-4b30-11e9-8213-a6d1b6769f66.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
