### PR TITLE
Capitalise each word in the name of publishing apps

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -37,7 +37,7 @@ module ExternalLinksHelper
     else
       I18n.t(
         'metrics.show.navigation.edit_link',
-        publishing_app: publishing_app.capitalize.tr('-', ' ')
+        publishing_app: publishing_app.tr('-', ' ').titlecase
       )
     end
   end

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -306,7 +306,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the specialist publisher application' do
         stub_metrics_page(base_path: 'specialist/path', time_period: :past_30_days, publishing_app: 'specialist-publisher')
         visit '/metrics/specialist/path'
-        label = I18n.t("metrics.show.navigation.edit_link", publishing_app: 'Specialist publisher')
+        label = I18n.t("metrics.show.navigation.edit_link", publishing_app: 'Specialist Publisher')
         expect(page).to have_link(label, href: "http://specialist-publisher.dev.gov.uk/news-storys/content-id/edit")
       end
 
@@ -320,7 +320,7 @@ RSpec.describe '/metrics/base/path', type: :feature do
       it 'renders the travel advice application' do
         stub_metrics_page(base_path: 'travel/path', time_period: :past_30_days, publishing_app: 'travel-advice-publisher')
         visit '/metrics/travel/path'
-        label = I18n.t("metrics.show.navigation.edit_link", publishing_app: 'Travel advice publisher')
+        label = I18n.t("metrics.show.navigation.edit_link", publishing_app: 'Travel Advice Publisher')
         expect(page).to have_link(label, href: 'http://travel-advice-publisher.dev.gov.uk/admin/countries/path')
       end
     end

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe ExternalLinksHelper do
           edit_label_for(publishing_app: 'content-publisher')
         ).to eq(I18n.t(
                   'metrics.show.navigation.edit_link',
-                  publishing_app: 'Content publisher'
+                  publishing_app: 'Content Publisher'
         ))
       end
     end


### PR DESCRIPTION
So "Manuals Publisher" rather than "Manuals publisher", which is more
consistent with how the application name is presented elsewhere.

# Screenshots

## Before
![before](https://user-images.githubusercontent.com/1130010/60256321-d3703600-98c0-11e9-9a54-44c3b6bbbadb.png)

## After
![after](https://user-images.githubusercontent.com/1130010/60256333-d79c5380-98c0-11e9-9848-c08ea00fdf5a.png)

---
# Review Checklist
* [x] Changes in scope.
* [x] Added/updated unit tests.
* [x] Added/updated feature tests.
* ~~Added/updated relevant documentation.~~
* [x] Added to Trello card.
