### PR TITLE
Fix nil in trend percentages

### DIFF
--- a/app/models/calculator/trend_percentage.rb
+++ b/app/models/calculator/trend_percentage.rb
@@ -9,9 +9,13 @@ class Calculator::TrendPercentage
   end
 
   def calculate
-    return 0 if previous <= 0
-
-    trend
+    if previous.nil? || current.nil?
+      nil
+    elsif previous <= 0
+      0
+    else
+      trend
+    end
   end
 
 private

--- a/spec/models/calculator/trend_percentage_spec.rb
+++ b/spec/models/calculator/trend_percentage_spec.rb
@@ -7,4 +7,16 @@ RSpec.describe Calculator::TrendPercentage do
   it 'returns trend percentage if previous value > 0' do
     expect(subject.calculate(2, 1)).to eq 100
   end
+
+  it 'returns trend percentage if previous value > 0' do
+    expect(subject.calculate(1, 2)).to eq(-50)
+  end
+
+  it 'returns nil if previous value is nil' do
+    expect(subject.calculate(2, nil)).to eq nil
+  end
+
+  it 'returns nil if current value is nil' do
+    expect(subject.calculate(nil, 2)).to eq nil
+  end
 end


### PR DESCRIPTION
If the previous value is nil, the trend percentage calculate threw an error. This puts gaurds in for nil values and adds more unit tests.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.