### PR TITLE
Change to use the CONTENT_DATA_API_BEARER_TOKEN

### DIFF
--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -4,7 +4,7 @@ class GdsApi::ContentDataApi < GdsApi::Base
   def initialize
     super("#{Plek.current.find('content-performance-manager')}/api/v1",
       disable_cache: true,
-      bearer_token: ENV['CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN'] || 'example')
+      bearer_token: ENV['CONTENT_DATA_API_BEARER_TOKEN'] || 'example')
   end
 
   def aggregated_metrics(base_path:, from:, to:)


### PR DESCRIPTION
Rather than the CONTENT_PERFORMANCE_MANAGER_BEARER_TOKEN, as part of
the work to rename the Content Performance Manager to the Content Data
API.

This change is dependent of this environment variable becoming
available through changing govuk-puppet.

This depends on https://github.com/alphagov/govuk-puppet/pull/9008

---
# Review Checklist
* [x] Changes in scope.
* ~~Added/updated unit tests.~~
* ~~Added/updated feature tests.~~
* ~~Added/updated relevant documentation.~~
* [x] Added to Trello card.
