### PR TITLE
Fix 'number of responses' font size

### DIFF
--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -48,6 +48,10 @@
     @include govuk-font(16);
   }
 
+  .app-c-info-metric__short-context {
+    @include govuk-font(19);
+  }
+
 }
 
 .govuk-grid-column-one-third {


### PR DESCRIPTION
# What
Fix the font size on the short context in the info metric component
(Ignore the missing comparison data in the "after" screenshot, this is because the dataset on my dev environment is lacking.)

# Screenshots

## Before
![Screen Shot 2019-06-20 at 08 22 54](https://user-images.githubusercontent.com/31649453/59829308-fa64c000-9334-11e9-9cf8-44ac4d6279f4.png)

## After
![Screen Shot 2019-06-20 at 08 22 39](https://user-images.githubusercontent.com/31649453/59829317-03559180-9335-11e9-9284-7874c88edc05.png)


