### PR TITLE
Remove hardcoded 6 from the document children table

### DIFF
--- a/app/views/documents/_table.html.erb
+++ b/app/views/documents/_table.html.erb
@@ -1,6 +1,11 @@
 <table class="table govuk-table" data-gtm-total-results="440627" data-gtm-page="1">
     <caption class="govuk-table__caption">
-      <p class="table-caption"><span class="table-caption__param">6</span> pages</p>
+      <p class="table-caption">
+        <span class="table-caption__param">
+          <%= @presenter.content_items.length %>
+        </span>
+        <%= @presenter.content_items.length == 1 ? 'page' : 'pages' %>
+      </p>
     </caption>
     <thead class="govuk-table__head" data-gtm-id="table-header">
       <tr class="govuk-table__row">


### PR DESCRIPTION
Replace it with the actual number of children.

# Screenshots

## Before
![before](https://user-images.githubusercontent.com/1130010/60251972-06aec700-98b9-11e9-8a3e-5542b351be8d.png)

## After
![after](https://user-images.githubusercontent.com/1130010/60251982-09a9b780-98b9-11e9-9367-ce2d405c2b32.png)

---
# Review Checklist
* [x] Changes in scope.
* ~~Added/updated unit tests.~~
* ~~Added/updated feature tests.~~
* ~~Added/updated relevant documentation.~~
* [ ] Added to Trello card.
