### PR TITLE
Only clear the default Rake task settings in development and test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 require_relative "config/application"
 Rails.application.load_tasks
 
-Rake::Task[:default].clear
+Rake::Task[:default].clear unless Rails.env.production?
 task default: %i[spec lint]


### PR DESCRIPTION
- Otherwise we see errors like this on deploys to production environments:

```
13:53:53 *** [err :: ip-10-12-6-44.eu-west-1.compute.internal] rake aborted!
13:53:53 *** [err :: ip-10-12-6-44.eu-west-1.compute.internal] Don't know how to build task 'default' (See the list of available tasks with `rake --tasks`)
13:53:53 *** [err :: ip-10-12-6-44.eu-west-1.compute.internal] /data/vhost/content-data/releases/20200519125347/Rakefile:4:in `<top (required)>'
```
