### PR TITLE
Remove the `monitor.csv.download.seconds.slow` counter

### DIFF
--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -20,9 +20,6 @@ class CsvExportWorker
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
     elapsed_time_seconds = (Time.zone.now - Time.zone.parse(start_time)).truncate
     GovukStatsd.count('monitor.csv.download.seconds', elapsed_time_seconds)
-    if elapsed_time_seconds > 60
-      GovukStatsd.count('monitor.csv.download.seconds.slow', elapsed_time_seconds)
-    end
   end
 
   def build_csv_presenter(search_params)

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -121,22 +121,6 @@ RSpec.describe CsvExportWorker do
     expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds', 25)
   end
 
-  context 'when the elapsed time is over 60 seconds' do
-    let(:completed_time) { Time.zone.local(2019, 4, 12, 14, 1, 1) }
-
-    it 'sends StatsD counter with the seconds elapsed' do
-      subject
-
-      expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds', 61)
-    end
-
-    it 'also sends StatsD counter (slow) with the seconds elapsed' do
-      subject
-
-      expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds.slow', 61)
-    end
-  end
-
   after(:each) do
     Fog::Mock.reset
   end


### PR DESCRIPTION
# What

Remove the `monitor.csv.download.seconds.slow` counter

# Why

We were sending this counter to calculate the
percentage of slow downloads.

This is no longer neccessary, as we are going,
to use percentiles of the raw metric, so the code is redundant.


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
