### PR TITLE
Fix table row presenter with nil data

### DIFF
--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -12,11 +12,11 @@ class ContentRowPresenter
     @raw_document_type = data[:document_type]
     @document_type = humanize(data[:document_type])
     @sibling_order = data[:sibling_order] || '-'
-    @upviews = number_with_delimiter(data[:upviews], delimiter: ',')
+    @upviews = number_with_delimiter(data[:upviews], delimiter: ',') || 'No data'
     @satisfaction_percentage = format_satisfaction_percentage(data[:satisfaction])
     @satisfaction_responses = format_satisfaction_responses(data[:useful_yes], data[:useful_no])
 
-    @searches = number_with_delimiter(data[:searches], delimiter: ',')
+    @searches = number_with_delimiter(data[:searches], delimiter: ',') || 'No data'
   end
 
 private
@@ -26,6 +26,8 @@ private
   end
 
   def format_satisfaction_responses(yes_responses, no_responses)
+    return 'No data' if yes_responses.nil? || no_responses.nil?
+
     total_responses = yes_responses + no_responses
 
     if total_responses.positive?

--- a/spec/features/document_children_page/no_data_spec.rb
+++ b/spec/features/document_children_page/no_data_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe 'No metric data' do
+  include RequestStubs
+  include TableDataSpecHelpers
+
+  let(:document_id) { '1234:en' }
+  let(:items) do
+    [
+      {
+        "base_path" => '/parent',
+        "title" => "Parent",
+        "primary_organisation_id" => "7809-org",
+        "document_type" => "manual",
+        "sibling_order" => nil,
+        "upviews" => nil,
+        "pviews" => nil,
+        "feedex" => nil,
+        "useful_yes" => nil,
+        "useful_no" => nil,
+        "satisfaction" => nil,
+        "searches" => nil
+      },
+      {
+        "base_path" => "/child/1",
+        "title" => "Child 1",
+        "primary_organisation_id" => "7809-org",
+        "document_type" => "manual_section",
+        "sibling_order" => 1,
+        "upviews" => nil,
+        "pviews" => nil,
+        "useful_yes" => nil,
+        "useful_no" => nil,
+        "satisfaction" => nil,
+        "searches" => nil,
+      },
+      {
+        "base_path" => "/child/2",
+        "title" => "Child 2",
+        "primary_organisation_id" => "7809-org",
+        "document_type" => "manual_section",
+        "sibling_order" => 2,
+        "upviews" => nil,
+        "pviews" => nil,
+        "feedex" => nil,
+        "useful_yes" => nil,
+        "useful_no" => nil,
+        "satisfaction" => nil,
+        "searches" => nil,
+      }
+    ]
+  end
+
+  before do
+    response = { documents: items }
+    stub_document_children_page(document_id: document_id, response: response)
+    GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
+
+    visit "/documents/#{document_id}/children"
+  end
+
+  it 'renders the page without error' do
+    expect(page.status_code).to eq(200)
+    expect(page).to have_content('Content data')
+  end
+
+  it 'renders the data in a table' do
+    table_rows = extract_table_content('.govuk-table')
+    expect(table_rows).to eq(
+      [
+        ['Section', 'Page title', 'Document type', 'Unique page views', 'Users who found page useful', 'Searches from page'],
+        ['-', 'Parent /parent', 'Manual', 'No data', 'No data', 'No data'],
+        ['1', 'Child 1 /child/1', 'Manual section', 'No data', 'No data', 'No data'],
+        ['2', 'Child 2 /child/2', 'Manual section', 'No data', 'No data', 'No data'],
+      ]
+    )
+  end
+end

--- a/spec/presenters/content_row_presenter_spec.rb
+++ b/spec/presenters/content_row_presenter_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe ContentRowPresenter do
         base_path: '/some/base_path',
         document_type: 'news_story',
         title: 'a title',
-        upviews: '200,001',
+        upviews: 200_001,
         satisfaction: nil,
         useful_yes: 0,
         useful_no: 0,
@@ -69,6 +69,38 @@ RSpec.describe ContentRowPresenter do
 
     it 'returns "no responses" for responses' do
       expect(subject.satisfaction_responses).to eq("No responses")
+    end
+  end
+
+  context 'when there is nil for useful_yes' do
+    let(:additional_params) { { useful_yes: nil } }
+
+    it 'returns nil for percentage' do
+      expect(subject.satisfaction_responses).to eq('No data')
+    end
+  end
+
+  context 'when there is nil for useful_no' do
+    let(:additional_params) { { useful_no: nil } }
+
+    it 'returns nil for percentage' do
+      expect(subject.satisfaction_responses).to eq('No data')
+    end
+  end
+
+  context 'when there is nil for upviews' do
+    let(:additional_params) { { upviews: nil } }
+
+    it 'returns nil for percentage' do
+      expect(subject.upviews).to eq('No data')
+    end
+  end
+
+  context 'when there is nil for searches' do
+    let(:additional_params) { { searches: nil } }
+
+    it 'returns nil for percentage' do
+      expect(subject.searches).to eq('No data')
     end
   end
 end


### PR DESCRIPTION
This fixes a bug where the table row presenter doesn't know how to process nils for useful_yes, useful_no, satisfaction or searches. Now it will return the string 'No data'.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
