### PR TITLE
Fix word count metric for CSV export

### DIFF
--- a/app/presenters/content_items_csv_presenter.rb
+++ b/app/presenters/content_items_csv_presenter.rb
@@ -49,7 +49,7 @@ class ContentItemsCSVPresenter
       I18n.t('metrics.reading_time.short_title') => lambda do |result_row|
         format_duration(result_row[:reading_time])
       end,
-      I18n.t('metrics.words.short_title') => raw_field(:words),
+      I18n.t('metrics.words.short_title') => raw_field(:word_count),
       I18n.t('metrics.pdf_count.short_title') => raw_field(:pdf_count)
     }
 

--- a/spec/presenters/content_items_csv_presenter_spec.rb
+++ b/spec/presenters/content_items_csv_presenter_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ContentItemsCSVPresenter do
         useful_no: 300,
         searches: 14,
         feedex: 24,
-        words: 50,
+        word_count: 50,
         reading_time: 50,
         pdf_count: 0
       },
@@ -50,7 +50,7 @@ RSpec.describe ContentItemsCSVPresenter do
         useful_no: 200,
         searches: 14,
         feedex: 24,
-        words: 100,
+        word_count: 100,
         reading_time: 100,
         pdf_count: 3
       }


### PR DESCRIPTION
This fixes a bug whereby word count is not available in the CSV export due to incorrectly referencing of `words` instead of `word count`.

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* [x] Added/updated relevant documentation.
* [x] Added to Trello card.