### PR TITLE
Replace 404 page not found error page

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -17,6 +17,6 @@ class MetricsController < ApplicationController
   end
 
   rescue_from GdsApi::HTTPNotFound do
-    render file: Rails.root.join('public', '404.html'), status: :not_found, layout: false
+    render file: Rails.root.join('app/views/errors', '404.html.erb'), status: :not_found, layout: true
   end
 end

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,0 +1,34 @@
+<% content_for :title, t("errors.404") %>
+
+<!DOCTYPE html>
+<html class="govuk-template">
+<head>
+  <meta charset="utf-8" />
+  <title>Page not found – GOV.UK</title>
+  <link rel="stylesheet" media="all" href="/errors.css" />
+</head>
+
+<body class='govuk-template__body'>
+  <div class="govuk-width-container">
+    <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h1 class="govuk-heading-xl">Page not found</h1>
+          <p class="govuk-body">
+            If you typed the web address, check it is correct.
+          </p>
+          <p class="govuk-body">
+            If you pasted the web address, check you copied the entire address.
+          </p>
+        </div>
+      </div>
+    </main>
+  </div>
+
+  <div class="govuk-body">
+    <a href="<%= Plek.new.external_url_for('support') + '/content_data_feedback/new' %>">
+      Send us feedback
+    </a>
+  </div>
+</body>
+</html>

--- a/config/locales/views/errors/en.yml
+++ b/config/locales/views/errors/en.yml
@@ -1,0 +1,3 @@
+en:
+  errors:
+    404: 'Page not found'


### PR DESCRIPTION
The 404 page now has a header, which follows the layout of other pages.

Trello: https://trello.com/c/1EfhcV4y

# Screenshots

## Before
![Screen Shot 2019-05-28 at 15 10 13](https://user-images.githubusercontent.com/6651749/58493574-28f2df00-816b-11e9-940e-3dd775cfe171.png)


## After
![Screen Shot 2019-05-28 at 17 00 02](https://user-images.githubusercontent.com/6651749/58493582-2db79300-816b-11e9-97b6-025e7593ce4c.png)
