### PR TITLE
Remove underlines from links in the table on the index page.

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -173,6 +173,7 @@ $sort-link-arrow-spacing: 4px;
 
   .content-item__link {
     font-weight: bold;
+    text-decoration: none;
   }
 
   .filters-control__wrapper {


### PR DESCRIPTION
# What
https://trello.com/c/3ieHD7sB/1259-1-remove-underline-from-table-links
Remove underlines

# Why
Match design

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
![Screen Shot 2019-03-28 at 08 29 47](https://user-images.githubusercontent.com/31649453/55142102-bbf3a680-5133-11e9-8fa2-10e8cf6dbea0.png)

## After
![Screen Shot 2019-03-28 at 08 29 53](https://user-images.githubusercontent.com/31649453/55142110-c150f100-5133-11e9-8efa-db486c4e08ad.png)

