### PR TITLE
Use parent_base_path to find parent in comparison page

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -15,6 +15,6 @@ class DocumentsController < ApplicationController
     @sort = Sort.parse(params[:sort] || 'sibling_order:asc')
 
     response = FetchDocumentChildren.call(document_id: @document_id, time_period: @time_period, sort: @sort)
-    @presenter = DocumentChildrenPresenter.new(response[:documents])
+    @presenter = DocumentChildrenPresenter.new(response[:documents], response[:parent_base_path])
   end
 end

--- a/app/presenters/document_children_presenter.rb
+++ b/app/presenters/document_children_presenter.rb
@@ -3,8 +3,8 @@ class DocumentChildrenPresenter
 
   attr_reader :kicker, :header, :title, :content_items
 
-  def initialize(documents)
-    parent = documents.find { |d| d[:sibling_order].nil? || d[:sibling_order].zero? }
+  def initialize(documents, parent_base_path)
+    parent = documents.find { |d| d[:base_path] == parent_base_path }
     @kicker = format_page_kicker(parent[:document_type])
     @header = format_header(parent[:title], parent[:document_type])
     @title = "#{@header}: #{@kicker}"

--- a/spec/features/document_children_page/no_data_spec.rb
+++ b/spec/features/document_children_page/no_data_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'No metric data' do
   end
 
   before do
-    response = { documents: items }
+    response = { parent_base_path: '/parent', documents: items }
     stub_document_children_page(document_id: document_id, response: response)
     GDS::SSO.test_user = build(:user, organisation_content_id: 'users-org-id')
 

--- a/spec/features/document_children_page/sorting_spec.rb
+++ b/spec/features/document_children_page/sorting_spec.rb
@@ -83,7 +83,7 @@ RSpec.feature "Sort results" do
     sorted_items = items.sort_by { |item| item['upviews'] }
     sorted_items.reverse!
 
-    response = { documents: sorted_items }
+    response = { parent_base_path: '/parent', documents: sorted_items }
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'sibling_order:asc')
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'upviews:desc', response: response)
 
@@ -98,7 +98,7 @@ RSpec.feature "Sort results" do
     sorted_items = items.sort_by { |item| item['satisfaction'] }
     sorted_items.reverse!
 
-    response = { documents: sorted_items }
+    response = { parent_base_path: '/parent', documents: sorted_items }
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'sibling_order:asc')
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'satisfaction:desc', response: response)
 
@@ -113,7 +113,7 @@ RSpec.feature "Sort results" do
     sorted_items = items.sort_by { |item| item['searches'] }
     sorted_items.reverse!
 
-    response = { documents: sorted_items }
+    response = { parent_base_path: '/parent', documents: sorted_items }
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'sibling_order:asc')
     stub_document_children_page(document_id: document_id, time_period: 'past-30-days', sort: 'searches:desc', response: response)
 

--- a/spec/presenters/document_children_presenter_spec.rb
+++ b/spec/presenters/document_children_presenter_spec.rb
@@ -4,7 +4,11 @@ RSpec.describe DocumentChildrenPresenter do
   let(:parent_document_type) { 'Manual' }
   let(:documents) do
     [
-      { title: 'Parent', document_type: parent_document_type },
+      {
+        title: 'Parent',
+        base_path: '/parent',
+        document_type: parent_document_type
+      },
       { title: 'Child1' },
       { title: 'Child2' }
     ]
@@ -17,7 +21,7 @@ RSpec.describe DocumentChildrenPresenter do
   end
 
   subject do
-    DocumentChildrenPresenter.new(documents)
+    DocumentChildrenPresenter.new(documents, '/parent')
   end
 
   before do
@@ -38,14 +42,14 @@ RSpec.describe DocumentChildrenPresenter do
     end
 
     context 'when guide with single colon' do
-      let(:documents) { [{ title: 'Parent: overview', document_type: 'guide' }] }
+      let(:documents) { [{ title: 'Parent: overview', document_type: 'guide', base_path: '/parent' }] }
       it 'return base of the title' do
         expect(subject.header).to eq('Parent')
       end
     end
 
     context 'when guide with multiple colons' do
-      let(:documents) { [{ title: 'Parent: topic: overview', document_type: 'guide' }] }
+      let(:documents) { [{ title: 'Parent: topic: overview', document_type: 'guide', base_path: '/parent' }] }
       it 'removed section from last colon from title' do
         expect(subject.header).to eq('Parent: topic')
       end

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -61,6 +61,7 @@ module GdsApi
 
       def document_children_response
         {
+          "parent_base_path": '/parent',
           "documents" => [
             {
               "base_path" => '/parent',


### PR DESCRIPTION
We now find the parent by base path, rather than relying on sibling order.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
