### PR TITLE
Add link to edit in content publisher.

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -1,10 +1,12 @@
 module ExternalLinksHelper
-  def edit_url_for(content_id:, publishing_app:, base_path:, document_type:, parent_content_id: '')
+  def edit_url_for(content_id:, publishing_app:, base_path:, document_type:, parent_content_id: '', locale: 'en')
     case publishing_app
     when 'whitehall'
       "#{external_url_for('whitehall-admin')}/government/admin/by-content-id/#{content_id}"
     when 'publisher'
       "#{external_url_for('support')}/content_change_request/new"
+    when 'content-publisher'
+      "#{external_url_for('content-publisher')}/documents/#{content_id}:#{locale}"
     when 'manuals-publisher'
       if document_type == 'manual'
         "#{external_url_for('manuals-publisher')}/manuals/#{content_id}"

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -128,7 +128,8 @@ class SingleContentItemPresenter
       publishing_app: metadata[:publishing_app],
       base_path: base_path,
       parent_content_id: metadata[:parent_content_id],
-      document_type: metadata[:document_type]
+      document_type: metadata[:document_type],
+      locale: metadata[:locale]
     )
   end
 

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
+    context 'with content-publisher' do
+      it 'generates a link to the content-publisher app' do
+        expect(
+          edit_url_for(content_id: 'content_id',
+            publishing_app: 'content-publisher',
+            base_path: '/anything',
+            document_type: 'news_story',
+            locale: 'fr')
+        ).to eq(
+          "#{external_url_for('content-publisher')}/documents/content_id:fr"
+        )
+      end
+    end
+
     context 'with contacts' do
       it 'generates a link to the contacts publisher app' do
         expect(
@@ -139,6 +153,17 @@ RSpec.describe ExternalLinksHelper do
         ).to eq(
           'Request a content change in GOV.UK Support'
         )
+      end
+    end
+
+    context 'with content-publisher' do
+      it 'uses the specific label' do
+        expect(
+          edit_label_for(publishing_app: 'content-publisher')
+        ).to eq(I18n.t(
+                  'metrics.show.navigation.edit_link',
+                  publishing_app: 'Content publisher'
+        ))
       end
     end
   end

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -68,6 +68,7 @@ module GdsApi
             title: "Content Title",
             base_path: "/#{base_path}",
             content_id: 'content-id',
+            locale: 'fr',
             first_published_at: "2018-07-17T10:35:59.000Z",
             public_updated_at: "2018-07-17T10:35:57.000Z",
             publishing_app: publishing_app,

--- a/spec/support/shared/metadata.rb
+++ b/spec/support/shared/metadata.rb
@@ -41,6 +41,7 @@ RSpec.shared_examples 'Metadata presentation' do
         :edit_url_for
       ).with(
         content_id: 'content-id',
+        locale: 'fr',
         publishing_app: 'whitehall',
         base_path: '/the/base/path',
         document_type: 'news_story',


### PR DESCRIPTION
# What
Adds a link `Edit in Content publisher` when the `publishing_app`
is `content-publisher`.


What are the proposed changes?

# Why
As a convenience to users

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
