### PR TITLE
Show comma separator in comparison data

### DIFF
--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -21,7 +21,7 @@
       <% if trend_percentage.blank? %>
         no comparison data
       <% else %>
-        <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
+        <% if trend_percentage > 0 %>+<% end %><%= number_to_percentage(trend_percentage, precision: 2, delimiter: ',') %>
       <% end %>
     </span>
     <% unless trend_percentage.blank? %>

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders trend percentage for page searches' do
-        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '406.25%'
+        expect(page).to have_selector '.searches .app-c-glance-metric__trend', text: '3,950.00%'
       end
 
       it 'renders glance metric for feedex comments' do

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -196,11 +196,11 @@ module GdsApi
             },
             {
               name: "searches",
-              total: 48,
+              total: 6,
               time_series: [
-                { "date" => day1, "value" => 16 },
-                { "date" => day2, "value" => 16 },
-                { "date" => day3, "value" => 16 }
+                { "date" => day1, "value" => 2 },
+                { "date" => day2, "value" => 2 },
+                { "date" => day3, "value" => 2 }
               ]
             },
             {


### PR DESCRIPTION
- Add delimiter to comparison data

# Screenshots
![Screen Shot 2019-04-30 at 17 18 42](https://user-images.githubusercontent.com/6651749/56976969-0c638700-6b6c-11e9-80fd-35f845594ed7.png)


The comparison data does not show a delimiter, so this PR fixes this.