### PR TITLE
Move app name into header and remove from banner, adjust tests accordingly

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {
     environment: Rails.application.config.govuk_environment,
-    product_name: "Publishing",
+    product_name: "Content Data",
     full_width: @fullwidth,
     navigation_items: [
       { text: "Switch app", href: Plek.new.external_url_for("signon") },
@@ -47,7 +47,7 @@
 
   <div class="banner govuk-grid-row">
     <div class="govuk-grid-column-three-quarters">
-      <%= render "govuk_publishing_components/components/phase_banner", {phase: "beta", message: banner_message, app_name: "Content data"} %>
+      <%= render "govuk_publishing_components/components/phase_banner", {phase: "beta", message: banner_message} %>
     </div>
     <%= content_for :local_nav %>
   </div>

--- a/spec/features/document_children_page/documents_children_page_spec.rb
+++ b/spec/features/document_children_page/documents_children_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe '/documents/:document_id/children' do
 
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
-    expect(page).to have_content('Content data')
+    expect(page).to have_content('Content Data')
   end
 
   it 'renders the data in a table' do

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe '/content' do
 
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
-    expect(page).to have_content('Content data')
+    expect(page).to have_content('Content Data')
   end
 
   it 'renders the data in a table' do
@@ -102,7 +102,7 @@ RSpec.describe '/content' do
     end
 
     it 'makes request to api with correct organisation_id' do
-      expect(page).to have_content('Content data')
+      expect(page).to have_content('Content Data')
     end
 
     it 'links to the page data page after filtering' do

--- a/spec/features/index_page/user_analytics_spec.rb
+++ b/spec/features/index_page/user_analytics_spec.rb
@@ -51,8 +51,4 @@ RSpec.feature 'user analytics' do
   scenario 'tracks time period reveal' do
     expect(page).to have_selector('[data-gtm-id="time-period-options"] summary')
   end
-
-  scenario 'tracks clicks on app name in header' do
-    expect(page).to have_selector('.govuk-phase-banner__content__app-name')
-  end
 end

--- a/spec/features/metrics_page/user_analytics_spec.rb
+++ b/spec/features/metrics_page/user_analytics_spec.rb
@@ -36,8 +36,4 @@ RSpec.feature 'user analytics' do
   scenario 'tracks content metrics reveal' do
     expect(page).to have_selector('[data-gtm-id="content-metrics"] summary')
   end
-
-  scenario 'tracks clicks on app name in header' do
-    expect(page).to have_selector('.govuk-phase-banner__content__app-name')
-  end
 end


### PR DESCRIPTION
# What
https://trello.com/c/sviPxTmq/1524-move-content-data-from-phase-banner-to-header
Change header to say Content Data (with a capital on Data)
Remove Content data from the phase banner

# Why
Improve link clarity, remove unclickable app name

# Screenshots

## Before
![Screen Shot 2019-06-26 at 11 36 10](https://user-images.githubusercontent.com/31649453/60175330-30111980-980b-11e9-8be4-fdf5be494790.png)

## After
![Screen Shot 2019-06-26 at 11 36 18](https://user-images.githubusercontent.com/31649453/60175334-34d5cd80-980b-11e9-9dbf-c4c995f1924c.png)

