### PR TITLE
Clean-up `Gemfile`: remove explicit versioning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,39 +4,40 @@ source "https://rubygems.org"
 
 gem "rails", "~> 5.2"
 
-gem "bootsnap", "~> 1"
+gem "bootsnap"
 gem "chartkick"
-gem "fog-aws", '~> 3'
-gem "gds-api-adapters", "~> 59"
-gem "gds-sso", "~> 14"
-gem "govuk_app_config", "~> 1"
-gem "govuk_publishing_components", "~> 16.6"
-gem "govuk_sidekiq", '~> 3'
+gem "factory_bot_rails"
+gem "fog-aws"
+gem "gds-api-adapters"
+gem "gds-sso"
+gem "govuk_app_config"
+gem "govuk_publishing_components"
+gem "govuk_sidekiq"
 gem "kaminari"
 gem "logstasher"
 gem "pg", "~> 1"
-gem "plek", "~> 2"
-gem "uglifier", "~> 4"
+gem "plek"
+gem "uglifier"
 
 group :development do
   gem "listen", "~> 3"
 end
 
 group :test do
-  gem "simplecov", "~> 0.16"
-  gem "timecop", "~> 0.9.1"
+  gem "simplecov"
+  gem "timecop"
 end
 
 group :development, :test do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "byebug", "~> 11"
+  gem "byebug"
   gem "capybara"
   gem "factory_bot_rails"
-  gem "govuk-lint", "~> 3"
+  gem "govuk-lint"
   gem "govuk_test"
   gem 'pry'
-  gem "rspec-rails", "~> 3"
+  gem "rspec-rails"
   gem "spring-commands-rspec"
   gem "webmock"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,6 @@ gem "pg", "~> 1"
 gem "plek"
 gem "uglifier"
 
-group :development do
-  gem "listen", "~> 3"
-end
-
 group :test do
   gem "simplecov"
   gem "timecop"

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,14 @@ gem "rails", "~> 5.2"
 
 gem "bootsnap", "~> 1"
 gem "chartkick"
-gem 'fog-aws', '~> 3'
+gem "fog-aws", '~> 3'
 gem "gds-api-adapters", "~> 59"
 gem "gds-sso", "~> 14"
 gem "govuk_app_config", "~> 1"
 gem "govuk_publishing_components", "~> 16.6"
-gem 'govuk_sidekiq', '~> 3'
-gem 'kaminari'
-gem 'logstasher'
+gem "govuk_sidekiq", '~> 3'
+gem "kaminari"
+gem "logstasher"
 gem "pg", "~> 1"
 gem "plek", "~> 2"
 gem "uglifier", "~> 4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -201,10 +201,6 @@ GEM
     kgio (2.11.2)
     kramdown (1.15.0)
     link_header (0.0.8)
-    listen (3.1.5)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-      ruby_dep (~> 1.2)
     logstash-event (1.2.02)
     logstasher (1.2.2)
       activesupport (>= 4.0)
@@ -343,7 +339,6 @@ GEM
     rubocop-rspec (1.32.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.0)
-    ruby_dep (1.5.0)
     rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sanitize (5.0.0)
@@ -446,7 +441,6 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   kaminari
-  listen (~> 3)
   logstasher
   pg (~> 1)
   plek

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,31 +432,31 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
-  bootsnap (~> 1)
-  byebug (~> 11)
+  bootsnap
+  byebug
   capybara
   chartkick
   factory_bot_rails
-  fog-aws (~> 3)
-  gds-api-adapters (~> 59)
-  gds-sso (~> 14)
-  govuk-lint (~> 3)
-  govuk_app_config (~> 1)
-  govuk_publishing_components (~> 16.6)
-  govuk_sidekiq (~> 3)
+  fog-aws
+  gds-api-adapters
+  gds-sso
+  govuk-lint
+  govuk_app_config
+  govuk_publishing_components
+  govuk_sidekiq
   govuk_test
   kaminari
   listen (~> 3)
   logstasher
   pg (~> 1)
-  plek (~> 2)
+  plek
   pry
   rails (~> 5.2)
-  rspec-rails (~> 3)
-  simplecov (~> 0.16)
+  rspec-rails
+  simplecov
   spring-commands-rspec
-  timecop (~> 0.9.1)
-  uglifier (~> 4)
+  timecop
+  uglifier
   webmock
 
 RUBY VERSION


### PR DESCRIPTION
# What

Clean up gem versions so we rely on Dependabot and tests to ensure 
incremental updates of our gems.
