### PR TITLE
Split filter and content presenter

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -12,14 +12,10 @@ class ContentController < ApplicationController
   end
 
   def index
-    document_types = FetchDocumentTypes.call[:document_types]
-    organisations = FetchOrganisations.call[:organisations]
-
     search_results = FindContent.call(search_params)
 
-    @presenter = ContentItemsPresenter.new(
-      search_results, search_params, document_types, organisations,
-    )
+    @filter = FilterPresenter.new(search_params)
+    @presenter = ContentItemsPresenter.new(search_results, search_params)
   end
 
   def export_csv

--- a/app/presenters/content_items_presenter.rb
+++ b/app/presenters/content_items_presenter.rb
@@ -3,9 +3,8 @@ class ContentItemsPresenter
   attr_reader :title, :content_items, :pagination, :filter, :search_parameters, :sort
   delegate :page, :total_pages, :prev_link?, :next_link?, :prev_label, :next_label, to: :pagination
 
-  def initialize(search_results, search_parameters, document_types, organisations)
+  def initialize(search_results, search_parameters)
     @title = 'Content items'
-    @filter = FilterPresenter.new(search_parameters, document_types, organisations)
     @search_parameters = search_parameters
     @sort = Sort.parse(search_parameters[:sort])
     @pagination = PaginationPresenter.new(

--- a/app/presenters/filter_presenter.rb
+++ b/app/presenters/filter_presenter.rb
@@ -1,8 +1,9 @@
 class FilterPresenter
-  def initialize(search_parameters, document_types, organisations)
-    @document_types = document_types
+  def initialize(search_parameters)
+    @document_types = FetchDocumentTypes.call[:document_types]
+    @organisations = FetchOrganisations.call[:organisations]
+
     @search_parameters = search_parameters
-    @organisations = organisations
   end
 
   def search_terms?

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -42,8 +42,8 @@
                 label: {
                   text: "Document type"
                 },
-                options: @presenter.filter.document_type_options,
-                selected_option: @presenter.filter.selected_document_type(params)
+                options: @filter.document_type_options,
+                selected_option: @filter.selected_document_type(params)
               }
           %>
 
@@ -53,8 +53,8 @@
                 label: {
                   text: "Organisation"
                 },
-                options: @presenter.filter.organisation_options.unshift(['','all']),
-                selected_option: @presenter.filter.selected_organisation(params)
+                options: @filter.organisation_options.unshift(['','all']),
+                selected_option: @filter.selected_organisation(params)
               }
           %>
 
@@ -80,7 +80,7 @@
           data-gtm-pagination-total-results="<%= @presenter.pagination.total_results %>"
           data-gtm-page="<%= @presenter.pagination.page %>">
           <caption class="govuk-table__caption">
-            <%= render('table_data_description', pagination: @presenter.pagination, filter: @presenter.filter) %>
+            <%= render('table_data_description', pagination: @presenter.pagination, filter: @filter) %>
           </caption>
           <thead class="govuk-table__head" data-gtm-id="table-header">
             <tr class="govuk-table__row">

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when on the first page' do
-    let(:presenter) { ContentItemsPresenter.new(search_results, search_parameters, [], []) }
+    let(:presenter) { ContentItemsPresenter.new(search_results, search_parameters) }
     it 'only returns the `Next` link' do
       expect(navigation_links).to eq(next_page: { url: "/content?organisation_id=org-1&page=2",
                                                                   title: 'Next',
@@ -26,7 +26,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when on the last page' do
-    let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 3), search_parameters, [], []) }
+    let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 3), search_parameters) }
 
     it 'only returns the `Previous` link' do
       expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1&page=2",
@@ -36,7 +36,7 @@ RSpec.describe PaginationHelper do
   end
 
   context 'when in the middle somewhere' do
-    let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 2), search_parameters, [], []) }
+    let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 2), search_parameters) }
 
     it 'returns `Previous` and `Next` links' do
       expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1",

--- a/spec/presenters/content_items_presenter_spec.rb
+++ b/spec/presenters/content_items_presenter_spec.rb
@@ -1,8 +1,6 @@
 RSpec.describe ContentItemsPresenter do
   include GdsApi::TestHelpers::ContentDataApi
 
-  let(:document_types) { [] }
-  let(:organisations) { [] }
   let(:search_parameters) do
     {
       date_range: 'last-30-days',
@@ -27,7 +25,7 @@ RSpec.describe ContentItemsPresenter do
   end
 
   subject do
-    ContentItemsPresenter.new(content_items, search_parameters, document_types, organisations)
+    ContentItemsPresenter.new(content_items, search_parameters)
   end
 
   describe '#prev_link?' do

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -17,12 +17,13 @@ RSpec.describe FilterPresenter do
     }
   end
 
+  before do
+    allow(FetchDocumentTypes).to receive(:call).and_return(document_types: document_types)
+    allow(FetchOrganisations).to receive(:call).and_return(organisations: organisations)
+  end
+
   subject do
-    FilterPresenter.new(
-      search_parameters,
-      document_types,
-      organisations,
-    )
+    FilterPresenter.new search_parameters
   end
 
   describe '#document_type_options' do

--- a/spec/presenters/filter_presenter_spec.rb
+++ b/spec/presenters/filter_presenter_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FilterPresenter do
   end
 
   subject do
-    FilterPresenter.new search_parameters
+    FilterPresenter.new(search_parameters)
   end
 
   describe '#document_type_options' do


### PR DESCRIPTION
[Trello card](https://github.com/alphagov/content-data-admin/pull/454)

### What

1. It moves out `FilterPresenter` from `ContentItemsPresenter`
2. It inlines code to retrieve `Organisations` and `DocumentTypes`
3. It simplifes code and tests to make them more readable

**Note**

In next PR we need to move into `ActiveModel` the code related to `Organisations` and `DocumentTypes` as we should not handle JSON directly within the application.

### Code sample

```ruby
  def index
    document_types = FetchDocumentTypes.call[:document_types]
    organisations = FetchOrganisations.call[:organisations]

    search_results = FindContent.call(search_params)

    @presenter = ContentItemsPresenter.new(
      search_results, search_params, document_types, organisations,
    )
  end
```

to:

```ruby
  def index
    search_results = FindContent.call(search_params)

    @filter = FilterPresenter.new(search_params)
    @presenter = ContentItemsPresenter.new(search_results, search_params)
  end
```

