### PR TITLE
Add tracking to content metrics section

### DIFF
--- a/app/views/metrics/_content_metrics.html.erb
+++ b/app/views/metrics/_content_metrics.html.erb
@@ -1,7 +1,7 @@
 
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds content-metrics">
+  <div class="govuk-grid-column-two-thirds content-metrics" data-gtm-id="content-metrics">
     <h2 class="section-content__header content-metrics__header">
       <%= t "metrics.show.section_headings.content" %>
     </h2>

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -33,6 +33,10 @@ RSpec.feature 'user analytics' do
     expect(page).to have_selector('[data-gtm-id="metric-summary"] summary')
   end
 
+  scenario 'tracks content metrics reveal' do
+    expect(page).to have_selector('[data-gtm-id="content-metrics"] summary')
+  end
+
   scenario 'tracks clicks on app name in header' do
     expect(page).to have_selector('.govuk-phase-banner__content__app-name')
   end


### PR DESCRIPTION
# What
https://trello.com/c/76VOZ7pD/1425-3-update-page-content-metrics-layout
A tiny change to add tracking to the reworked page content metrics section.