### PR TITLE
Rename satisfaction score

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -59,19 +59,19 @@ en:
         This is the number of internal site searches that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.
     satisfaction:
-      title: 'User satisfaction score'
-      short_title: 'User satisfaction score'
+      title: 'Users who found page useful'
+      short_title: 'Users who found page useful'
       summary: 'Percentage of users who answered ''yes'' to the ''Is this page useful?'' survey'
       context:
-        one: 'Users who found the page useful, out of %{total_responses} response'
-        other: 'Users who found the page useful, out of %{total_responses} responses'
+        one: 'Out of %{total_responses} response'
+        other: 'Out of %{total_responses} responses'
       unit: ''
       short_context:
         one: '%{total_responses} response'
         other: '%{total_responses} responses'
       data_source: calculated_google_analytics
       external_link: ''
-      about_title: 'About satisfaction score'
+      about_title: "About 'users who found page useful'"
       about: >
         Percentage of users who answered 'Yes' rather than 'No' to the 'Is this page useful?' survey.
         The more users who responded, the more reliable the score is. For a more reliable score

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe '/content' do
     table_rows = extract_table_content('.govuk-table')
     expect(table_rows).to eq(
       [
-        ['Page title', 'Document type', 'Unique pageviews', 'User satisfaction score', 'Searches from the page'],
+        ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from the page'],
         ['GOV.UK homepage /', 'Homepage', '1,233,018', '85% (100 responses)', '1,220'],
         ['The title /path/1', 'News story', '233,018', '81% (1,000 responses)', '220'],
         ['Another title /path/2', 'Guide', '100,018', '68% (50 responses)', '12'],

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Results pagination" do
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
         [
-          ['Page title', 'Document type', 'Unique pageviews', 'User satisfaction score', 'Searches from the page'],
+          ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from the page'],
           ['third title /path/3', 'Press release', '233,018', '81% (1,000 responses)', '220'],
           ['forth title /path/4', 'News story', '100,018', '68% (50 responses)', '12'],
         ]

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders about label for satisfaction' do
-        label = 'About satisfaction score'
+        label = "About 'users who found page useful'"
         expect(page).to have_selector(".metric-summary__satisfaction .govuk-details__summary-text", text: label)
       end
 

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -163,7 +163,7 @@ RSpec.describe SingleContentItemPresenter do
         { name: 'useful_no', total: 10 },
       ]
 
-      expected_context = 'Users who found the page useful, out of 15 responses'
+      expected_context = 'Out of 15 responses'
       expect(subject.satisfaction_context).to eq(expected_context)
       expect(subject.satisfaction_short_context).to eq('15 responses')
     end
@@ -176,7 +176,7 @@ RSpec.describe SingleContentItemPresenter do
         { name: 'useful_no', total: 0 },
       ]
 
-      expected_context = 'Users who found the page useful, out of 1 response'
+      expected_context = 'Out of 1 response'
       expect(subject.satisfaction_context).to eq(expected_context)
       expect(subject.satisfaction_short_context).to eq('1 response')
     end
@@ -189,7 +189,7 @@ RSpec.describe SingleContentItemPresenter do
         { name: 'useful_no', total: nil },
       ]
 
-      expected_context = 'Users who found the page useful, out of 0 responses'
+      expected_context = 'Out of 0 responses'
       expect(subject.satisfaction_context).to eq(expected_context)
       expect(subject.satisfaction_short_context).to eq('0 responses')
     end


### PR DESCRIPTION
# What
Renamed the user satisfaction score to 'users who found page useful'

# Why
To better reflect the metric

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.
