### PR TITLE
Lower the sidekiq worker concurrency

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,3 @@
-:concurrency:  6
+:concurrency:  2
 :queues:
   - export_csv


### PR DESCRIPTION
As the CSV is generated in memory, lowering the concurrency limit will prevent excessive memory usage with concurrent requests. This would have minimal user impact as they expect to wait for CSV
to be generated.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
