### PR TITLE
Match document time select options to index time select options

### DIFF
--- a/app/views/documents/children.html.erb
+++ b/app/views/documents/children.html.erb
@@ -27,7 +27,7 @@
         compact: true,
         render_button: true,
         current_selection: @time_period,
-        dates: time_select_options(TimeSelectHelper::METRIC_PAGE_TIME_PERIODS)
+        dates: time_select_options(TimeSelectHelper::CONTENT_PAGE_TIME_PERIODS)
       } %>
       <% end %>
     </div>


### PR DESCRIPTION
# What
https://trello.com/c/f7JJpYlr/1521-fix-links-for-time-selection-on-comparison-page
Fix date options

# Screenshots

## Before
![Screen Shot 2019-06-26 at 11 01 21](https://user-images.githubusercontent.com/31649453/60171466-95144180-9802-11e9-8b5a-88267e5deafd.png)

## After
![Screen Shot 2019-06-26 at 11 01 33](https://user-images.githubusercontent.com/31649453/60171487-9c3b4f80-9802-11e9-887c-e4dfd932dbdb.png)

