### PR TITLE
Fix guide titles for document children pages

### DIFF
--- a/app/presenters/document_children_presenter.rb
+++ b/app/presenters/document_children_presenter.rb
@@ -6,7 +6,7 @@ class DocumentChildrenPresenter
   def initialize(documents)
     parent = documents.find { |d| d[:sibling_order].nil? || d[:sibling_order].zero? }
     @kicker = format_page_kicker(parent[:document_type])
-    @header = parent[:title]
+    @header = format_header(parent[:title], parent[:document_type])
     @title = "#{@header}: #{@kicker}"
 
     @content_items = documents.map { |d| ContentRowPresenter.new(d) }
@@ -16,5 +16,13 @@ private
 
   def format_page_kicker(document_type)
     I18n.t('documents.children.kicker', type: humanize(document_type))
+  end
+
+  def format_header(title, document_type)
+    if document_type == 'guide' && title.include?(':')
+      title[0...title.rindex(':')]
+    else
+      title
+    end
   end
 end

--- a/spec/presenters/document_children_presenter_spec.rb
+++ b/spec/presenters/document_children_presenter_spec.rb
@@ -36,6 +36,20 @@ RSpec.describe DocumentChildrenPresenter do
     it 'return the page heading' do
       expect(subject.header).to eq('Parent')
     end
+
+    context 'when guide with single colon' do
+      let(:documents) { [{ title: 'Parent: overview', document_type: 'guide' }] }
+      it 'return base of the title' do
+        expect(subject.header).to eq('Parent')
+      end
+    end
+
+    context 'when guide with multiple colons' do
+      let(:documents) { [{ title: 'Parent: topic: overview', document_type: 'guide' }] }
+      it 'removed section from last colon from title' do
+        expect(subject.header).to eq('Parent: topic')
+      end
+    end
   end
 
   describe '#title' do


### PR DESCRIPTION
A parent guide page includes the first section the title. This means the document children page displays a section name in the header for guides. This a small fix to remove the extra section
name. For guides with multiple colons, it removes just the last section.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.