### PR TITLE
Improve layout of page data page which has no data to show

### DIFF
--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -39,7 +39,9 @@ class SingleContentItemPresenter
   end
 
   def total_satisfaction
-    number_to_percentage(value_for('satisfaction') * 100, precision: 0)
+    if !value_for('satisfaction').nil?
+      number_to_percentage(value_for('satisfaction') * 100, precision: 0)
+    end
   end
 
   def total_feedex

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -1,20 +1,25 @@
 <%
   name ||= false
-  figure ||= false
+  figure ||= nil
   period ||= false
   context ||= ""
   trend_percentage ||= ""
   measurement_display_label ||= ""
   measurement_explicit_label ||= ""
 %>
-<% if name && figure && period %>
+<% if name && period %>
   <div class="app-c-glance-metric govuk-body">
     <h3 class="app-c-glance-metric__heading"><%= name %></h3>
-    <span class="app-c-glance-metric__figure"><%= figure %><% if measurement_display_label %><span class="app-c-glance-metric__measurement"
-        <% if measurement_explicit_label %>
-          aria-label="<%= measurement_explicit_label %>"
-        <% end %>><%= measurement_display_label %></span>
-    <% end %>
+
+      <% if figure.nil? %>
+      <span class="app-c-glance-metric__figure">No data</span>
+      <% else %>
+      <span class="app-c-glance-metric__figure"><%= figure %><% if measurement_display_label %><span class="app-c-glance-metric__measurement"
+            <% if measurement_explicit_label %>
+              aria-label="<%= measurement_explicit_label %>"
+            <% end %>><%= measurement_display_label %></span>
+        <% end %>
+      <% end %>
     </span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
     <span class="app-c-glance-metric__trend">

--- a/app/views/components/_info-metric.html.erb
+++ b/app/views/components/_info-metric.html.erb
@@ -1,6 +1,6 @@
 <%
   name ||= false
-  figure ||= false
+  figure ||= nil
   period ||= false
   about ||= false
   trend_percentage ||= false
@@ -8,7 +8,7 @@
   short_context ||= false
   about_label ||= "About this data"
 %>
-<% if name && figure && context %>
+<% if name && context %>
   <div class="app-c-info-metric govuk-body">
     <h3 class="app-c-info-metric__heading" data-gtm-id="metric-section-heading"><%= name %></h3>
     <p class="app-c-info-metric__context govuk-body-s"><%= context %></p>
@@ -24,35 +24,42 @@
         <% end %>
       </div>
     <% end %>
-    <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 "><%= figure %></span>
-    <% if short_context %>
-      <span class="app-c-info-metric__short-context">
-        (<%= short_context %>)
-      </span>
-    <% end %>
-    <% if trend_percentage %>
-      <span class="app-c-info-metric__trend">
-        <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
-      </span>
-      <% if trend_percentage > 0 %>
-        <span class="app-c-info-metric__trend--up">
-          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9650;</span>
-          <span class="app-c-info-metric__trend-text">Upward trend</span>
-        <span>
-      <% elsif trend_percentage < 0 %>
-        <span class="app-c-info-metric__trend--down">
-          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9660;</span>
-          <span class="app-c-info-metric__trend-text">Downward trend</span>
-        <span>
-      <% else %>
-        <span class="app-c-info-metric__trend--no-change">
-          <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9679;</span>
-          <span class="app-c-info-metric__trend-text">No change</span>
-        <span>
-      <% end %>
-    <% end %>
-    <% if period && trend_percentage %>
-      <span class="app-c-info-metric__period"><%= period %></span>
-    <% end %>
-  </div>
+
+  <span class="app-c-info-metric__figure govuk-!-font-weight-bold govuk-!-font-size-36 ">
+    <% if figure.nil? %>
+      No data
+    <% else %>
+      <%= figure %>
+        </span>
+          <% if short_context %>
+            <span class="app-c-info-metric__short-context">
+              (<%= short_context %>)
+            </span>
+          <% end %>
+          <% if trend_percentage %>
+            <span class="app-c-info-metric__trend">
+              <% if trend_percentage > 0 %>+<% end %><%= '%.2f' % trend_percentage %>%
+            </span>
+            <% if trend_percentage > 0 %>
+              <span class="app-c-info-metric__trend--up">
+                <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9650;</span>
+                <span class="app-c-info-metric__trend-text">Upward trend</span>
+              <span>
+            <% elsif trend_percentage < 0 %>
+              <span class="app-c-info-metric__trend--down">
+                <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9660;</span>
+                <span class="app-c-info-metric__trend-text">Downward trend</span>
+              <span>
+            <% else %>
+              <span class="app-c-info-metric__trend--no-change">
+                <span aria-hidden="true" class="app-c-info-metric__trend-icon">&#9679;</span>
+                <span class="app-c-info-metric__trend-text">No change</span>
+              <span>
+            <% end %>
+          <% end %>
+          <% if period && trend_percentage %>
+            <span class="app-c-info-metric__period"><%= period %></span>
+          <% end %>
+        </div>
+    <%end %>
 <% end %>

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -4,7 +4,7 @@
       figure: total[:figure],
       measurement_display_label: total[:display_label],
       measurement_explicit_label: total[:explicit_label],
-      context: context,
+      context: (context if total[:figure]),
       trend_percentage: @performance_data.trend_percentage(metric_name),
       period: @performance_data.period
     } %>

--- a/app/views/metrics/_glance_metric.html.erb
+++ b/app/views/metrics/_glance_metric.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-column-one-quarter glance-metric <%=metric_name%>">
   <%= render "components/glance-metric", {
       name: @performance_data.metric_short_title(metric_name),
-      figure: total[:figure],
+      figure: (total[:figure] if total[:figure]),
       measurement_display_label: total[:display_label],
       measurement_explicit_label: total[:explicit_label],
       context: (context if total[:figure]),

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -7,7 +7,9 @@
   }%>
 </div>
 
-<%= render 'chart', series: @performance_data.chart_for_metric(metric_name) %>
+<% if total %>
+  <%= render 'chart', series: @performance_data.chart_for_metric(metric_name) %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-half">

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "Glance Metric", type: :view do
   end
 
   it "does not render if figure is not supplied" do
-    data[:figure] = false
-    assert_empty render_component(data)
+    data[:figure] = nil
+    render_component(data)
+    assert_select ".app-c-glance-metric__figure", text: 'No data'
   end
 
   it "does not render if period is not supplied" do

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Glance Metric", type: :view do
     assert_empty render_component(data)
   end
 
-  it "does not render if figure is not supplied" do
+  it "renders no data if figure is not present" do
     data[:figure] = nil
     render_component(data)
     assert_select ".app-c-glance-metric__figure", text: 'No data'

--- a/spec/components/info_metric_spec.rb
+++ b/spec/components/info_metric_spec.rb
@@ -23,8 +23,9 @@ RSpec.describe "Info Metric", type: :view do
   end
 
   it "does not render if figure is not supplied" do
-    data[:figure] = false
-    assert_empty render_component(data)
+    data[:figure] = nil
+    render_component(data)
+    assert_select ".app-c-info-metric__figure", text: 'No data'
   end
 
 

--- a/spec/components/info_metric_spec.rb
+++ b/spec/components/info_metric_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "Info Metric", type: :view do
     assert_empty render_component(data)
   end
 
-  it "does not render if figure is not supplied" do
+  it "renders no data if figure is not present" do
     data[:figure] = nil
     render_component(data)
     assert_select ".app-c-info-metric__figure", text: 'No data'


### PR DESCRIPTION
When a content is published there is no data present until the ETL process
executes. Currently, the page does not hint that there is no data present,
this may confuse users to think that the page maybe broken.

Now the page is styled like other pages for consistency and displays the sentence,
no data, to make it more clear.

Trello card: https://trello.com/c/JOfeWXgS

# Screenshots

## Before
![Screen Shot 2019-05-23 at 15 57 14](https://user-images.githubusercontent.com/6651749/58263190-776f3a80-7d73-11e9-9085-06fd76ff8594.png)

## After
![Screen Shot 2019-05-23 at 15 55 31](https://user-images.githubusercontent.com/6651749/58263047-41ca5180-7d73-11e9-98bb-9339142c74c7.png)