### PR TITLE
Revert "Disable CSV download link"

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -65,12 +65,12 @@
         </div>
 
             <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
-            <!-- <p>
-              <a href="<%# content_export_csv_path(@presenter.search_parameters) %>"
+            <p>
+              <a href="<%= content_export_csv_path(@presenter.search_parameters) %>"
                  class="govuk-link govuk-body-s download-link" data-gtm-id="csv-download-link">
                 Download all data in CSV format
               </a>
-            </p> -->
+            </p>
         </div>
     </div>
     <div class="govuk-grid-column-three-quarters">

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -44,7 +44,6 @@ RSpec.describe 'Exporting CSV' do
   end
 
   before(:each) do
-    pending("something else getting finished")
     stub_content_page(time_period: 'past-30-days', organisation_id: 'all', items: items)
     stub_content_page_csv_download(time_period: 'past-30-days', organisation_id: 'all', items: items)
     GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id', email: 'to@example.com')

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -53,7 +53,6 @@ RSpec.feature 'user analytics' do
   end
 
   scenario 'tracks CSV download link' do
-    pending("something else getting finished")
     expect(page).to have_selector('[data-gtm-id="csv-download-link"]')
   end
 


### PR DESCRIPTION
This reverts PR #439. This now makes the CSV download link visible for users, as previously disabled due to issues with analytics tracking.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
