### PR TITLE
Fix inflection 'out of 1 responses'

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -67,11 +67,15 @@ class SingleContentItemPresenter
   end
 
   def satisfaction_context
-    I18n.t("metrics.satisfaction.context", total_responses: number_with_delimiter(useful_yes_no_total))
+    I18n.t("metrics.satisfaction.context",
+      total_responses: number_with_delimiter(useful_yes_no_total),
+      count: useful_yes_no_total)
   end
 
   def satisfaction_short_context
-    I18n.t("metrics.satisfaction.short_context", total_responses: number_with_delimiter(useful_yes_no_total))
+    I18n.t("metrics.satisfaction.short_context",
+      total_responses: number_with_delimiter(useful_yes_no_total),
+      count: useful_yes_no_total)
   end
 
   def searches_context

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -62,9 +62,13 @@ en:
       title: 'User satisfaction score'
       short_title: 'User satisfaction score'
       summary: 'Percentage of users who answered ''yes'' to the ''Is this page useful?'' survey'
-      context: 'Users who found the page useful, out of %{total_responses} responses'
+      context:
+        one: 'Users who found the page useful, out of %{total_responses} response'
+        other: 'Users who found the page useful, out of %{total_responses} responses'
       unit: ''
-      short_context: '%{total_responses} responses'
+      short_context:
+        one: '%{total_responses} response'
+        other: '%{total_responses} responses'
       data_source: calculated_google_analytics
       external_link: ''
       about_title: 'About satisfaction score'

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe SingleContentItemPresenter do
 
       expected_context = 'Users who found the page useful, out of 15 responses'
       expect(subject.satisfaction_context).to eq(expected_context)
+      expect(subject.satisfaction_short_context).to eq('15 responses')
+    end
+
+    it 'returns context about the satisfaction metric for a single response' do
+      current_period_data[:time_series_metrics] = [
+        { name: 'pviews', total: 5 },
+        { name: 'upviews', total: 5 },
+        { name: 'useful_yes', total: 1 },
+        { name: 'useful_no', total: 0 },
+      ]
+
+      expected_context = 'Users who found the page useful, out of 1 response'
+      expect(subject.satisfaction_context).to eq(expected_context)
+      expect(subject.satisfaction_short_context).to eq('1 response')
     end
 
     it 'does not fail when there are no metrics' do
@@ -177,6 +191,7 @@ RSpec.describe SingleContentItemPresenter do
 
       expected_context = 'Users who found the page useful, out of 0 responses'
       expect(subject.satisfaction_context).to eq(expected_context)
+      expect(subject.satisfaction_short_context).to eq('0 responses')
     end
   end
 


### PR DESCRIPTION
# What
Fix inflection 'out of 1 responses'
# Why
When there's exactly 1 response, the text under the user
satisfaction score in the at-a-glance section says
"Users who found the page useful, out of 1 responses". This is ungrammatical
as it should be singular '1 response'.

# Screenshots
*If applicable add screenshots otherwise remove this section.*

## Before
<img width="249" alt="Screenshot 2019-04-25 at 16 22 41" src="https://user-images.githubusercontent.com/511319/56747759-76e48380-6776-11e9-9fcc-08a5f0786e9c.png">

## After

Coming soon

Trello: https://trello.com/c/vO3DkpTk/1362-2-fix-inflection-out-of-1-responses-in-at-a-glance-user-satisfaction-score

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
