### PR TITLE
Replace govuk-lint with rubocop-govuk & scss_lint-govuk

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 inherit_gem:
-  govuk-lint: "configs/rubocop/all.yml"
+  rubocop-govuk:
+    - "config/default.yml"
+    - "config/rails.yml"
+
 AllCops:
   TargetRubyVersion: 2.6
 Metrics/BlockLength:

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,1 @@
+plugin_gems: ['scss_lint-govuk']

--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,11 @@ group :development, :test do
   gem "byebug"
   gem "capybara"
   gem "factory_bot_rails"
-  gem "govuk-lint"
   gem "govuk_test"
   gem 'pry'
   gem "rspec-rails"
+  gem "rubocop-govuk", "~> 1"
+  gem "scss_lint-govuk", "~> 0"
   gem "spring-commands-rspec"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,11 +123,6 @@ GEM
       warden-oauth2 (~> 0.0.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    govuk-lint (4.2.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -313,6 +308,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -337,6 +336,8 @@ GEM
       tilt
     scss_lint (0.59.0)
       sass (~> 3.5, >= 3.5.5)
+    scss_lint-govuk (0.2.0)
+      scss_lint
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -417,7 +418,6 @@ DEPENDENCIES
   fog-aws
   gds-api-adapters
   gds-sso
-  govuk-lint
   govuk_app_config
   govuk_publishing_components
   govuk_sidekiq
@@ -429,6 +429,8 @@ DEPENDENCIES
   pry
   rails (~> 5.2)
   rspec-rails
+  rubocop-govuk (~> 1)
+  scss_lint-govuk (~> 0)
   simplecov
   spring-commands-rspec
   timecop

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,5 @@
 desc "Run govuk-lint on all files"
 task "lint" do
   sh "bundle exec rubocop app config lib spec --parallel"
-  sh "bundle exec govuk-lint-sass app/assets/stylesheets"
+  sh "bundle exec scss-lint app/assets/stylesheets"
 end


### PR DESCRIPTION
As govuk-lint is soon to be deprecated. The style rules will remain the same.