### PR TITLE
Abbreviate glance metric figures

### DIFF
--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -1,16 +1,30 @@
 <%
+  measurement_display_labels = {Thousand: 'k', Million: 'm', Billion: 'b'}
   name ||= false
   figure ||= false
   period ||= false
-  measurement_display_label ||= ""
-  measurement_explicit_label ||= ""
   context ||= ""
   trend_percentage ||= ""
+
+  if figure
+    number = number_to_human(figure.gsub(/,/, '').to_i, :format => '%n', :precision => 3)
+    measurement_explicit_label = number_to_human(figure.gsub(/,/, '').to_i, :format => '%u', :precision => 3)
+    if figure.end_with? "%"
+      measurement_display_label = "%"
+    else
+      measurement_display_label = measurement_display_labels[measurement_explicit_label.to_sym]
+    end
+  end
 %>
 <% if name && figure && period %>
   <div class="app-c-glance-metric govuk-body">
     <h3 class="app-c-glance-metric__heading"><%= name %></h3>
-    <span class="app-c-glance-metric__figure"><%= figure %><span class="app-c-glance-metric__measurement" <% if measurement_explicit_label %>aria-label="<%= measurement_explicit_label %>"<% end %>><%= measurement_display_label %></span></span>
+    <span class="app-c-glance-metric__figure"><%= number %><% if measurement_display_label %><span class="app-c-glance-metric__measurement"
+        <% if measurement_explicit_label %>
+          aria-label="<%= measurement_explicit_label %>"
+        <% end %>><%= measurement_display_label %></span>
+    <% end %>
+    </span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">
       <% if trend_percentage.blank? %>

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -4,9 +4,7 @@ RSpec.describe "Glance Metric", type: :view do
   let(:data) {
     {
       name: "Unique pageviews",
-      figure: "167",
-      measurement_display_label: "m",
-      measurement_explicit_label: "million",
+      figure: "167,000,000",
       context: "This is in your top 10 items",
       trend_percentage: 0.5,
       period: "Apr 2018 to Mar 2018",
@@ -37,10 +35,27 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric"
     assert_select ".app-c-glance-metric__heading", text: "Unique pageviews"
     assert_select ".app-c-glance-metric__figure", text: "167m"
-    assert_select ".app-c-glance-metric__measurement[aria-label=million]"
+    assert_select ".app-c-glance-metric__measurement[aria-label=Million]"
     assert_select ".app-c-glance-metric__context", text: "This is in your top 10 items"
     assert_select ".app-c-glance-metric__trend", text: "+0.50%"
     assert_select ".app-c-glance-metric__period", text: "Apr 2018 to Mar 2018"
+  end
+
+  it "formats the number and label correctly" do
+    render_component(data)
+    assert_select ".app-c-glance-metric__figure", text: "167m"
+    assert_select ".app-c-glance-metric__measurement[aria-label=Million]"
+    data[:figure] = "15,000,000,000"
+    render_component(data)
+    assert_select ".app-c-glance-metric__figure", text: "15b"
+    assert_select ".app-c-glance-metric__measurement[aria-label=Billion]"
+    data[:figure] = "15,000"
+    render_component(data)
+    assert_select ".app-c-glance-metric__figure", text: "15k"
+    assert_select ".app-c-glance-metric__measurement[aria-label=Thousand]"
+    data[:figure] = "15%"
+    render_component(data)
+    assert_select ".app-c-glance-metric__figure", text: "15%"
   end
 
   it "does not show an aria label if no explicit measurement label is provided" do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     describe 'glance metrics section' do
       it 'renders glance metrics unique page views' do
-        expect(page).to have_selector '.glance-metric.upviews', text: '6,000'
+        expect(page).to have_selector '.glance-metric.upviews', text: '6k'
       end
 
       it 'renders trend percentage for unique pageviews' do


### PR DESCRIPTION
# What
https://trello.com/c/aWmUQbVq/947-2-fix-overflowing-figures-on-glance-metrics
This updates the Glance Metric component to let it abbreviate the figures it is passed and apply the visible label and screenreader support label. It updates the existing tests and adds a couple more.

# Why
Glance metrics were written to take input of an abbreviated number and the appropriate labels, but we have never passed in the data in that format. This means that the text is often stretching the limits of its container and occasionally overflows.

# Screenshots

Note that the before/after are not using the same dataset - the code does properly round the numbers.

## Before
![Screen Shot 2019-03-26 at 08 33 41](https://user-images.githubusercontent.com/31649453/54982905-a94a6780-4fa3-11e9-88be-c34130562c63.png)

## After
![Screen Shot 2019-03-26 at 08 33 50](https://user-images.githubusercontent.com/31649453/54982914-aea7b200-4fa3-11e9-9f6d-f9f42aa524ac.png)
