### PR TITLE
Send a counter to StatsD for csv download time

### DIFF
--- a/app/controllers/content_controller.rb
+++ b/app/controllers/content_controller.rb
@@ -21,7 +21,7 @@ class ContentController < ApplicationController
   def export_csv
     @recipient = current_user.email
 
-    CsvExportWorker.perform_async(search_params, @recipient)
+    CsvExportWorker.perform_async(search_params, @recipient, Time.zone.now)
   end
 
 private

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -7,7 +7,7 @@ class CsvExportWorker
   sidekiq_options retry: 0
   sidekiq_options queue: 'export_csv'
 
-  def perform(search_params, recipient_address)
+  def perform(search_params, recipient_address, start_time)
     search_params = search_params.symbolize_keys
     presenter = build_csv_presenter(search_params)
 
@@ -18,6 +18,11 @@ class CsvExportWorker
 
     # Send email with link
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
+    elapsed_time_seconds = (Time.zone.now - Time.zone.parse(start_time)).truncate
+    GovukStatsd.count('monitor.csv.download.seconds', elapsed_time_seconds)
+    if elapsed_time_seconds > 60
+      GovukStatsd.count('monitor.csv.download.seconds.slow', elapsed_time_seconds)
+    end
   end
 
   def build_csv_presenter(search_params)

--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -64,6 +64,8 @@ RSpec.describe 'Exporting CSV' do
     connection.directories.each(&:destroy)
     @directory = connection.directories.create(key: ENV['AWS_CSV_EXPORT_BUCKET_NAME'])
 
+    allow(GovukStatsd).to receive(:count)
+
     visit "/content"
     click_link('Download all data in CSV format')
   end


### PR DESCRIPTION
# What
Send a StatsD metric for elapsed time in seconds to generate the CSV
Adds `start_time` to the Sidekiq worker call.
The Sidekiq worker then uses this to send a counter to StatsD
with the number of seconds elapsed.
It also sends a second counter (marked slow) when the elapsed time is over 60 seconds, 
so we can calculate the percentage of slow downloads.

# Why
We want to know how long the users are waiting
for a CSV download.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.

Trello: https://trello.com/c/3Eg16r1C/1257-3-build-sli-grafana-dashboard