### PR TITLE
Increase the threshold for slow downloads.

### DIFF
--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -20,7 +20,7 @@ class CsvExportWorker
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
     elapsed_time_seconds = (Time.zone.now - Time.zone.parse(start_time)).truncate
     GovukStatsd.count('monitor.csv.download.seconds', elapsed_time_seconds)
-    if elapsed_time_seconds > 60
+    if elapsed_time_seconds > 60 * 15
       GovukStatsd.count('monitor.csv.download.seconds.slow', elapsed_time_seconds)
     end
   end


### PR DESCRIPTION
# What
Increasing the threshold for the
`monitor.csv.download.seconds.slow` counter
to 15 minutes.

# Why
We are telling the users to expect their
download email within 15 minutes. We
are creating an SLI dashboard and we want to include 
the percentage of slow CSV downloads.

The original [PR is here](https://github.com/alphagov/content-data-admin/pull/469)

Trello: https://trello.com/c/3Eg16r1C/1257-3-build-sli-grafana-dashboard

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
