### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,4 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-task default: %i(spec lint)
+task default: %i(spec)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,5 +1,0 @@
-desc "Run govuk-lint on all files"
-task lint: :environment do
-  sh "bundle exec rubocop app config lib spec --parallel"
-  sh "bundle exec scss-lint app/assets/stylesheets"
-end


### PR DESCRIPTION
- This `lint` task is not very useful as it hides the directories that
  it operates on, and we're trying to move away from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.