### PR TITLE
Add text to make user aware links open new tabs

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -53,7 +53,7 @@ en:
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       data_source: google_analytics
-      external_link: 'See search terms in Google Analytics'
+      external_link: 'See search terms in Google Analytics (opens in new tab)'
       about_title: 'About searches from the page'
       about: >
         This is the number of internal site searches that were started from the page. When people
@@ -80,7 +80,7 @@ en:
       context: ''
       unit: 'comments'
       data_source: feedback_explorer
-      external_link: 'See comments in Feedback Explorer'
+      external_link: 'See comments in Feedback Explorer (opens in new tab)'
       about_title: 'About number of feedback comments'
       about: >
         You can use Feedback Explorer ('Feedex') to find out what users are saying about your

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -2,7 +2,7 @@ en:
   metrics:
     metric_section:
       download_link: 'Download %{metric_name} CSV'
-      external_link: 'See %{metric_unit} in %{data_source}'
+      external_link: 'See %{metric_unit} in %{data_source} (opens in new tab)'
     show:
       browser_title: '%{content_title}: Page data'
       page_kicker: 'Page data'


### PR DESCRIPTION
# What
https://trello.com/c/pAMwo89A/1534-2-add-opens-in-a-new-tab-text-to-links
Add text so user knows a new tab will open

# Why
Help users understand how to get back to the app afterwards




