### PR TITLE
Fix spelling mistakes in CSV export view

### DIFF
--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sending the CSV export</h1>
     <p>The data you exported is on its way. We'll send an email to <%= @recipient %> with a link to download the CSV.</p>
-    <p>Most emails should arrive within 15 mins. If you don't recieve an email within 30 mins, contact 
+    <p>Most emails should arrive within 15 minutes. If you don't receive an email within 30 minutes, contact 
     <a href="mailto:content-data-feedback@digital.cabinet-office.gov.uk">content-data-feedback@digital.cabinet-office.gov.uk</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
The word 'receive' was corrected and mins was elongated to minutes.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
