### PR TITLE
Remove support for `local_env.rb`

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -59,14 +59,4 @@ Rails.application.configure do
 
   # Using polling file checker, requires VM time to be in sync with host
   config.file_watcher = ActiveSupport::FileUpdateChecker
-
-  # load environment variables from local_env.yml
-  config.before_configuration do
-    env_file = Rails.root.join('config', 'local_env.yml')
-    if File.exist?(env_file)
-      YAML.safe_load(File.open(env_file)).each do |key, value|
-        ENV[key.to_s] = value
-      end
-    end
-  end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,14 +41,4 @@ Rails.application.configure do
   config.active_job.queue_adapter = :sidekiq
   require 'govuk_sidekiq/testing'
   Sidekiq::Testing.inline!
-
-  # load environment variables from local_env.yml
-  config.before_configuration do
-    env_file = Rails.root.join('config', 'local_env.yml')
-    if File.exist?(env_file)
-      YAML.safe_load(File.open(env_file)).each do |key, value|
-        ENV[key.to_s] = value
-      end
-    end
-  end
 end


### PR DESCRIPTION
# What
Remove support for `local_env.rb`

# Why
I added this support to help with local development.

Turns out this is unnecessary as [direnv](https://direnv.net/) will do the job.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
