### PR TITLE
Use rubocop directly

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,11 @@
+inherit_gem:
+  govuk-lint: "configs/rubocop/all.yml"
+AllCops:
+  TargetRubyVersion: 2.6
+Metrics/BlockLength:
+  Exclude:
+    - "Rakefile"
+    - "**/*.rake"
+    - "spec/**/*.rb"
+    - "config/routes.rb"
+    - "config/environments/*.rb"

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,5 @@
 desc "Run govuk-lint on all files"
 task "lint" do
-  sh "govuk-lint-ruby app config lib spec --format clang --rails"
-  sh "govuk-lint-sass app/assets/stylesheets"
+  sh "bundle exec rubocop app config lib spec --parallel"
+  sh "bundle exec govuk-lint-sass app/assets/stylesheets"
 end


### PR DESCRIPTION
This adds an import for the rules in govuk-lint gem into to the local `.rubocup.yml`. This allows us to use rubocop directly rather than through govuk-lint cli which adds no extra functionality.

Benefits include:
- Speeds up linting, by enabling parallel checking
- Lower overhead for new developers who are used to rubocop
- Better compatibility with developer environments - as most linting tools interface with rubocop

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.