### PR TITLE
Tidy up results table description text

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -6,10 +6,18 @@
         <span class="table-caption__param"><%= I18n.t('no_matching_results') %></span>
     <% end %>
     <% if filter.search_terms? %>
-        for "<span class="table-caption__param"><%= filter.search_terms %></span>"
+        for '<span class="table-caption__param"><%= filter.search_terms %></span>'
     <% end %>
     <% if filter.document_type? && filter.document_type_id != "all" %>
-        in <span class="table-caption__param"><%= filter.document_type_name %></span>
+        for <span class="table-caption__param"><%= filter.document_type_name.downcase %></span>
+    <% else %>
+        for <span class="table-caption__param">all document types</span>
     <% end %>
-    from <span class="table-caption__param"><%= filter.organisation_name %></span>
+    from <span class="table-caption__param">
+    <% if filter.organisation_name == "All organisations" %>
+        all organisations
+    <% else %>
+        <%= filter.organisation_name %>
+    <% end %>
+    </span>
 </h1>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -1,5 +1,5 @@
 en:
-  no_matching_results: 'no matching results'
+  no_matching_results: 'No matching results'
   data_sources:
     google_analytics: 'Google Analytics'
     calculated_google_analytics: 'calculated from Google Analytics'

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results from another org')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results for all document types from another org')
     end
 
     it 'respects date range' do
@@ -144,7 +144,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result from All organisations')
+        expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result for all document types from all organisations')
       end
     end
 
@@ -217,7 +217,7 @@ RSpec.describe '/content' do
       end
 
       it 'describes the filter in the table header' do
-        expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result for "Relevant" from All organisations')
+        expect(page).to have_css('h1.table-caption', exact_text: "Showing 1 result for 'Relevant' for all document types from all organisations")
       end
     end
   end
@@ -241,7 +241,7 @@ RSpec.describe '/content' do
     end
 
     it 'describes the filter in the table header' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result in News story from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 1 result for news story from org (OI)')
     end
 
     it 'allows the filter to be cleared' do
@@ -250,7 +250,7 @@ RSpec.describe '/content' do
       expect(page).to have_select('document_type', selected: ["", "All document types"])
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows.count).to eq(4)
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 3 results for all document types from org (OI)')
     end
   end
 
@@ -261,7 +261,7 @@ RSpec.describe '/content' do
     end
 
     it 'shows a no data message in the table header' do
-      expect(page).to have_css('h1.table-caption', exact_text: "#{I18n.t 'no_matching_results'} from org (OI)")
+      expect(page).to have_css('h1.table-caption', exact_text: "#{I18n.t 'no_matching_results'} for all document types from org (OI)")
     end
   end
 
@@ -272,7 +272,7 @@ RSpec.describe '/content' do
     end
 
     it 'formats the page numbers correctly in the table header' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 150 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 150 results for all document types from org (OI)')
     end
   end
 end

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe "Results pagination" do
     end
 
     it 'shows the second page of data' do
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results for all document types from org (OI)')
       click_on 'Next'
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
@@ -97,7 +97,7 @@ RSpec.describe "Results pagination" do
           ['forth title /path/4', 'News story', '100,018', '68% (50 responses)', '12'],
         ]
       )
-      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results from org (OI)')
+      expect(page).to have_css('h1.table-caption', exact_text: 'Showing 102 results for all document types from org (OI)')
     end
   end
 end


### PR DESCRIPTION
# What

https://trello.com/c/FOGiwFqQ/1330-add-all-document-types-to-the-sentence-summary

- display "all document types" when it is chosen
- downcase the generic terms "all document types" and "all organisations"
- capitalise initial on "No matching results"
- change double quotes to single quotes
- update tests to reflect new expectations

# Why
Makes it more explicit what is being shown, improves readability slightly.

# Screenshots
## Before
![Screen Shot 2019-04-16 at 10 52 03](https://user-images.githubusercontent.com/31649453/56200058-f74c0b80-6035-11e9-8b2e-a789aae80f85.png)

## After

![Screen Shot 2019-04-16 at 10 51 49](https://user-images.githubusercontent.com/31649453/56200076-fdda8300-6035-11e9-80ba-5c4ff26df925.png)
