### PR TITLE
Add nta font

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,9 @@ $govuk-global-styles: true;
 // gem components
 @import 'govuk_publishing_components/all_components';
 
+// TODO: remove the font-face include when govuk_publishing_components doesn't
+// rely on govuk_template and has $govuk-compatibility-govuktemplate set to false
+@include _govuk-font-face-nta;
 
 // local components
 @import "components/chart";


### PR DESCRIPTION
Font loading is disabled since govuk-frontend v2.9.0 to ensure font file is not required twice for projects that rely on govuk_template. The typeface comes disabled from govuk_publishing_component and needs to be enabled in repos that don't rely govuk_template.

---
# Review Checklist
* [x] Changes in scope.
