### PR TITLE
Fix download times metrics

### DIFF
--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -20,9 +20,6 @@ class CsvExportWorker
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
     elapsed_time_seconds = (Time.zone.now - Time.zone.parse(start_time)).truncate
     GovukStatsd.count('monitor.csv.download.seconds', elapsed_time_seconds)
-    if elapsed_time_seconds > 60
-      GovukStatsd.count('monitor.csv.download.seconds.slow', elapsed_time_seconds)
-    end
   end
 
   def build_csv_presenter(search_params)

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -19,7 +19,7 @@ class CsvExportWorker
     # Send email with link
     ContentCsvMailer.content_csv_email(recipient_address, file_url).deliver_now
     elapsed_time_seconds = (Time.zone.now - Time.zone.parse(start_time)).truncate
-    GovukStatsd.count('monitor.csv.download.seconds', elapsed_time_seconds)
+    GovukStatsd.timing('monitor.csv.download.ms', elapsed_time_seconds * 1000)
   end
 
   def build_csv_presenter(search_params)

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CsvExportWorker do
     allow(FindContent).to receive(:enum)
       .with(search_params)
       .and_return(content_items)
-    allow(GovukStatsd).to receive(:count)
+    allow(GovukStatsd).to receive(:timing)
 
     Fog.mock!
     ENV['AWS_REGION'] = 'eu-west-1'
@@ -115,10 +115,10 @@ RSpec.describe CsvExportWorker do
     expect(mail.body).to match(/https:\/\/test-bucket.s3-eu-west-1.amazonaws.com/)
   end
 
-  it 'sends StatsD counter with the seconds elapsed' do
+  it 'sends StatsD timing with the milliseconds elapsed' do
     subject
 
-    expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds', 25)
+    expect(GovukStatsd).to have_received(:timing).with('monitor.csv.download.ms', 25_000)
   end
 
   after(:each) do

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -121,22 +121,6 @@ RSpec.describe CsvExportWorker do
     expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds', 25)
   end
 
-  context 'when the elapsed time is over 60 seconds' do
-    let(:completed_time) { Time.zone.local(2019, 4, 12, 14, 1, 1) }
-
-    it 'sends StatsD counter with the seconds elapsed' do
-      subject
-
-      expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds', 61)
-    end
-
-    it 'also sends StatsD counter (slow) with the seconds elapsed' do
-      subject
-
-      expect(GovukStatsd).to have_received(:count).with('monitor.csv.download.seconds.slow', 61)
-    end
-  end
-
   after(:each) do
     Fog::Mock.reset
   end


### PR DESCRIPTION
# What

Remove the `monitor.csv.download.seconds.slow` counter

# Why

We were sending this counter to calculate the
percentage of slow downloads.

This is no longer neccessary, as we are going,
to use percentiles of the raw metric, so the code is redundant.

# What

Use GovukStatsd `timing` not `count`

refactor the call to use `timing` with
the number of milliseconds.

## Why

I called the wrong method when I implemented the
CSV download time Statsd call.

Trello: https://trello.com/c/3Eg16r1C/1257-3-build-sli-grafana-dashboard

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
