### PR TITLE
Link to comparison page

### DIFF
--- a/app/assets/stylesheets/components/_related-actions.scss
+++ b/app/assets/stylesheets/components/_related-actions.scss
@@ -2,18 +2,25 @@
 
 .app-c-related-actions {
   background-color: $grey-4;
-  @include govuk-responsive-padding(3, "top");
-  @include govuk-responsive-margin(1, "bottom");
+  @include govuk-responsive-padding(5, "top");
+  @include govuk-responsive-padding(3, "bottom");
+  @include govuk-responsive-padding(3, "left");
+  @include govuk-responsive-padding(3, "right");
   @include govuk-font(19);
 }
 
 .app-c-related-actions__links {
-  @include govuk-responsive-padding(3, "left");
-  @include govuk-responsive-padding(2, "bottom");
+  @include govuk-responsive-padding(0);
   list-style-type: none;
 }
 
 .app-c-related-actions__link {
   @include govuk-responsive-padding(1, "bottom");
+  margin: 0;
   list-style-type: none;
+}
+
+.app-c-related-actions__links--local {
+  border-top: 1px solid $grey-2;
+  @include govuk-responsive-padding(3, "top");
 }

--- a/app/helpers/document_children_helper.rb
+++ b/app/helpers/document_children_helper.rb
@@ -1,0 +1,10 @@
+module DocumentChildrenHelper
+  def parent_document_id(content_id, locale, parent_document_id)
+    parent_document_id || "#{content_id}:#{locale}"
+  end
+
+  def document_children_link_for(document_id)
+    content_data_url = Plek.new.external_url_for('content-data')
+    "#{content_data_url}/documents/#{document_id}/children"
+  end
+end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -136,7 +136,7 @@ class SingleContentItemPresenter
 
   def local_links
     local_links = []
-    if @single_page_data[:number_of_related_content] > 1
+    if @single_page_data[:number_of_related_content].positive?
 
       document_id = parent_document_id(
         @single_page_data[:metadata][:content_id],

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -1,6 +1,7 @@
 class SingleContentItemPresenter
   include MetricsFormatterHelper
   include ExternalLinksHelper
+  include DocumentChildrenHelper
 
   attr_reader :date_range
 
@@ -131,6 +132,25 @@ class SingleContentItemPresenter
       document_type: metadata[:document_type],
       locale: metadata[:locale]
     )
+  end
+
+  def local_links
+    local_links = []
+    if @single_page_data[:number_of_related_content] > 1
+
+      document_id = parent_document_id(
+        @single_page_data[:metadata][:content_id],
+        @single_page_data[:metadata][:locale],
+        @single_page_data[:metadata][:parent_document_id]
+      )
+
+      local_links.append(
+        link_url: document_children_link_for(document_id),
+        label: 'See data for all sections',
+        gtm_id: 'compare-link'
+      )
+    end
+    local_links
   end
 
   def edit_label

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -128,7 +128,7 @@ class SingleContentItemPresenter
       content_id: metadata[:content_id],
       publishing_app: metadata[:publishing_app],
       base_path: base_path,
-      parent_content_id: metadata[:parent_content_id],
+      parent_content_id: parent_content_id,
       document_type: metadata[:document_type],
       locale: metadata[:locale]
     )
@@ -204,6 +204,11 @@ private
 
   def value_for(metric)
     @metrics[metric][:value]
+  end
+
+  def parent_content_id
+    document_id = metadata[:parent_document_id]
+    document_id.split(':')[0] unless document_id.nil?
   end
 
   def useful_yes_no_total

--- a/app/views/components/_related-actions.html.erb
+++ b/app/views/components/_related-actions.html.erb
@@ -1,18 +1,39 @@
 <%
-  links ||= []
+  external_links ||= []
+  local_links ||= []
+  classname ||= false
 %>
-<% if links.any? %>
+<% if external_links.any? || local_links.any? %>
   <div class="app-c-related-actions">
-    <ul class="govuk-body govuk-body-s app-c-related-actions__links">
-      <% links.each do |l| %>
-        <% if l[:label] && l[:link_url] %>
-          <li class="app-c-related-actions__link">
-            <a href="<%= l[:link_url] %>" class="govuk-link">
-              <%= l[:label] %>
-            </a>
-          </li>
+    <% if external_links.any? %>
+      <ul class="govuk-body govuk-body-s app-c-related-actions__links app-c-related-actions__links--external">
+        <% external_links.each do |l| %>
+          <% if l[:label] && l[:link_url] %>
+            <li class="app-c-related-actions__link">
+              <a href="<%= l[:link_url] %>" class="govuk-link">
+                <%= l[:label] %>
+              </a>
+            </li>
+          <% end %>
         <% end %>
-      <% end %>
-    </ul>
+      </ul>
+    <% end %>
+    <% if local_links.any? %>
+      <ul
+      class="govuk-body govuk-body-s app-c-related-actions__links app-c-related-actions__links--local">
+        <% local_links.each do |l| %>
+          <% if l[:label] && l[:link_url] %>
+            <li class="app-c-related-actions__link">
+              <a
+              href="<%= l[:link_url] %>" class="govuk-link"
+              <% if l[:gtm_id].present? %>data-gtm-id="<%= l[:gtm_id] %>"<% end %>
+              >
+                <%= l[:label] %>
+              </a>
+            </li>
+          <% end %>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -29,7 +29,7 @@
   <div class="govuk-grid-column-one-third related-actions">
     <%= render "components/related-actions",
       {
-        links: [
+        external_links: [
           {
             link_url: "//www.gov.uk#{@performance_data.base_path}",
             label: t(".navigation.visit_page")
@@ -38,7 +38,8 @@
             link_url: @performance_data.edit_url,
             label: @performance_data.edit_label
           }
-        ]
+        ],
+        local_links: @performance_data.local_links
       } %>
   </div>
 </div>

--- a/spec/components/related_actions_spec.rb
+++ b/spec/components/related_actions_spec.rb
@@ -3,16 +3,23 @@ require 'rails_helper'
 RSpec.describe "Related actions", type: :view do
   let(:data) {
     {
-      links: [
-                {
-                  link_url: "//www.gov.uk/govpage",
-                  label: "View on GOV.UK"
-                },
-                {
-                  link_url: "//www.gov.uk/moregov",
-                  label: "Edit in Whitehall"
-                }
-              ]
+        external_links: [
+          {
+            link_url: "//www.gov.uk/govpage",
+            label: "View on GOV.UK"
+          },
+          {
+            link_url: "//www.gov.uk/moregov",
+            label: "Edit in Whitehall"
+          }
+        ],
+        local_links: [
+          {
+            link_url: "../compare",
+            label: "See all 5 chapters",
+            gtm_id: 'compare-link'
+          }
+        ]
       }
   }
 
@@ -26,11 +33,14 @@ RSpec.describe "Related actions", type: :view do
 
   it "renders correctly when given valid data" do
     render_component(data)
-    assert_select ".app-c-related-actions", 1
-    assert_select "ul", 1
-    assert_select "li", 2
+    assert_select ".app-c-related-actions__links--external", 1
+    assert_select ".app-c-related-actions__links--local", 1
+    assert_select "ul", 2
+    assert_select "li", 3
     assert_select "a", href: "//www.gov.uk/govpage", text: "View on GOV.UK"
     assert_select "a", href: "//www.gov.uk/moregov", text: "Edit in Whitehall"
+    assert_select "a", href: "/../compare", text: "See all 5 chapters"
+    assert_select "a[data-gtm-id=\"compare-link\"]", 1
   end
 
   def render_component(locals)

--- a/spec/features/metrics_page/document_children_link_spec.rb
+++ b/spec/features/metrics_page/document_children_link_spec.rb
@@ -1,0 +1,31 @@
+RSpec.feature 'link to document children' do
+  include RequestStubs
+
+  scenario 'content has no children pages' do
+    stub_metrics_page(base_path: nil, time_period: :past_30_days)
+    visit '/metrics?date_range=past-30-days'
+
+    expect(page).to have_no_link('See data for all sections')
+  end
+
+  scenario 'content is parent of 2 pages' do
+    stub_metrics_page(base_path: nil, time_period: :past_30_days, related_content: 3)
+    visit '/metrics?date_range=past-30-days'
+
+    link = Plek.new.external_url_for('content-data') + '/documents/content-id:fr/children'
+    expect(page).to have_link('See data for all sections', href: link)
+  end
+
+  scenario 'content is child of 2 pages' do
+    stub_metrics_page(
+      base_path: nil,
+      time_period: :past_30_days,
+      related_content: 3,
+      parent_document_id: '1234:en'
+    )
+    visit '/metrics?date_range=past-30-days'
+
+    link = Plek.new.external_url_for('content-data') + '/documents/1234:en/children'
+    expect(page).to have_link('See data for all sections', href: link)
+  end
+end

--- a/spec/helpers/document_children_helper_spec.rb
+++ b/spec/helpers/document_children_helper_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe DocumentChildrenHelper do
+  describe '#parent_document_id' do
+    context 'parent document id is nil' do
+      it 'return current content id and locale' do
+        value = parent_document_id('1234', 'en', nil)
+        expect(value).to eq '1234:en'
+      end
+    end
+
+    context 'parent document id is present' do
+      it 'return current content id and locale' do
+        value = parent_document_id('1234', 'en', '5678:fr')
+        expect(value).to eq '5678:fr'
+      end
+    end
+  end
+end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -308,4 +308,66 @@ RSpec.describe SingleContentItemPresenter do
       expect(subject.feedback_explorer_href).to eq("#{Plek.new.external_url_for('support')}/anonymous_feedback?from=2018-11-25&to=2018-12-24&paths=#{CGI.escape('/the/base/path')}")
     end
   end
+
+  describe '#local_links' do
+    context 'when there are 2 related content pages' do
+      before { current_period_data[:number_of_related_content] = 2 }
+
+      context 'when it is the parent page' do
+        before do
+          current_period_data[:metadata][:content_id] = '1234'
+          current_period_data[:metadata][:locale] = 'en'
+          current_period_data[:metadata][:parent_document_id] = nil
+        end
+
+        it 'return a link to the document children page' do
+          link_url = "#{Plek.new.external_url_for('content-data')}/documents/1234:en/children"
+
+          expect(subject.local_links).to eq([
+            {
+              link_url: link_url,
+              label: 'See data for all sections',
+              gtm_id: 'compare-link'
+            }
+          ])
+        end
+      end
+
+      context 'when it is the child page' do
+        before do
+          current_period_data[:metadata][:content_id] = '1234'
+          current_period_data[:metadata][:locale] = 'en'
+          current_period_data[:metadata][:parent_document_id] = '5678:fr'
+        end
+
+        it 'return a link to the document children page' do
+          link_url = "#{Plek.new.external_url_for('content-data')}/documents/5678:fr/children"
+
+          expect(subject.local_links).to eq([
+            {
+              link_url: link_url,
+              label: 'See data for all sections',
+              gtm_id: 'compare-link'
+            }
+          ])
+        end
+      end
+    end
+
+    context 'when there is 1 related content pages' do
+      before { current_period_data[:number_of_related_content] = 1 }
+
+      it 'return a link to the document children page' do
+        expect(subject.local_links).to eq([])
+      end
+    end
+
+    context 'when there is 0 related content pages' do
+      before { current_period_data[:number_of_related_content] = 0 }
+
+      it 'return a link to the document children page' do
+        expect(subject.local_links).to eq([])
+      end
+    end
+  end
 end

--- a/spec/presenters/single_content_item_presenter_spec.rb
+++ b/spec/presenters/single_content_item_presenter_spec.rb
@@ -311,7 +311,7 @@ RSpec.describe SingleContentItemPresenter do
 
   describe '#local_links' do
     context 'when there are 2 related content pages' do
-      before { current_period_data[:number_of_related_content] = 2 }
+      before { current_period_data[:number_of_related_content] = 1 }
 
       context 'when it is the parent page' do
         before do
@@ -351,14 +351,6 @@ RSpec.describe SingleContentItemPresenter do
             }
           ])
         end
-      end
-    end
-
-    context 'when there is 1 related content pages' do
-      before { current_period_data[:number_of_related_content] = 1 }
-
-      it 'return a link to the document children page' do
-        expect(subject.local_links).to eq([])
       end
     end
 

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -5,7 +5,7 @@ module RequestStubs
   include GdsApi::TestHelpers::ContentDataApi
   include GdsApi::TestHelpers::ResponseHelpers
 
-  def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall', content_item_missing: false, current_data_missing: false, comparision_data_missing: false, edition_metrics_missing: false)
+  def stub_metrics_page(base_path:, time_period:, publishing_app: 'whitehall', content_item_missing: false, current_data_missing: false, comparision_data_missing: false, edition_metrics_missing: false, related_content: 0, parent_document_id: nil)
     dates = build(:date_range, time_period)
     prev_dates = dates.previous
 
@@ -15,6 +15,9 @@ module RequestStubs
     previous_period_data = older_single_page_response(
       base_path, prev_dates.from, prev_dates.to
     )
+
+    current_period_data[:metadata][:parent_document_id] = parent_document_id
+    current_period_data[:number_of_related_content] = related_content
 
     current_period_data[:metadata][:publishing_app] = publishing_app
     previous_period_data[:metadata][:publishing_app] = publishing_app

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -126,8 +126,9 @@ module GdsApi
             primary_organisation_title: "The Ministry",
             historical: false,
             withdrawn: false,
-            parent_content_id: ''
+            parent_document_id: nil
           },
+          number_of_related_content: 0,
           time_period: {
             to: to,
             from: from

--- a/spec/support/shared/metadata.rb
+++ b/spec/support/shared/metadata.rb
@@ -45,7 +45,7 @@ RSpec.shared_examples 'Metadata presentation' do
         publishing_app: 'whitehall',
         base_path: '/the/base/path',
         document_type: 'news_story',
-        parent_content_id: ''
+        parent_content_id: nil
       ).and_return(
         'https://expected-link'
       )


### PR DESCRIPTION
This adds the link from page data pages to the comparison pages. The link will only show if there is available content.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.