### PR TITLE
Add tests for app name tracking on metrics page

### DIFF
--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -36,4 +36,8 @@ RSpec.feature 'user analytics' do
   scenario 'tracks metric "about this data" reveal' do
     expect(page).to have_selector('[data-gtm-id="metric-summary"] summary')
   end
+
+  scenario 'tracks clicks on app name in header' do
+    expect(page).to have_selector('.govuk-phase-banner__content__app-name')
+  end
 end


### PR DESCRIPTION
# What
This adds a feature to test to tracking of users clicking on the app name in the banner on the metrics page.

# Why
To make sure we don't break page attributes used by Google Tag Manager

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
