### PR TITLE
Fix tests for document children with no data

### DIFF
--- a/spec/features/document_children_page/no_data_spec.rb
+++ b/spec/features/document_children_page/no_data_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'No metric data' do
 
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
-    expect(page).to have_content('Content data')
+    expect(page).to have_content('Content Data')
   end
 
   it 'renders the data in a table' do


### PR DESCRIPTION
The test is incorrectly looking for `Content data` when it should be `Content Data` because we moved the application name to the navigation bar.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.