### PR TITLE
Fix parent sibling order reference

### DIFF
--- a/app/presenters/content_row_presenter.rb
+++ b/app/presenters/content_row_presenter.rb
@@ -11,7 +11,7 @@ class ContentRowPresenter
     @base_path = format_base_path(data[:base_path])
     @raw_document_type = data[:document_type]
     @document_type = humanize(data[:document_type])
-    @sibling_order = data[:sibling_order] || '-'
+    @sibling_order = format_sibling_order(data[:sibling_order])
     @upviews = number_with_delimiter(data[:upviews], delimiter: ',') || 'No data'
     @satisfaction_percentage = format_satisfaction_percentage(data[:satisfaction])
     @satisfaction_responses = format_satisfaction_responses(data[:useful_yes], data[:useful_no])
@@ -40,5 +40,9 @@ private
   def format_base_path(base_path)
     #  remove '/' to make base_path usable in links
     base_path.delete_prefix('/')
+  end
+
+  def format_sibling_order(number)
+    number.nil? || number.zero? ? '-' : number
   end
 end

--- a/app/presenters/document_children_presenter.rb
+++ b/app/presenters/document_children_presenter.rb
@@ -4,7 +4,7 @@ class DocumentChildrenPresenter
   attr_reader :kicker, :header, :title, :content_items
 
   def initialize(documents)
-    parent = documents.find { |d| d[:sibling_order] == nil }
+    parent = documents.find { |d| d[:sibling_order].nil? || d[:sibling_order].zero? }
     @kicker = format_page_kicker(parent[:document_type])
     @header = parent[:title]
     @title = "#{@header}: #{@kicker}"

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -67,7 +67,7 @@ module GdsApi
               "title" => "Parent",
               "primary_organisation_id" => "7809-org",
               "document_type" => "manual",
-              "sibling_order" => nil,
+              "sibling_order" => 0,
               "upviews" => 10,
               "pviews" => 2,
               "feedex" => 0,


### PR DESCRIPTION
The API references the parent document with a sibling order of 0, instead of '-'. This fixes the logic selecting the parent and the formatting the order value in the table.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.