### PR TITLE
Support `local_env.yml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 .byebug_history
 
 /coverage
+/config/local_env.yml

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,4 +59,14 @@ Rails.application.configure do
 
   # Using polling file checker, requires VM time to be in sync with host
   config.file_watcher = ActiveSupport::FileUpdateChecker
+
+  # load environment variables from local_env.yml
+  config.before_configuration do
+    env_file = Rails.root.join('config', 'local_env.yml')
+    if File.exist?(env_file)
+      YAML.safe_load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end
+    end
+  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,14 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   require 'govuk_sidekiq/testing'
   Sidekiq::Testing.inline!
+
+  # load environment variables from local_env.yml
+  config.before_configuration do
+    env_file = Rails.root.join('config', 'local_env.yml')
+    if File.exist?(env_file)
+      YAML.safe_load(File.open(env_file)).each do |key, value|
+        ENV[key.to_s] = value
+      end
+    end
+  end
 end


### PR DESCRIPTION
# What
Support local environment variables for `development` and `test`
environments, defined in `config/local_env.yml`.

This is the same as `content-performance-manager` which supports
it in `development`.

The file is git-ignored so we can all have different ones.

# Why

Local (mac not VM) development is difficult.

This enables you to have local environment variables.
This is very useful if, for instance, you want your database to be configured in 
a non-standard way (i.e. in Docker)

You don't have to use it but it makes life easier if you do.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
