### PR TITLE
Rename total_words to word_count to be consistent

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -48,7 +48,7 @@ class ContentItemsCSVPresenter
       'Link to feedback comments' => lambda do |result_row|
         feedback_comments_link(result_row[:base_path])
       end,
-      I18n.t('metrics.words.short_title') => raw_field(:word_count),
+      I18n.t('metrics.words.short_title') => raw_field(:words),
       I18n.t('metrics.pdf_count.short_title') => raw_field(:pdf_count),
       I18n.t('metrics.reading_time.short_title') => lambda do |result_row|
         format_duration(result_row[:reading_time])

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -48,7 +48,7 @@ class SingleContentItemPresenter
     number_with_delimiter value_for('feedex')
   end
 
-  def total_words
+  def words
     number_with_delimiter value_for('words')
   end
 

--- a/app/views/metrics/_content_metrics.html.erb
+++ b/app/views/metrics/_content_metrics.html.erb
@@ -7,7 +7,7 @@
     </h2>
 
     <dl class="govuk-summary-list govuk-summary-list--small content-metrics__data">
-      <% ['reading_time', 'total_words', 'total_pdf_count'].each do |metric| %>
+      <% ['reading_time', 'words', 'total_pdf_count'].each do |metric| %>
         <div class="govuk-summary-list__row content-metric__<%= metric.gsub('_', '-') %>">
         <dt class="govuk-summary-list__key" data-gtm-id="metric-section-heading">
           <%= t "metrics.#{metric}.title" %>
@@ -22,7 +22,7 @@
     <%= render "govuk_publishing_components/components/details", {
       title: t("metrics.page_content.about_title")
     } do %>
-      <% ['reading_time', 'total_words', 'total_pdf_count'].each do |metric| %>
+      <% ['reading_time', 'words', 'total_pdf_count'].each do |metric| %>
         <h3 class="govuk-heading-s"><%= @performance_data.metric_about_label(metric) %></h3>
         <p class="govuk-body govuk-body-s"><%= raw t("metrics.#{metric}.about") %></p>
       <% end %>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -93,7 +93,7 @@ en:
         end of a transaction that started on GOV.UK.
 
         You'll need a Signon account with Feedback Explorer permissions to see the comments.
-    total_words:
+    words:
       title: 'Word count'
       short_title: 'Word count'
       summary: 'Number of words on the page'

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -170,12 +170,12 @@ RSpec.describe '/metrics/base/path', type: :feature do
       end
 
       it 'renders a metric for word count' do
-        expect(page).to have_selector '.content-metric__total-words .govuk-summary-list__value', text: '200'
+        expect(page).to have_selector '.content-metric__words .govuk-summary-list__value', text: '200'
       end
 
       it 'renders about label for word count' do
         label = 'Word count'
-        expect(page).to have_selector(".content-metric__total-words .govuk-summary-list__key", text: label)
+        expect(page).to have_selector(".content-metric__words .govuk-summary-list__key", text: label)
       end
 
       it 'renders a metric for time to read' do

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ContentItemsCSVPresenter do
         useful_no: 300,
         searches: 14,
         feedex: 24,
-        word_count: 50,
+        words: 50,
         reading_time: 50,
         pdf_count: 0
       },
@@ -50,7 +50,7 @@ RSpec.describe ContentItemsCSVPresenter do
         useful_no: 200,
         searches: 14,
         feedex: 24,
-        word_count: 100,
+        words: 100,
         reading_time: 100,
         pdf_count: 3
       }

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -241,17 +241,17 @@ RSpec.describe SingleContentItemPresenter do
     end
   end
 
-  describe '#total_words' do
+  describe '#words' do
     it 'correctly formats number for a value in the millions' do
       current_period_data[:edition_metrics] = [{ name: 'words', value: 5_000 }]
 
-      expect(subject.total_words).to eq('5,000')
+      expect(subject.words).to eq('5,000')
     end
 
     it 'correctly formats number for a small value' do
       current_period_data[:edition_metrics] = [{ name: 'words', value: 50 }]
 
-      expect(subject.total_words).to eq('50')
+      expect(subject.words).to eq('50')
     end
   end
 

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -23,7 +23,7 @@ module GdsApi
               useful_yes: 1050,
               useful_no: 2334,
               pdf_count: 0,
-              word_count: 0
+              words: 0
             },
             {
               base_path: '/path/1',
@@ -38,7 +38,7 @@ module GdsApi
               useful_yes: 2837,
               useful_no: 7495,
               pdf_count: 0,
-              word_count: 0
+              words: 0
             },
             {
               base_path: '/path/2',
@@ -53,7 +53,7 @@ module GdsApi
               useful_yes: 1530,
               useful_no: 1255,
               pdf_count: 0,
-              word_count: 170
+              words: 170
             }
           ]
         }

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe CsvExportWorker do
         useful_no: 300,
         searches: 14,
         feedex: 24,
-        word_count: 50,
+        words: 50,
         reading_time: 50,
         pdf_count: 0
       },
@@ -52,7 +52,7 @@ RSpec.describe CsvExportWorker do
         useful_no: 200,
         searches: 14,
         feedex: 24,
-        word_count: 100,
+        words: 100,
         reading_time: 100,
         pdf_count: 3
       }


### PR DESCRIPTION
### What
Rename total_words to word_count to be consistent.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.