### PR TITLE
Increase timeout for the Content Data API

### DIFF
--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -4,6 +4,7 @@ class GdsApi::ContentDataApi < GdsApi::Base
   def initialize
     super("#{Plek.current.find('content-data-api')}/api/v1",
       disable_cache: true,
+      timeout: 60,
       bearer_token: ENV['CONTENT_DATA_API_BEARER_TOKEN'] || 'example')
   end
 


### PR DESCRIPTION
There are some timeouts occuring when generating CSV files. I believe
the default timeout is 4 seconds in the GDS API Adapters, so increase
this to 60 seconds (which matches the NGinx proxy read timeout).

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
