### PR TITLE
Add &document_type=homepage to Feedex Uri

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -43,7 +43,12 @@ module ExternalLinksHelper
   def feedex_url(from:, to:, base_path:)
     host = Plek.new.external_url_for('support')
     path = CGI.escape(base_path)
-    "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
+    base_request = "#{host}/anonymous_feedback?from=#{from}&to=#{to}&paths=#{path}"
+    if base_path == '/'
+      base_request + '&document_type=homepage'
+    else
+      base_request
+    end
   end
 
   def google_analytics_url(from:, to:, base_path:)

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -154,6 +154,17 @@ RSpec.describe ExternalLinksHelper do
                base_path: '/the/base/path'
       )).to eq(expected_link)
     end
+
+    it 'adds document type of homepage when when the page concerned is the homepage' do
+      host = Plek.new.external_url_for('support')
+      expected_link = "#{host}/anonymous_feedback?from=2018-11-25&to=2018-12-24&paths=%2F&document_type=homepage"
+
+      expect(feedex_url(
+               from: Date.new(2018, 11, 25),
+               to: Date.new(2018, 12, 24),
+               base_path: '/'
+      )).to eq(expected_link)
+    end
   end
 
   describe '#google_analytics_url' do


### PR DESCRIPTION
# What
Add &document_type=homepage to Feedex Uri

# Why

When sending users to the feedback explorer for the GOV.UK homepage,
the users were seeing feedback for all content (under '/').

This PR adds the document type of homepage to the query string to limit
the results to what we want.

# Screenshots

## Before
<img width="1307" alt="Screenshot 2019-04-29 at 15 27 13" src="https://user-images.githubusercontent.com/511319/56903090-8a079400-6a93-11e9-9e6e-d24add30fb05.png">

## After
<img width="1334" alt="Screenshot 2019-04-29 at 15 27 37" src="https://user-images.githubusercontent.com/511319/56903115-968bec80-6a93-11e9-94ee-da0b0204731a.png">


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
