### PR TITLE
Update layout of content metrics

### DIFF
--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -76,4 +76,47 @@
     text-align: right;
     @include govuk-responsive-margin(2, "top");
   }
+
+  .govuk-summary-list--small {
+    @include govuk-font($size: 16);
+    @include govuk-responsive-margin(1, "bottom");
+
+  }
+
+  .govuk-summary-list__value--right-align {
+    text-align: right;
+   }
+
+  .govuk-summary-list__key {
+    font-weight: normal;
+  }
+
+  .content-metrics {
+    .page-help {
+      @include govuk-responsive-margin(1, "left");
+    }
+   }
+
+  .content-metrics__header {
+    @include govuk-responsive-margin(4, "bottom");
+  }
+
+  .content-metrics__help-icon {
+    vertical-align: bottom;
+  }
+
+  .content-metrics__data {
+    .govuk-summary-list__row {
+      &:last-of-type {
+        .govuk-summary-list__key,
+        .govuk-summary-list__value {
+          border-bottom: none;
+        }
+      }
+    }
+  }
+
+  .content-metrics__data {
+    border-top: 2px solid $grey-3;
+  }
 }

--- a/app/views/metrics/_content_metrics.html.erb
+++ b/app/views/metrics/_content_metrics.html.erb
@@ -1,0 +1,32 @@
+
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds content-metrics">
+    <h2 class="section-content__header content-metrics__header">
+      <%= t "metrics.show.section_headings.content" %>
+    </h2>
+
+    <dl class="govuk-summary-list govuk-summary-list--small content-metrics__data">
+      <% ['reading_time', 'total_words', 'total_pdf_count'].each do |metric| %>
+        <div class="govuk-summary-list__row content-metric__<%= metric.gsub('_', '-') %>">
+        <dt class="govuk-summary-list__key" data-gtm-id="metric-section-heading">
+          <%= t "metrics.#{metric}.title" %>
+        </dt>
+        <dd class="govuk-summary-list__value govuk-summary-list__value--right-align">
+          <%= @performance_data.send(metric) %>
+        </dd>
+      </div>
+      <% end %>
+
+    </dl>
+    <%= render "govuk_publishing_components/components/details", {
+      title: t("metrics.page_content.about_title")
+    } do %>
+      <% ['reading_time', 'total_words', 'total_pdf_count'].each do |metric| %>
+        <h3 class="govuk-heading-s"><%= @performance_data.metric_about_label(metric) %></h3>
+        <p class="govuk-body govuk-body-s"><%= raw t("metrics.#{metric}.about") %></p>
+      <% end %>
+
+    <% end %>
+  </div>
+</div>

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -10,7 +10,6 @@
 <% if total %>
   <%= render 'chart', series: @performance_data.chart_for_metric(metric_name) %>
 <% end %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">
     <% if external_link %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -135,20 +135,7 @@
     </div>
   </div>
 </div>
-
-
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-full section-content section-content__quality">
-    <h2 class="section-content__header"><%= t ".section_headings.content" %></h2>
-    <div class="govuk-grid-column-one-third metric-summary metric-summary__reading-time">
-      <%= render 'metric_header', metric_name: 'reading_time', value: @performance_data.reading_time, show_trend: false, context_value: {number_of_words: @performance_data.total_words} %>
-    </div>
-    <div class="govuk-grid-column-one-third metric-summary metric-summary__words">
-      <%= render 'metric_header', metric_name: 'words', value: @performance_data.total_words, show_trend: false %>
-    </div>
-    <div class="govuk-grid-column-one-third metric-summary metric-summary__pdf-count">
-      <%= render 'metric_header', metric_name: 'pdf_count', value: @performance_data.total_pdf_count, show_trend: false %>
-    </div>
-  </div>
-</div>
+<%= render 'content_metrics', performance_data: @performance_data %>
+
+

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -93,7 +93,7 @@ en:
         end of a transaction that started on GOV.UK.
 
         You'll need a Signon account with Feedback Explorer permissions to see the comments.
-    words:
+    total_words:
       title: 'Word count'
       short_title: 'Word count'
       summary: 'Number of words on the page'
@@ -120,7 +120,7 @@ en:
         of 200 words per minute. The time it takes to read the page is rounded up to the nearest minute.
         This calculation doesn’t take into account how complicated the content is or any of the page’s
         attachments.
-    pdf_count:
+    total_pdf_count:
       title: 'Number of PDFs'
       short_title: 'Number of PDFs'
       summary: 'Number of .pdf attachments on the page'
@@ -134,4 +134,5 @@ en:
         maintain. PDFs can often be bad for accessibility and rarely comply with open standards.
         Several PDFs on one page may indicate that too many users needs are being met by them.
         <a href="https://gds.blog.gov.uk/2018/07/16/why-gov-uk-content-should-be-published-in-html-and-not-pdf/">Read more about why to avoid PDFs</a>.
-
+    page_content:
+      about_title: "About 'page content' metrics"

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -161,30 +161,30 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders a metric for pdf_count' do
-        expect(page).to have_selector '.metric-summary__pdf-count', text: '3'
+        expect(page).to have_selector '.content-metric__total-pdf-count .govuk-summary-list__value', text: '3'
       end
 
       it 'renders about label for pdf count' do
-        label = 'About number of PDFs'
-        expect(page).to have_selector(".metric-summary__pdf-count .govuk-details__summary-text", text: label)
+        label = 'Number of PDFs'
+        expect(page).to have_selector(".content-metric__total-pdf-count .govuk-summary-list__key", text: label)
       end
 
       it 'renders a metric for word count' do
-        expect(page).to have_selector '.metric-summary__words', text: '200'
+        expect(page).to have_selector '.content-metric__total-words .govuk-summary-list__value', text: '200'
       end
 
       it 'renders about label for word count' do
-        label = 'About word count'
-        expect(page).to have_selector(".metric-summary__words .govuk-details__summary-text", text: label)
+        label = 'Word count'
+        expect(page).to have_selector(".content-metric__total-words .govuk-summary-list__key", text: label)
       end
 
       it 'renders a metric for time to read' do
-        expect(page).to have_selector '.metric-summary__reading-time', text: '200'
+        expect(page).to have_selector '.content-metric__reading-time .govuk-summary-list__value', text: '0h 20m'
       end
 
       it 'renders about label for time to read' do
-        label = 'About reading time'
-        expect(page).to have_selector(".metric-summary__reading-time .govuk-details__summary-text", text: label)
+        label = 'Reading time'
+        expect(page).to have_selector(".content-metric__reading-time .govuk-summary-list__key", text: label)
       end
 
 


### PR DESCRIPTION
# What

https://trello.com/c/76VOZ7pD/1425-3-update-page-content-metrics-layout
This is the first step towards adding document info to multi part pages. It adjusts
the layout of the metrics about the content, including PDFs. PDFs will later be
handled by the document structure components so this is an interim solution to keep
them appearing but the layout will remain for the other two metrics.

# Why
Reduce use of space, bring in line with the design for document structure content

# Screenshots
## Before
![Screen Shot 2019-05-23 at 11 13 42](https://user-images.githubusercontent.com/31649453/58245259-48919e00-7d4c-11e9-8600-4f7d1b0ee923.png)
## After
![Screen Shot 2019-05-30 at 14 45 22](https://user-images.githubusercontent.com/31649453/58637256-076c3180-82ea-11e9-907c-a0360b13ba83.png)




