### PR TITLE
Add explicit link for switching apps in Signon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,6 +27,7 @@
     product_name: "Publishing",
     full_width: @fullwidth,
     navigation_items: [
+      { text: "Switch app", href: Plek.new.external_url_for("signon") },
       { text: current_user.name, href: Plek.new.external_url_for('signon') },
       { text: "Log out", href: gds_sign_out_path }
     ]


### PR DESCRIPTION
# What
https://trello.com/c/SorbEsQE/1459-add-a-switch-app-link-to-the-header-and-make-sure-that-the-profile-name-links-to-the-right-place-in-signon

Adds a link to signon so users can switch apps more easily.

# Why
The name already links here but users are not recognising that. This brings us in line with what the Publisher team do.

# Screenshot
![Screen Shot 2019-06-04 at 08 23 59](https://user-images.githubusercontent.com/31649453/58859760-7bb82380-86a2-11e9-9f3e-74f809a78455.png)
