### PR TITLE
Revert "Bump govuk_app_config from 1.16.1 to 1.16.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ GEM
       rubocop (~> 0.64)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.16.2)
+    govuk_app_config (1.16.1)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)


### PR DESCRIPTION
Reverts alphagov/content-data-admin#529

https://github.com/alphagov/govuk_app_config/pull/93