### PR TITLE
Style page links on compare page to look the same as index page

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -63,7 +63,6 @@ $govuk-global-styles: true;
     @include media(mobile) {
       @include govuk-responsive-padding(3, "left");
     }
-
   }
 
   .table-caption__param {
@@ -163,6 +162,11 @@ $govuk-global-styles: true;
 
   .govuk-table__cell--numeric {
     @include govuk-font($size: 14, $tabular: true);
+  }
+
+  .content-item__link {
+    font-weight: bold;
+    text-decoration: none;
   }
 
   .gem-c-layout-for-admin .govuk-grid-row {

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -33,11 +33,6 @@
     }
   }
 
-  .content-item__link {
-    font-weight: bold;
-    text-decoration: none;
-  }
-
   .filters-control__wrapper {
     border-bottom: 1px solid $govuk-border-colour;
     @include govuk-responsive-padding(3, "left");


### PR DESCRIPTION
# What
https://trello.com/c/Pd4TSrme/1523-fix-page-title-styling-in-table-on-comparison-page
Add bold and remove underline on page links

# Why
Match the index page

# Screenshots

## Before
![Screen Shot 2019-06-26 at 10 16 41](https://user-images.githubusercontent.com/31649453/60168974-b4f53680-97fd-11e9-93d3-56ca0c337092.png)

## After
![Screen Shot 2019-06-26 at 10 16 58](https://user-images.githubusercontent.com/31649453/60168985-ba528100-97fd-11e9-8dc9-e4e80cb51651.png)
