### PR TITLE
Change text to follow GOV.UK style

### DIFF
--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -9,7 +9,7 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sending the CSV export</h1>
     <p>The data you exported is on its way. We'll send an email to <%= @recipient %> with a link to download the CSV.</p>
-    <p>Most emails should arrive within 15 minutes. If you don't receive an email within 30 minutes, contact 
+    <p>Most emails arrive within 15 minutes. If you do not receive an email within 30 minutes, contact 
     <a href="mailto:content-data-feedback@digital.cabinet-office.gov.uk">content-data-feedback@digital.cabinet-office.gov.uk</a>.</p>
   </div>
 </div>


### PR DESCRIPTION
# What
Removed 'should' and a negative contraction

# Why
Because they can be ambiguous for users

---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
