### PR TITLE
Rename searches from the page

### DIFF
--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -47,14 +47,14 @@ en:
         high ratio (above 1.4), this indicates that users have to come back to that page within
         their session - investigate the navigation from that page further to identify any issues.
     searches:
-      title: 'Searches from the page'
-      short_title: 'Searches from the page'
+      title: 'Searches from page'
+      short_title: 'Searches from page'
       summary: 'Number of on-page searches'
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       data_source: google_analytics
       external_link: 'See search terms in Google Analytics (opens in new tab)'
-      about_title: 'About searches from the page'
+      about_title: 'About searches from page'
       about: >
         This is the number of internal site searches that were started from the page. When people
         use internal search, it's an indication that they haven't found what they're looking for.

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe '/content' do
     table_rows = extract_table_content('.govuk-table')
     expect(table_rows).to eq(
       [
-        ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from the page'],
+        ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from page'],
         ['GOV.UK homepage /', 'Homepage', '1,233,018', '85% (100 responses)', '1,220'],
         ['The title /path/1', 'News story', '233,018', '81% (1,000 responses)', '220'],
         ['Another title /path/2', 'Guide', '100,018', '68% (50 responses)', '12'],

--- a/spec/features/index_page/results_pagination_spec.rb
+++ b/spec/features/index_page/results_pagination_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe "Results pagination" do
       table_rows = extract_table_content('.govuk-table')
       expect(table_rows).to eq(
         [
-          ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from the page'],
+          ['Page title', 'Document type', 'Unique pageviews', 'Users who found page useful', 'Searches from page'],
           ['third title /path/3', 'Press release', '233,018', '81% (1,000 responses)', '220'],
           ['forth title /path/4', 'News story', '100,018', '68% (50 responses)', '12'],
         ]

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -220,7 +220,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
         internal_searches_rows = extract_table_content(".chart.searches table")
         expect(internal_searches_rows).to match_array([
           expected_table_dates,
-          ["Searches from the page", "80", "80", "83"]
+          ["Searches from page", "80", "80", "83"]
         ])
       end
 


### PR DESCRIPTION
 

# What
Renamed 'searches from the page' to 'searches from page'
# Why
For consistency with 'users who found page useful' metric

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [ ] Added to Trello card.
