### PR TITLE
Remove duplicated `factory_bot_rails`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem "rails", "~> 5.2"
 
 gem "bootsnap"
 gem "chartkick"
-gem "factory_bot_rails"
 gem "fog-aws"
 gem "gds-api-adapters"
 gem "gds-sso"


### PR DESCRIPTION
# What
Remove duplicated `factory_bot_rails

# Why
This gem was in the Gemfile twice and bundler has been complaining about it.

Removed it from the production section as
we don't use it in production.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
