### PR TITLE
Abbreviate glance metric figures

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -15,6 +15,18 @@ class SingleContentItemPresenter
     assign_pageviews_per_visit
   end
 
+  def abbreviated_total_upviews
+    abbreviate(value_for('upviews'))
+  end
+
+  def abbreviated_total_searches
+    abbreviate(value_for('searches'))
+  end
+
+  def abbreviated_total_feedex
+    abbreviate(value_for('feedex'))
+  end
+
   def total_upviews
     number_with_delimiter value_for('upviews')
   end
@@ -155,6 +167,14 @@ class SingleContentItemPresenter
   end
 
 private
+
+  def abbreviate(number)
+    {
+      figure: number_to_human(number, format: '%n'),
+      display_label: number_to_human(number, format: '%u', units: { unit: "", thousand: "k", million: "m", billion: "b" }),
+      explicit_label: number_to_human(number, format: '%u')
+    }
+  end
 
   def value_for(metric)
     @metrics[metric][:value]

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -2,15 +2,20 @@
   name ||= false
   figure ||= false
   period ||= false
-  measurement_display_label ||= ""
-  measurement_explicit_label ||= ""
   context ||= ""
   trend_percentage ||= ""
+  measurement_display_label ||= ""
+  measurement_explicit_label ||= ""
 %>
 <% if name && figure && period %>
   <div class="app-c-glance-metric govuk-body">
     <h3 class="app-c-glance-metric__heading"><%= name %></h3>
-    <span class="app-c-glance-metric__figure"><%= figure %><span class="app-c-glance-metric__measurement" <% if measurement_explicit_label %>aria-label="<%= measurement_explicit_label %>"<% end %>><%= measurement_display_label %></span></span>
+    <span class="app-c-glance-metric__figure"><%= figure %><% if measurement_display_label %><span class="app-c-glance-metric__measurement"
+        <% if measurement_explicit_label %>
+          aria-label="<%= measurement_explicit_label %>"
+        <% end %>><%= measurement_display_label %></span>
+    <% end %>
+    </span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">
       <% if trend_percentage.blank? %>

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -1,7 +1,9 @@
 <div class="govuk-grid-column-one-quarter glance-metric <%=metric_name%>">
   <%= render "components/glance-metric", {
       name: @performance_data.metric_short_title(metric_name),
-      figure: total,
+      figure: total[:figure],
+      measurement_display_label: total[:display_label],
+      measurement_explicit_label: total[:explicit_label],
       context: context,
       trend_percentage: @performance_data.trend_percentage(metric_name),
       period: @performance_data.period

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -58,22 +58,22 @@
 <div class="govuk-grid-row" data-gtm-id="glance-metrics">
   <%= render "glance_metric",
       metric_name: "upviews",
-      total: @performance_data.total_upviews,
+      total: @performance_data.abbreviated_total_upviews,
       context: nil %>
 
   <%= render "glance_metric",
       metric_name: "satisfaction",
-      total: @performance_data.total_satisfaction,
+      total: {figure: @performance_data.total_satisfaction},
       context: @performance_data.satisfaction_context %>
 
   <%= render "glance_metric",
       metric_name: "searches",
-      total: @performance_data.total_searches,
+      total: @performance_data.abbreviated_total_searches,
       context: @performance_data.searches_context %>
 
   <%= render "glance_metric",
       metric_name: "feedex",
-      total: @performance_data.total_feedex,
+      total: @performance_data.abbreviated_total_feedex,
       context: @performance_data.feedex_context %>
 </div>
 

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Glance Metric", type: :view do
     {
       name: "Unique pageviews",
       figure: "167",
+      measurement_explicit_label: 'Million',
       measurement_display_label: "m",
-      measurement_explicit_label: "million",
       context: "This is in your top 10 items",
       trend_percentage: 0.5,
       period: "Apr 2018 to Mar 2018",
@@ -37,7 +37,7 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric"
     assert_select ".app-c-glance-metric__heading", text: "Unique pageviews"
     assert_select ".app-c-glance-metric__figure", text: "167m"
-    assert_select ".app-c-glance-metric__measurement[aria-label=million]"
+    assert_select ".app-c-glance-metric__measurement[aria-label=Million]"
     assert_select ".app-c-glance-metric__context", text: "This is in your top 10 items"
     assert_select ".app-c-glance-metric__trend", text: "+0.50%"
     assert_select ".app-c-glance-metric__period", text: "Apr 2018 to Mar 2018"

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     describe 'glance metrics section' do
       it 'renders glance metrics unique page views' do
-        expect(page).to have_selector '.glance-metric.upviews', text: '6,000'
+        expect(page).to have_selector '.glance-metric.upviews', text: '6k'
       end
 
       it 'renders trend percentage for unique pageviews' do

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -194,6 +194,38 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
+  describe '#abbreviated_total_feedex' do
+    it 'correctly formats a value in the billions' do
+      current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 1_000_000_000 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]
+
+      expect(subject.abbreviated_total_feedex).to eq(display_label: "b", explicit_label: "Billion", figure: "1")
+    end
+
+    it 'correctly formats a value in the millions' do
+      current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 1_489_000 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]
+
+      expect(subject.abbreviated_total_feedex).to eq(display_label: "m", explicit_label: "Million", figure: "1.49")
+    end
+
+    it 'correctly formats a value in the thousands' do
+      current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 3_353 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]
+
+      expect(subject.abbreviated_total_feedex).to eq(display_label: "k", explicit_label: "Thousand", figure: "3.35")
+    end
+
+    it 'correctly formats a small value' do
+      current_period_data[:time_series_metrics] = [{ name: 'feedex', total: 53 }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]
+
+      expect(subject.abbreviated_total_feedex).to eq(display_label: "", explicit_label: "", figure: "53")
+    end
+
+    it 'handles nil values' do
+      current_period_data[:time_series_metrics] = [{ name: 'feedex', total: nil }, { name: 'upviews', total: '0' }, { name: 'pviews', total: 0 }]
+
+      expect(subject.abbreviated_total_feedex).to eq(display_label: nil, explicit_label: nil, figure: nil)
+    end
+  end
+
   describe '#total_words' do
     it 'correctly formats number for a value in the millions' do
       current_period_data[:edition_metrics] = [{ name: 'words', value: 5_000 }]


### PR DESCRIPTION
# What
https://trello.com/c/aWmUQbVq/947-2-fix-overflowing-figures-on-glance-metrics

Glance metrics were written to take input of an abbreviated number
and the appropriate labels, but we have never passed in the data in
that format. This means that the text is often stretching the limits
of its container and occasionally overflows. This change fixes that,
using a presenter to send the correct data to the glance metric
component where it is necessary to abbreviate.

# Screenshots

(Ignore the data disparity, the rounding is correct but the sources in each image are different.)

## Before
![Screen Shot 2019-03-26 at 08 33 41](https://user-images.githubusercontent.com/31649453/55074820-3b786b80-5089-11e9-86d7-71e35daee88b.png)

## After
![Screen Shot 2019-03-26 at 08 33 50](https://user-images.githubusercontent.com/31649453/55074832-429f7980-5089-11e9-9844-5dd56e574a8a.png)
