### PR TITLE
Add guidance text when there are no results on index page

### DIFF
--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -117,4 +117,13 @@
   .autocomplete__dropdown-arrow-down {
     @include govuk-responsive-padding(1, "top");
   }
+
+  .no-results {
+    @include govuk-font($size: 16);
+    @include govuk-responsive-padding(1, "left");
+  }
+
+  .no-results__header {
+    @include govuk-font(16, "bold");
+  }
 }

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -135,9 +135,23 @@
             </tr>
           <% end %>
           </tbody>
-   </table>
-
+        </table>
         </div>
+        <%if @presenter.pagination.total_results == 0 %>
+          <div class="no-results govuk-body ">
+            <h2 class="no-results__header">Sorry, we couldn’t find any results matching your selection</h3>
+
+              <p class="govuk-!-font-size-16">To improve your search results:</p>
+              <ul class="govuk-list govuk-list--bullet govuk-!-font-size-16">
+              <li>check your spelling</li>
+              <li>try the full URL or keywords instead of part of a URL</li>
+              <li>remove filters</li>
+              <li>come back tomorrow if the content was first published today</li>
+              </ul>
+              <p class="govuk-!-font-size-16">Content Data does not include services, campaigns, PDFs or blogs.</p>
+          </div>
+        <% end %>
+
         <div data-gtm-id="pagination-links">
           <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
         </div>


### PR DESCRIPTION
# What
https://trello.com/c/R26631io/1486-3-design-a-more-helpful-error-message-for-no-results-found
Add guidance text when queries return no results

I considered putting this into the localisation files for ease of updating, but it needed too much markup to make it look right.

# Why
Help users find their content

# Screenshots

## Before
![Screen Shot 2019-06-26 at 15 37 39](https://user-images.githubusercontent.com/31649453/60190061-ebe14180-9829-11e9-9610-d570a3d09f0b.png)

## After
![Screen Shot 2019-06-26 at 15 42 37](https://user-images.githubusercontent.com/31649453/60190093-f6034000-9829-11e9-85ed-fa42410807e3.png)

