### PR TITLE
Fix heading format of travel advice comparison page

### DIFF
--- a/app/presenters/document_children_presenter.rb
+++ b/app/presenters/document_children_presenter.rb
@@ -19,7 +19,7 @@ private
   end
 
   def format_header(title, document_type)
-    if document_type == 'guide' && title.include?(':')
+    if %w(guide travel_advice).include?(document_type) && title.include?(':')
       title[0...title.rindex(':')]
     else
       title

--- a/spec/presenters/document_children_presenter_spec.rb
+++ b/spec/presenters/document_children_presenter_spec.rb
@@ -41,6 +41,13 @@ RSpec.describe DocumentChildrenPresenter do
       expect(subject.header).to eq('Parent')
     end
 
+    context 'when travel advice with single colon' do
+      let(:documents) { [{ title: 'Parent: overview', document_type: 'travel_advice', base_path: '/parent' }] }
+      it 'return base of the title' do
+        expect(subject.header).to eq('Parent')
+      end
+    end
+
     context 'when guide with single colon' do
       let(:documents) { [{ title: 'Parent: overview', document_type: 'guide', base_path: '/parent' }] }
       it 'return base of the title' do


### PR DESCRIPTION
This adds travel advice to the document types which the heading is formatted. This is removing a page section from the main content title i.e. `Travel to Spain: Overview` -> `Travel to Spain`.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
