### PR TITLE
Disable showing comparison data

### DIFF
--- a/app/assets/stylesheets/components/_glance-metric.scss
+++ b/app/assets/stylesheets/components/_glance-metric.scss
@@ -4,11 +4,7 @@
 .app-c-glance-metric {
   @include govuk-responsive-margin(6, "bottom");
   border-top: 1px solid $govuk-border-colour;
-  border-bottom: 1px solid $govuk-border-colour;
-
-  @include media(mobile) {
-    border-bottom: 0;
-  }
+  border-bottom: 0;
 }
 
 .app-c-glance-metric__heading {

--- a/app/views/components/_glance-metric.html.erb
+++ b/app/views/components/_glance-metric.html.erb
@@ -22,31 +22,5 @@
       <% end %>
     </span>
     <p class="app-c-glance-metric__context govuk-body-xs"><%= context %></p>
-    <span class="app-c-glance-metric__trend">
-      <% if trend_percentage.blank? %>
-        no comparison data
-      <% else %>
-        <% if trend_percentage > 0 %>+<% end %><%= number_to_percentage(trend_percentage, precision: 2, delimiter: ',') %>
-      <% end %>
-    </span>
-    <% unless trend_percentage.blank? %>
-      <% if trend_percentage > 0 %>
-        <span class="app-c-glance-metric__trend--up">
-          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9650;</span>
-          <span class="app-c-glance-metric__trend-text">Upward trend</span>
-        <span>
-      <% elsif trend_percentage < 0 %>
-        <span class="app-c-glance-metric__trend--down">
-          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9660;</span>
-          <span class="app-c-glance-metric__trend-text">Downward trend</span>
-        <span>
-      <% else %>
-        <span class="app-c-glance-metric__trend--no-change">
-          <span aria-hidden="true" class="app-c-glance-metric__trend-icon">&#9679;</span>
-          <span class="app-c-glance-metric__trend-text">No change</span>
-        <span>
-      <% end %>
-    <% end %>
-    <p class="app-c-glance-metric__period govuk-body-xs"><%= period %></p>
   </div>
 <% end %>

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -2,7 +2,7 @@
   <%= render 'metric_header', {
     metric_name: metric_name,
     value: total,
-    show_trend: true,
+    show_trend: false,
     short_context: short_context
   }%>
 </div>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -102,7 +102,7 @@
       <%= render 'metric_header', {
         metric_name: 'pageviews_per_visit',
         value: @performance_data.pageviews_per_visit,
-        show_trend: true,
+        show_trend: false,
         short_context: nil
       }%>
     </div>

--- a/spec/components/glance_metric_spec.rb
+++ b/spec/components/glance_metric_spec.rb
@@ -40,8 +40,6 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric__figure", text: "167m"
     assert_select ".app-c-glance-metric__measurement[aria-label=Million]"
     assert_select ".app-c-glance-metric__context", text: "This is in your top 10 items"
-    assert_select ".app-c-glance-metric__trend", text: "+0.50%"
-    assert_select ".app-c-glance-metric__period", text: "Apr 2018 to Mar 2018"
   end
 
   it "does not show an aria label if no explicit measurement label is provided" do
@@ -50,7 +48,7 @@ RSpec.describe "Glance Metric", type: :view do
     assert_select ".app-c-glance-metric__measurement[aria-label=million]", 0
   end
 
-  it "displays the correct trend direction" do
+  pending "displays the correct trend direction" do
     render_component(data)
     assert_select ".app-c-glance-metric__trend--up .app-c-glance-metric__trend-text", text: "Upward trend"
     data[:trend_percentage] = -2

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "/metrics/base/path", type: :feature do
         expect(page).to have_selector ".glance-metric.upviews", text: "6k"
       end
 
-      it "renders trend percentage for unique page views" do
+      pending "renders trend percentage for unique page views" do
         expect(page).to have_selector ".upviews .app-c-glance-metric__trend", text: "+500.00%"
       end
 
@@ -79,7 +79,7 @@ RSpec.describe "/metrics/base/path", type: :feature do
         expect(page).to have_selector ".glance-metric.satisfaction", text: "700"
       end
 
-      it "renders trend percentage for satisfaction score" do
+      pending "renders trend percentage for satisfaction score" do
         expect(page).to have_selector ".satisfaction .app-c-glance-metric__trend", text: "+50.00%"
       end
 
@@ -91,7 +91,7 @@ RSpec.describe "/metrics/base/path", type: :feature do
         expect(page).to have_selector ".glance-metric.searches", text: "4.05%"
       end
 
-      it "renders trend percentage for page searches" do
+      pending "renders trend percentage for page searches" do
         expect(page).to have_selector ".searches .app-c-glance-metric__trend", text: "3,950.00%"
       end
 
@@ -99,7 +99,7 @@ RSpec.describe "/metrics/base/path", type: :feature do
         expect(page).to have_selector ".glance-metric.feedex", text: "63"
       end
 
-      it "renders trend percentage for feedex comments" do
+      pending "renders trend percentage for feedex comments" do
         expect(page).to have_selector ".feedex .app-c-glance-metric__trend", text: "+5.00%"
       end
 
@@ -245,7 +245,7 @@ RSpec.describe "/metrics/base/path", type: :feature do
     end
 
     context "when the data-api has no comparison data" do
-      it "returns trend as `no comparison data`" do
+      pending "returns trend as `no comparison data`" do
         stub_metrics_page(
           base_path: "base/path",
           time_period: "past_30_days",


### PR DESCRIPTION
As it could be misleading now that the way data is collected through
Google Analytics has changed. Also tweak the CSS to adjust for the
removal of the comparison data.

# Screenshots

## Before
![homepage-before](https://user-images.githubusercontent.com/1130010/71269597-a1a7cb80-2347-11ea-83a3-96120496404d.png)

## After
![image](https://user-images.githubusercontent.com/1130010/71269591-9d7bae00-2347-11ea-8681-f7f1bf3a450c.png)


---
# Review Checklist
* [ ] Changes in scope.
* [ ] Added/updated unit tests.
* [ ] Added/updated feature tests.
* [ ] Added/updated relevant documentation.
* [ ] Added to Trello card.
