### PR TITLE
Allow content data to be requested by month

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,11 @@ class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
   before_action :authenticate_user!
+  before_action :downcase_date_range
+
+private
+
+  def downcase_date_range
+    params[:date_range].downcase! if params[:date_range]
+  end
 end

--- a/app/helpers/time_select_helper.rb
+++ b/app/helpers/time_select_helper.rb
@@ -15,4 +15,19 @@ module TimeSelectHelper
       }
     end
   end
+
+  def custom_months
+    years = (2018..Time.zone.today.year).to_a.freeze
+    months = Date::MONTHNAMES.compact
+
+    years.flat_map do |year|
+      months.map do |month|
+        "#{month.downcase}-#{year}"
+      end
+    end
+  end
+
+  def custom_month_selected(time_period)
+    custom_months.include?(time_period)
+  end
 end

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -1,9 +1,9 @@
 class DateRange
-  attr_reader :time_period, :to, :from
+  attr_reader :to, :from
+  attr_accessor :time_period
 
   def initialize(time_period, relative_date = nil)
     relative_date = relative_date || Time.zone.yesterday
-
     @time_period = time_period
     @to = date_to_range(relative_date, time_period)[:to]
     @from = date_to_range(relative_date, time_period)[:from]
@@ -12,12 +12,21 @@ class DateRange
   def previous
     relative_date = @from
     relative_date -= 1.day unless @time_period == "last-month"
-    DateRange.new(time_period, relative_date)
+    if specific_month_requested
+      DateRange.new(previous_specific_month)
+    else
+      DateRange.new(time_period, relative_date)
+    end
   end
 
 private
 
+  YEARS = (2018..Time.zone.today.year).to_a.freeze
+  MONTHS = Date::MONTHNAMES.compact
+
   def date_to_range(relative_date, time_period)
+    return specified_month if specific_month_requested
+
     case time_period
     when "last-month"
       {
@@ -45,10 +54,35 @@ private
         to: relative_date,
       }
     else
+      @time_period = "past-30-days"
       {
         from: relative_date - 29.days,
         to: relative_date,
       }
     end
+  end
+
+  def specific_month_requested
+    @specific_month_requested ||= months_and_years.include?(@time_period)
+  end
+
+  def previous_specific_month
+    months_and_years[months_and_years.index(time_period) - 1]
+  end
+
+  def months_and_years
+    @months_and_years ||= YEARS.flat_map do |year|
+      MONTHS.map do |month|
+        "#{month.downcase}-#{year}"
+      end
+    end
+  end
+
+  def specified_month
+    month = Date.parse(time_period)
+    {
+      from: month.beginning_of_month,
+      to: month.end_of_month,
+    }
   end
 end

--- a/app/views/components/_time-select.html.erb
+++ b/app/views/components/_time-select.html.erb
@@ -4,22 +4,32 @@
   render_button ||= false
   submit_button_text = t ".submit_button"
   compact ||= false
+  custom_month_selected ||= false
 
   if dates.length > 1
     dates.each {|d| d[:bold] = "true"}
+
+    if current_selection
+      if custom_month_selected
+        translation = I18n.t("metrics.show.time_periods.custom-month.leading")
+      else
+        translation = dates.find {|d| d[:value] == current_selection }[:text]
+      end
+    end
   end
 
   selectable = dates.find {|d| d[:value] == current_selection}
   if selectable
     selectable[:checked] = true
   end
+
 %>
 <% if dates.length > 1 && current_selection %>
   <div class="app-c-time-select <% if compact %> app-c-time-select--compact<% end %>" data-gtm-id="time-period-options">
     <%if compact %>
-      <h2 class="govuk-heading-s app-c-time-select__heading"><%= t '.title_compact', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
+      <h2 class="govuk-heading-s app-c-time-select__heading"><%= t '.title_compact', time_period: translation  %></h2>
     <% else %>
-      <h2 class="govuk-heading-l app-c-time-select__heading"><%= t '.title', time_period: dates.find {|d| d[:value] == current_selection }[:text] %></h2>
+      <h2 class="govuk-heading-l app-c-time-select__heading"><%= t '.title', time_period: translation %></h2>
     <% end %>
     <%= render "govuk_publishing_components/components/details", {
       title: t('.change_dropdown')

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -27,6 +27,7 @@
             current_selection: @presenter.time_period,
             compact: true,
             base_path: "/",
+            custom_month_selected: custom_month_selected(@presenter.time_period),
             dates: time_select_options(TimeSelectHelper::CONTENT_PAGE_TIME_PERIODS)
           } %>
 

--- a/app/views/documents/children.html.erb
+++ b/app/views/documents/children.html.erb
@@ -28,6 +28,7 @@
         compact: true,
         render_button: true,
         current_selection: @time_period,
+        custom_month_selected: custom_month_selected(@time_period),
         dates: time_select_options(TimeSelectHelper::CONTENT_PAGE_TIME_PERIODS)
       } %>
       <% end %>

--- a/app/views/metrics/_metric_header.html.erb
+++ b/app/views/metrics/_metric_header.html.erb
@@ -1,6 +1,7 @@
 <%
   show_trend ||= false
   short_context ||= false
+  custom_month_selected ||= false
   if defined?(context_value)
     context = t("metrics.#{metric_name}.summary", context_value)
   else
@@ -18,10 +19,17 @@
   }
 
   if show_trend
-    options.update({
-      trend_percentage: @performance_data.trend_percentage(metric_name),
-      period: t("metrics.show.time_periods.#{time_period}.reference")
-    })
+    if custom_month_selected
+      options.update({
+        trend_percentage: @performance_data.trend_percentage(metric_name),
+        period: t("metrics.show.time_periods.custom-month.reference")
+      })
+    else
+      options.update({
+        trend_percentage: @performance_data.trend_percentage(metric_name),
+        period: t("metrics.show.time_periods.#{time_period}.reference")
+      })
+    end
   end
 
   if short_context

--- a/app/views/metrics/_metric_section.html.erb
+++ b/app/views/metrics/_metric_section.html.erb
@@ -3,7 +3,8 @@
     metric_name: metric_name,
     value: total,
     show_trend: false,
-    short_context: short_context
+    short_context: short_context,
+    custom_month_selected: custom_month_selected
   }%>
 </div>
 

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -52,6 +52,7 @@
   <%= render "components/time-select", {
     render_button: true,
     current_selection: current_selection,
+    custom_month_selected: custom_month_selected(current_selection),
     dates: time_select_options(TimeSelectHelper::METRIC_PAGE_TIME_PERIODS)
   } %>
 <% end %>
@@ -86,7 +87,8 @@
         metric_name: 'upviews',
         total: @performance_data.total_upviews,
         short_context: nil,
-        external_link: nil %>
+        external_link: nil,
+        custom_month_selected: custom_month_selected(current_selection) %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
@@ -94,7 +96,8 @@
         metric_name: 'pviews',
         total: @performance_data.total_pviews,
         short_context: nil,
-        external_link: nil %>
+        external_link: nil,
+        custom_month_selected: custom_month_selected(current_selection) %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
@@ -102,6 +105,7 @@
       <%= render 'metric_header', {
         metric_name: 'pageviews_per_visit',
         value: @performance_data.pageviews_per_visit,
+        custom_month_selected: custom_month_selected(current_selection),
         show_trend: false,
         short_context: nil
       }%>
@@ -113,7 +117,8 @@
         metric_name: 'searches',
         total: @performance_data.total_searches,
         short_context: nil,
-        external_link: @performance_data.search_terms_href %>
+        external_link: @performance_data.search_terms_href,
+        custom_month_selected: custom_month_selected(current_selection) %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
@@ -123,7 +128,8 @@
         metric_name: 'feedex',
         total: @performance_data.total_feedex,
         short_context: nil ,
-        external_link: @performance_data.feedback_explorer_href %>
+        external_link: @performance_data.feedback_explorer_href,
+        custom_month_selected: custom_month_selected(current_selection) %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
@@ -132,7 +138,8 @@
           metric_name: 'satisfaction',
           value: @performance_data.total_satisfaction,
           show_trend: true,
-          short_context: @performance_data.satisfaction_short_context
+          short_context: @performance_data.satisfaction_short_context,
+          custom_month_selected: custom_month_selected(current_selection)
       }%>
     </div>
   </div>

--- a/config/locales/views/metrics/en.yml
+++ b/config/locales/views/metrics/en.yml
@@ -36,3 +36,6 @@ en:
         past-2-years:
           leading: 'past 2 years'
           reference: 'from previous 2 years'
+        custom-month:
+          leading: 'custom month selection'
+          reference: 'from specified month'

--- a/spec/components/time_select_spec.rb
+++ b/spec/components/time_select_spec.rb
@@ -65,6 +65,12 @@ RSpec.describe "Time Select", type: :view do
     assert_select ".gem-c-button.govuk-button"
   end
 
+  it "renders custom month text if custom month specified" do
+    data[:custom_month_selected] = true
+    render_component(data)
+    assert_select ".app-c-time-select__heading", text: "Showing data from custom month selection"
+  end
+
   def render_component(locals)
     render partial: "components/time-select", locals: locals
   end

--- a/spec/helpers/time_select_helper_spec.rb
+++ b/spec/helpers/time_select_helper_spec.rb
@@ -45,5 +45,15 @@ RSpec.describe TimeSelectHelper do
         ])
       end
     end
+
+    describe "#custom_month_selected" do
+      it "returns true for a valid custom month" do
+        expect(custom_month_selected("november-2018")).to eq(true)
+      end
+
+      it "returns false for a non custom month" do
+        expect(custom_month_selected("past-2-years")).to eq(false)
+      end
+    end
   end
 end

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -184,4 +184,33 @@ RSpec.describe DateRange do
       it { is_expected.to have_attributes(time_period: "past-2-years") }
     end
   end
+
+  describe "for a specific month and year" do
+    let(:time_period) { "november-2019" }
+
+    describe "relative to the specified month and year" do
+      subject { DateRange.new(time_period) }
+
+      it { is_expected.to have_attributes(to: Date.new(2019, 11, 30)) }
+      it { is_expected.to have_attributes(from: Date.new(2019, 11, 1)) }
+      it { is_expected.to have_attributes(time_period: "november-2019") }
+    end
+
+    describe "#previous" do
+      subject { DateRange.new(time_period).previous }
+
+      it { is_expected.to be_an_instance_of(DateRange) }
+      it { is_expected.to have_attributes(to: Date.new(2019, 10, 31)) }
+      it { is_expected.to have_attributes(from: Date.new(2019, 10, 1)) }
+      it { is_expected.to have_attributes(time_period: "october-2019") }
+    end
+
+    describe "when an invalid month is specified" do
+      subject { DateRange.new("september-1885") }
+
+      it { is_expected.to have_attributes(to: Date.new(2018, 12, 24)) }
+      it { is_expected.to have_attributes(from: Date.new(2018, 11, 25)) }
+      it { is_expected.to have_attributes(time_period: "past-30-days") }
+    end
+  end
 end


### PR DESCRIPTION
This PR allows a user to manually update the `date_range` param to a format such as `march-2020` to see data for this specific time frame.

[dependent content-data-api PR](https://github.com/alphagov/content-data-api/pull/1442)
[trello](https://trello.com/c/OKYeyYHe/1799-5-allow-content-data-api-and-content-data-admin-to-return-data-by-month)