### PR TITLE
Change heading to be less repetitive

### DIFF
--- a/config/locales/views/components/en.yml
+++ b/config/locales/views/components/en.yml
@@ -15,7 +15,7 @@ en:
         historical: 'History mode'
         withdrawn_and_historical: 'History mode and Withdrawn'
     time-select:
-      title: 'Page data: %{time_period}'
+      title: 'Showing data from %{time_period}'
       title_compact: 'Showing data from %{time_period}'
       change_dropdown: 'Change time period'
       submit_button: 'Change dates'

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -85,7 +85,12 @@ RSpec.describe '/content' do
       visit "/content?date_range=past-year&organisation_id=org-id"
       click_link 'The title'
       expect(current_path).to eq '/metrics/path/1'
-      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.past-year.leading')}")
+
+      expected_text = I18n.t(
+        'components.time-select.title',
+        time_period: I18n.t('metrics.show.time_periods.past-year.leading')
+      )
+      expect(page).to have_content(expected_text)
     end
   end
 
@@ -102,7 +107,11 @@ RSpec.describe '/content' do
 
     it 'links to the page data page after filtering' do
       click_on 'The title'
-      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.last-month.leading')}")
+      expected_text = I18n.t(
+        'components.time-select.title',
+        time_period: I18n.t('metrics.show.time_periods.last-month.leading')
+      )
+      expect(page).to have_content(expected_text)
     end
 
     it 'selected organisation is shown in dropdown menu' do
@@ -122,7 +131,11 @@ RSpec.describe '/content' do
       select 'another org', from: 'organisation_id'
       click_on 'Filter'
       click_on 'The title'
-      expect(page).to have_content("Page data: #{I18n.t('metrics.show.time_periods.past-year.leading')}")
+      expected_text = I18n.t(
+        'components.time-select.title',
+        time_period: I18n.t('metrics.show.time_periods.past-year.leading')
+      )
+      expect(page).to have_content(expected_text)
     end
 
     context 'when no organisation_id in params' do


### PR DESCRIPTION
# What
Took out the repetition of 'page data' (it used to appear in the kicker and the header)

# Why
Titles are more meaningful if they're not repetitive


---
# Review Checklist
* [x] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [x] Added to Trello card.
