### PR TITLE
Delete redundant tracking data attributes

### DIFF
--- a/app/views/components/_chart.html.erb
+++ b/app/views/components/_chart.html.erb
@@ -83,7 +83,7 @@
       <% end %>
       <%= line_chart(chart_format_data, library: chart_library_options, defer: true) %>
     </div>
-    <div class="app-c-chart__table" id="<%= table_id %>" data-gtm="view-table-reveal" data-gtm-id="view-table-reveal">
+    <div class="app-c-chart__table" id="<%= table_id %>" data-gtm-id="view-table-reveal">
       <%= render(
         "govuk_publishing_components/components/details",
         title: t(".table_dropdown", metric_name: chart_label)

--- a/app/views/content/_page_title.html.erb
+++ b/app/views/content/_page_title.html.erb
@@ -4,7 +4,6 @@
   data: {
     'gtm-id': 'content-item-link',
     'gtm-item-document-type': item.raw_document_type,
-    'gtm': item.raw_document_type
   } %>
 <br>
 <span class="base-path">/<%= CGI::unescape(item.base_path) %></span>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -74,7 +74,6 @@
       <div class="table-wrapper">
         <table class="table govuk-table"
           data-gtm-total-results="<%= @presenter.pagination.total_results %>"
-          data-gtm-pagination-total-results="<%= @presenter.pagination.total_results %>"
           data-gtm-page="<%= @presenter.pagination.page %>">
           <caption class="govuk-table__caption">
             <%= render('table_data_description', pagination: @presenter.pagination, filter: @filter) %>

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -25,10 +25,6 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="content-item-link"][data-gtm-item-document-type]')
   end
 
-  scenario 'tracks content item page links (old way)' do
-    expect(page).to have_selector('[data-gtm-id="content-item-link"][data-gtm]')
-  end
-
   help_icon_columns = %w(upviews satisfaction searches)
 
   help_icon_columns.each do |column|

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -17,10 +17,6 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-total-results]')
   end
 
-  scenario 'tracks total number of results (old way)' do
-    expect(page).to have_selector('[data-gtm-pagination-total-results]')
-  end
-
   scenario 'tracks prev and next pagination links' do
     expect(page).to have_selector('[data-gtm-id="pagination-links"]')
   end

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -13,10 +13,6 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="page-kicker"]')
   end
 
-  scenario 'tracks view table reveal section (old way)' do
-    expect(page).to have_selector('[data-gtm="view-table-reveal"]')
-  end
-
   scenario 'tracks view table reveal section' do
     expect(page).to have_selector('[data-gtm-id="view-table-reveal"]')
   end


### PR DESCRIPTION
# What
Remove redundant tracking data attributes.

# Why
Some existing data attributes were renamed for consistency as part of https://trello.com/c/spmbz9Yl. We temporarily kept the old ones alongside the new ones so that we wouldn't lose any tracking during the switchover.

Trello: https://trello.com/c/ddvtKkCq/1365-1-delete-some-data-attributes-that-are-no-longer-needed


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
