### PR TITLE
Remove blank entry from dropdown

### DIFF
--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -43,14 +43,13 @@
                 selected_option: @filter.selected_document_type(params)
               }
           %>
-
           <%= render "govuk_publishing_components/components/accessible_autocomplete",
               {
                 id: 'organisation_id',
                 label: {
                   text: "Organisation"
                 },
-                options: @filter.organisation_options.unshift(['','all']),
+                options: @filter.organisation_options,
                 selected_option: @filter.selected_organisation(params)
               }
           %>


### PR DESCRIPTION
# What & why
Bugfix:  It is necessary to add blank entries to the lists for the dropdowns but this was being added in two places, resulting in a duplicate.

# Screenshots
## Before
![Screen Shot 2019-06-12 at 08 22 09](https://user-images.githubusercontent.com/31649453/59331255-64ed7e80-8ceb-11e9-820e-db640a42b36e.png)

## After
![Screen Shot 2019-06-12 at 08 22 21](https://user-images.githubusercontent.com/31649453/59331276-733b9a80-8ceb-11e9-8c70-ff1c75586adf.png)

