### PR TITLE
Move metadata into a table

### DIFF
--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -1,36 +1,18 @@
 .app-c-metadata__list {
-
-  @include media-down(mobile) {
-    @include govuk-clearfix;
-    margin-bottom: govuk-spacing(3);
-  }
+  width: 100%;
+  border-spacing: 0;
 }
 
 .app-c-metadata__title {
-  @include grid-column( 1 / 5);
+  width: 20%;
+  vertical-align: top;
+  text-align: left;
+  font-weight: normal;
   padding: 0;
-  margin: 0;
-
-  @include media-down(mobile) {
-    @include grid-column( 1 / 3, mobile );
-    @include govuk-font(16);
-    padding: 0;
-    margin: 0;
-    margin-bottom: govuk-spacing(1);
-  }
-}
-
-.app-c-metadata__title--wrappable {
-  height: 2.5em;
 }
 
 .app-c-metadata__description {
-
-  @include media-down(mobile) {
-    @include grid-column( 2 / 3, mobile );
-    @include govuk-font(16);
-    padding: 0;
-    margin: 0;
-    margin-bottom: govuk-spacing(1);
-  }
+  padding: 0;
 }
+
+

--- a/app/views/components/_metadata.html.erb
+++ b/app/views/components/_metadata.html.erb
@@ -5,21 +5,28 @@
     status ||= nil
 %>
 
-<div class="app-c-metadata govuk-body govuk-body-xs">
+<table class="app-c-metadata govuk-body govuk-body-xs app-c-metadata__list">
+
   <% if status %>
-    <dl class="app-c-metadata__list">
-      <dt class="app-c-metadata__title"><%= t ".labels.status" %></dt>
-      <dd class="app-c-metadata__description govuk-!-font-weight-bold"><%= status %></dd>
-    </dl>
+    <tr>
+        <th scope="row" class="app-c-metadata__title"><%= t ".labels.status" %></th>
+        <td class="app-c-metadata__description govuk-!-font-weight-bold"><%= status %></td>
+    </tr>
   <% end %>
-  <dl class="app-c-metadata__list">
-    <% if publishing_organisation %>
-      <dt class="app-c-metadata__title"><%= t ".labels.publishing_organisation" %></dt>
-      <dd class="app-c-metadata__description"><%= publishing_organisation %></dd>
-    <% end %>
-    <dt class="app-c-metadata__title"><%= t ".labels.document_type" %></dt>
-    <dd class="app-c-metadata__description"><%= document_type %></dd>
-    <dt class="app-c-metadata__title app-c-metadata__title--wrappable"><%= t ".labels.base_path" %></dt>
-    <dd class="app-c-metadata__description">gov.uk<%= base_path %></dd>
-  </dl>
-</div>
+  <% if publishing_organisation %>
+    <tr>
+      <th scope="row" class="app-c-metadata__title"><%= t ".labels.publishing_organisation" %></th>
+      <td class="app-c-metadata__description"><%= publishing_organisation %></td>
+    </tr>
+  <% end %>
+
+    <tr>
+      <th scope="row" class="app-c-metadata__title"><%= t ".labels.document_type" %></th>
+      <td class="app-c-metadata__description"><%= document_type %></td>
+    </tr>
+    <tr>
+      <th scope="row" class="app-c-metadata__title app-c-metadata__title--wrappable"><%= t ".labels.base_path" %></th>
+      <td class="app-c-metadata__description">gov.uk<%= base_path %></td>
+    </tr>
+
+</table>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe '/metrics/base/path', type: :feature do
 
     describe 'metadata section' do
       it 'renders the metadata' do
-        metadata = find('.page-metadata').all('dl').map do |el|
-          el.all('dt,dd').map(&:text)
+        metadata = find('.page-metadata').all('tr').map do |el|
+          el.all('th,td').map(&:text)
         end
         expect(metadata).to eq([
-                                 [I18n.t("components.metadata.labels.publishing_organisation"), 'The Ministry',
-                                  I18n.t("components.metadata.labels.document_type"), 'News story',
-                                  I18n.t("components.metadata.labels.base_path"), 'gov.uk/base/path']
+                                [I18n.t("components.metadata.labels.publishing_organisation"), 'The Ministry'],
+                                [I18n.t("components.metadata.labels.document_type"), 'News story'],
+                                [I18n.t("components.metadata.labels.base_path"), 'gov.uk/base/path']
                                ])
       end
     end


### PR DESCRIPTION
https://trello.com/c/NpoSJh3C/806-2-bug-fix-wrapping-on-page-metadata-at-tablet-size
The metadata was written as a list but has been formatted to look
like a simple table. This causes wrapping issues when the description
is long, so refactoring it into a table is both necessary and results
in cleaner code.

# Screenshots

## Before
![Screen Shot 2019-03-27 at 14 55 46](https://user-images.githubusercontent.com/31649453/55086622-a08b8b80-50a0-11e9-9b9d-814aedf49cb2.png)

## After
![Screen Shot 2019-03-27 at 14 55 57](https://user-images.githubusercontent.com/31649453/55086640-a5e8d600-50a0-11e9-99c6-ba38a3a6aaec.png)

