### PR TITLE
Tweak aesthetics on index page filters

### DIFF
--- a/app/assets/stylesheets/components/_metadata.scss
+++ b/app/assets/stylesheets/components/_metadata.scss
@@ -14,5 +14,3 @@
 .app-c-metadata__description {
   padding: 0;
 }
-
-

--- a/app/assets/stylesheets/components/_time-select.scss
+++ b/app/assets/stylesheets/components/_time-select.scss
@@ -12,7 +12,7 @@
   @include govuk-responsive-padding(1, "bottom");
 
   .app-c-time-select__heading {
-    @include govuk-font($size: 16, $weight: bold);
+    @include govuk-font($size: 16);
   }
 }
 

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -182,10 +182,9 @@ $sort-link-arrow-spacing: 4px;
   }
 
   .filter-form__filters {
-    @include govuk-responsive-padding(6, "top");
 
     .govuk-label {
-      @include govuk-font($size: 16, $weight: bold);
+      @include govuk-font($size: 16);
     }
 
     .govuk-select {
@@ -232,4 +231,33 @@ $sort-link-arrow-spacing: 4px;
     @include govuk-responsive-margin(6, "top");
   }
 
+  .gem-c-input {
+    @include govuk-font(16);
+    @include govuk-responsive-padding(2, "left");
+  }
+
+  .autocomplete__option {
+    @include govuk-responsive-padding(2, "top");
+    @include govuk-responsive-padding(2, "bottom");
+    @include govuk-responsive-padding(2, "left");
+    @include govuk-font(16);
+  }
+
+  .autocomplete__input {
+    @include govuk-responsive-padding(2, "top");
+    @include govuk-responsive-padding(2, "bottom");
+    @include govuk-responsive-padding(2, "left");
+    @include govuk-font(16);
+  }
+
+  .autocomplete__hint {
+    @include govuk-responsive-padding(2, "top");
+    @include govuk-responsive-padding(2, "bottom");
+    @include govuk-responsive-padding(2, "left");
+    @include govuk-font(16);
+  }
+
+  .autocomplete__dropdown-arrow-down {
+    @include govuk-responsive-padding(1, "top");
+  }
 }

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -9,7 +9,6 @@
         <span class="filters-control filters-control--show govuk-visually-hidden">
           <a href="" class="govuk-link filters-control__link filters-control__link--show">Show filters</a>&nbsp;&#x25BC;</span>
       </div>
-
       <div class="filter-form">
         <%= form_tag content_path,
           method: 'get',
@@ -23,7 +22,6 @@
             base_path: "/",
             dates: time_select_options(TimeSelectHelper::CONTENT_PAGE_TIME_PERIODS)
           } %>
-          <hr class="govuk-section-break govuk-section-break--s govuk-section-break--visible">
 
           <div class="filter-form__filters">
             <%= render "govuk_publishing_components/components/input", {


### PR DESCRIPTION
# What

https://trello.com/c/XltI9DFZ/1255-1-un-bold-headings-for-the-filters-on-the-index-page-and-adjust-the-font-size-inside-all-filter-boxes

- Remove bold to de-emphasise
- Reduce font size and add padding to keep a good hit size on selects
- Remove hr to bring both parts of the form together visually

# Why
Meet design, give less emphasis to the filters, make more text fit in dropdown options without wrapping.

# Screenshots

## Before
![Screen Shot 2019-04-02 at 13 59 26](https://user-images.githubusercontent.com/31649453/55404325-93aee200-554f-11e9-8bf3-50dc83473bef.png)

## After

![Screen Shot 2019-04-02 at 13 59 19](https://user-images.githubusercontent.com/31649453/55404321-901b5b00-554f-11e9-8517-cd72efd339a6.png)
