### PR TITLE
Pin govuk_publishing_components to 17.21.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "fog-aws"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
-gem "govuk_publishing_components"
+gem "govuk_publishing_components", "~> 17" # Content Data uses the accessible autocomplete component which was removed in version 18
 gem "govuk_sidekiq"
 gem "kaminari"
 gem "mail-notify"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -444,7 +444,7 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govuk_app_config
-  govuk_publishing_components
+  govuk_publishing_components (~> 17)
   govuk_sidekiq
   govuk_test
   kaminari


### PR DESCRIPTION
Content Data uses the accessible autocomplete component which was removed in version 18.
Arose from https://github.com/alphagov/govuk-developer-docs/pull/2830