### PR TITLE
Fix mobile layout on content metrics

### DIFF
--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -77,46 +77,50 @@
     @include govuk-responsive-margin(2, "top");
   }
 
-  .govuk-summary-list--small {
-    @include govuk-font($size: 16);
-    @include govuk-responsive-margin(1, "bottom");
-
-  }
-
-  .govuk-summary-list__value--right-align {
-    text-align: right;
-   }
-
-  .govuk-summary-list__key {
-    font-weight: normal;
-  }
-
-  .content-metrics {
-    .page-help {
-      @include govuk-responsive-margin(1, "left");
-    }
-   }
-
   .content-metrics__header {
     @include govuk-responsive-margin(4, "bottom");
   }
 
-  .content-metrics__help-icon {
-    vertical-align: bottom;
-  }
+  @include govuk-media-query($from: tablet) {
+    .govuk-summary-list--small {
+      @include govuk-font($size: 16);
+      @include govuk-responsive-margin(1, "bottom");
 
-  .content-metrics__data {
-    .govuk-summary-list__row {
-      &:last-of-type {
-        .govuk-summary-list__key,
-        .govuk-summary-list__value {
-          border-bottom: none;
+    }
+
+    .govuk-summary-list__value--right-align {
+      text-align: right;
+     }
+
+    .govuk-summary-list__key {
+      font-weight: normal;
+    }
+
+    .content-metrics {
+      .page-help {
+        @include govuk-responsive-margin(1, "left");
+      }
+     }
+
+
+
+    .content-metrics__help-icon {
+      vertical-align: bottom;
+    }
+
+    .content-metrics__data {
+      .govuk-summary-list__row {
+        &:last-of-type {
+          .govuk-summary-list__key,
+          .govuk-summary-list__value {
+            border-bottom: none;
+          }
         }
       }
     }
-  }
 
-  .content-metrics__data {
-    border-top: 2px solid $grey-3;
+    .content-metrics__data {
+      border-top: 2px solid $grey-3;
+    }
   }
 }


### PR DESCRIPTION
# What
Update so that the overrides only affect full width view

# Why
Mobile view is currently broken - see screenshot

# Screenshots

## Before
<img width="432" alt="Screen Shot 2019-06-04 at 14 25 11" src="https://user-images.githubusercontent.com/31649453/58882788-f9952280-86d4-11e9-84ff-71cb2746d8f1.png">

## After
<img width="440" alt="Screen Shot 2019-06-04 at 14 25 24" src="https://user-images.githubusercontent.com/31649453/58882793-fe59d680-86d4-11e9-905b-87932aa33b2f.png">
