### PR TITLE
Remove default focus state from searchbox

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -29,7 +29,6 @@
                   text: "Search for a title or URL"
                 },
                 name: "search_term",
-                autofocus: true,
                 tabindex: 0,
                 value: params[:search_term],
               } %>


### PR DESCRIPTION
https://trello.com/c/VPwvpZpm/1328-search-box-is-always-selected-by-default

# What
Remove focus state from searchbox on load

# Why
Focusing the user directly on the search means they may miss the date filters. This is particularly confusing for assistive tech as a screenreader will start reading the page from the focused position, so it would miss the headings on the page by default.

# Screenshots
## Before
![Screen Shot 2019-04-15 at 14 29 26](https://user-images.githubusercontent.com/31649453/56136637-16da2a00-5f8b-11e9-9ca1-d4768ec72106.png)

## After
![Screen Shot 2019-04-15 at 14 29 38](https://user-images.githubusercontent.com/31649453/56136631-1477d000-5f8b-11e9-87cd-2356d705c32a.png)

