### PR TITLE
Update page title suffix to GOV.UK Content Data

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   environment: Rails.application.config.govuk_environment,
+  product_name: "Content Data",
   browser_title: yield(:title) do %>
   <%= render "govuk_publishing_components/components/skip_link" %>
   <%= render "govuk_publishing_components/components/layout_header", {

--- a/spec/features/index_page/index_page_spec.rb
+++ b/spec/features/index_page/index_page_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe '/content' do
   it 'renders the page without error' do
     expect(page.status_code).to eq(200)
     expect(page).to have_content('Content Data')
+    expect(page).to have_title('Content items - GOV.UK Content Data')
   end
 
   it 'renders the data in a table' do


### PR DESCRIPTION
The title of the page should render with the suffix of GOV.UK Content Data instead of GOV.UK Publishing. This is consistent with the wording in the header.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.