### PR TITLE
Extend 'default' task with RuboCop linting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,17 +6,3 @@ inherit_gem:
 inherit_mode:
   merge:
     - Exclude
-
-AllCops:
-  TargetRubyVersion: 2.6
-Metrics/BlockLength:
-  Exclude:
-    - "Rakefile"
-    - "**/*.rake"
-    - "spec/**/*.rb"
-    - "config/routes.rb"
-    - "config/environments/*.rb"
-
-Rails/HelperInstanceVariable:
-  Exclude:
-    - "app/helpers/pagination_helper.rb"

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
-# Add your own tasks in files placed in lib/tasks ending in .rake,
-# for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
-
 require_relative "config/application"
-
 Rails.application.load_tasks
-task default: %i[spec]
+
+Rake::Task[:default].clear
+task default: %i[spec lint]

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -2,24 +2,24 @@ module PaginationHelper
   include Kaminari::Helpers::HelperMethods
   attr_accessor :content
 
-  def navigation_links
+  def navigation_links(presenter)
     result = {}
-    if @presenter.prev_link?
+    if presenter.prev_link?
       result = result.merge(
         previous_page: {
-          url: path_to_prev_page(@presenter.content_items),
+          url: path_to_prev_page(presenter.content_items),
           title: "Previous",
-          label: @presenter.prev_label,
+          label: presenter.prev_label,
         },
       )
     end
 
-    if @presenter.next_link?
+    if presenter.next_link?
       result = result.merge(
         next_page: {
-          url: path_to_next_page(@presenter.content_items),
+          url: path_to_next_page(presenter.content_items),
           title: "Next",
-          label: @presenter.next_label,
+          label: presenter.next_label,
         },
       )
     end

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -161,7 +161,7 @@
         <% end %>
 
         <div data-gtm-id="pagination-links">
-          <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links %>
+          <%= render "govuk_publishing_components/components/previous_and_next_navigation", navigation_links(@presenter) %>
         </div>
     </div>
 </div>

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Lint Ruby"
+task lint: :environment do
+  sh "bundle exec rubocop"
+end

--- a/spec/helpers/pagination_helper_spec.rb
+++ b/spec/helpers/pagination_helper_spec.rb
@@ -13,15 +13,14 @@ RSpec.describe PaginationHelper do
     controller.params[:action] = "index"
     controller.params[:controller] = "content"
     controller.params[:organisation_id] = "org-1"
-    @presenter = presenter
   end
 
   context "when on the first page" do
     let(:presenter) { ContentItemsPresenter.new(search_results, search_parameters) }
     it "only returns the `Next` link" do
-      expect(navigation_links).to eq(next_page: { url: "/content?organisation_id=org-1&page=2",
-                                                  title: "Next",
-                                                  label: "2 of 3" })
+      expect(navigation_links(presenter)).to eq(next_page: { url: "/content?organisation_id=org-1&page=2",
+                                                             title: "Next",
+                                                             label: "2 of 3" })
     end
   end
 
@@ -29,9 +28,9 @@ RSpec.describe PaginationHelper do
     let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 3), search_parameters) }
 
     it "only returns the `Previous` link" do
-      expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1&page=2",
-                                                      title: "Previous",
-                                                      label: "2 of 3" })
+      expect(navigation_links(presenter)).to eq(previous_page: { url: "/content?organisation_id=org-1&page=2",
+                                                                 title: "Previous",
+                                                                 label: "2 of 3" })
     end
   end
 
@@ -39,12 +38,12 @@ RSpec.describe PaginationHelper do
     let(:presenter) { ContentItemsPresenter.new(search_results.merge(page: 2), search_parameters) }
 
     it "returns `Previous` and `Next` links" do
-      expect(navigation_links).to eq(previous_page: { url: "/content?organisation_id=org-1",
-                                                      title: "Previous",
-                                                      label: "1 of 3" },
-                                     next_page: { url: "/content?organisation_id=org-1&page=3",
-                                                  title: "Next",
-                                                  label: "3 of 3" })
+      expect(navigation_links(presenter)).to eq(previous_page: { url: "/content?organisation_id=org-1",
+                                                                 title: "Previous",
+                                                                 label: "1 of 3" },
+                                                next_page: { url: "/content?organisation_id=org-1&page=3",
+                                                             title: "Next",
+                                                             label: "3 of 3" })
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/5Gob6WUL/147-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This adds a new 'lint' rake task that runs as part of a default call to
'rake'. Having linting run locally by default makes it easier to catch
build issues, and is a prerequisite for moving to GitHub Actions, since we
want to avoid listing lots of separate build steps.