### PR TITLE
Align search link to match other pages better

### DIFF
--- a/app/assets/stylesheets/compare/_show.scss
+++ b/app/assets/stylesheets/compare/_show.scss
@@ -7,7 +7,8 @@
 
   .local-nav__search-link {
     display: block;
-    @include govuk-responsive-margin(5, "right");
+    @include govuk-responsive-margin(0, "top");
+    @include govuk-responsive-margin(4, "right");
   }
 
   .gem-c-phase-banner {


### PR DESCRIPTION
# What
https://trello.com/c/gPmlYaoC/1519-fix-styling-of-search-link-on-comparison-page
Align search link better

# Screenshots

## Before
![Screen Shot 2019-06-27 at 09 15 32](https://user-images.githubusercontent.com/31649453/60249224-4fb44a80-98bc-11e9-9123-756a5302ab4e.png)

## After
![Screen Shot 2019-06-27 at 09 15 12](https://user-images.githubusercontent.com/31649453/60249241-593db280-98bc-11e9-89dd-cfb5bbdfdc0f.png)

