### PR TITLE
README: Remove old, dev VM 'how to run the app' instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,38 +10,9 @@ This application is currently in development for a private beta.
 
 [Content Data API]: https://github.com/alphagov/content-data-api
 
-## Running the application
-
-### Standalone
-
-Launch the rails server:
-
-```bash
-bundle exec unicorn -c config/unicorn.rb
-```
-
-### Using the GDS development VM
-
-See the [getting started guide](https://docs.publishing.service.gov.uk/getting-started.html) for instructions about setting up and running your development VM.
-
-In the development VM, go to:
-
-```bash
-cd /var/govuk/govuk-puppet/development-vm
-```
-
-Then run:
-
- ```bash
- bowl content-data-admin
- ```
-
-The application can be accessed from:
-
-http://content-data-admin.dev.gov.uk
-
 ## Running the test suite
 To run the test suite:
+
  ```bash
  $ bundle exec rake
  ```
@@ -49,4 +20,3 @@ To run the test suite:
 ## Licence
 
 [MIT License](LICENCE)
-


### PR DESCRIPTION
# What

- These instructions referenced the deprecated GOV.UK Development VM, `bowler`, \*and\* `./startup.sh`.
- The new standard is [GOV.UK Docker](https://github.com/alphagov/govuk-docker).

# Why

The instructions to run the app were out of date and potentially confusing for new people or external contributors.

---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.