### PR TITLE
Switch to using `content-data-api` with Plek

### DIFF
--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -2,7 +2,7 @@ require 'gds_api/base'
 
 class GdsApi::ContentDataApi < GdsApi::Base
   def initialize
-    super("#{Plek.current.find('content-performance-manager')}/api/v1",
+    super("#{Plek.current.find('content-data-api')}/api/v1",
       disable_cache: true,
       bearer_token: ENV['CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN'] || 'example')
   end
@@ -38,7 +38,7 @@ class GdsApi::ContentDataApi < GdsApi::Base
 private
 
   def content_data_api_endpoint
-    Plek.current.find('content-performance-manager').to_s
+    Plek.current.find('content-data-api').to_s
   end
 
   def aggregated_metrics_url(base_path, from, to)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -6,7 +6,7 @@ module GdsApi
     module ContentDataApi
       include ResponseHelpers
 
-      CONTENT_DATA_API_ENDPOINT = Plek.current.find('content-performance-manager')
+      CONTENT_DATA_API_ENDPOINT = Plek.current.find('content-data-api')
 
       def content_data_api_has_orgs
         url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"


### PR DESCRIPTION
Rather than the Content Performance Manager, following on from the
work to change the name of the Content Performance Manager to the
Content Data API.

Currently, the domain for the Content Performance Manager was being
overwritten in AWS Staging and AWS Production, but with this change,
that will become unnecessary.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* ~~Added/updated relevant documentation.~~
* [x] Added to Trello card.
