### PR TITLE
Fix sentence case for document types in table summary

### DIFF
--- a/app/views/content/_table_data_description.html.erb
+++ b/app/views/content/_table_data_description.html.erb
@@ -9,7 +9,7 @@
         for '<span class="table-caption__param"><%= filter.search_terms %></span>'
     <% end %>
     <% if filter.document_type? && filter.document_type_id != "all" %>
-        for <span class="table-caption__param"><%= filter.document_type_name.downcase %></span>
+        for <span class="table-caption__param"><%= filter.document_type_name.humanize(capitalize: false) %></span>
     <% else %>
         for <span class="table-caption__param">all document types</span>
     <% end %>


### PR DESCRIPTION
# What
https://trello.com/c/DmEHFLCa/1514-capitalisation-of-acronyms-in-summary-above-index-page-table

We previously made a conscious decision to downcase document type names, but this has led to items with abbreviated terms or acronyms coming out incorrectly, eg html instead of HTML. This PR adds logic to the presenter to exclude the relevant terms from being downcased.

# Screenshots

## Before
![Screen Shot 2019-06-24 at 11 52 28](https://user-images.githubusercontent.com/31649453/60013904-97966000-9677-11e9-8a8a-0799f25de04c.png)

## After
![Screen Shot 2019-06-24 at 11 52 38](https://user-images.githubusercontent.com/31649453/60013915-9d8c4100-9677-11e9-95ee-52491a116758.png)

