### PR TITLE
Fix rendering of 404 page

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -17,6 +17,6 @@ class MetricsController < ApplicationController
   end
 
   rescue_from GdsApi::HTTPNotFound do
-    render file: Rails.root.join("app/views/errors/404.html.erb"), status: :not_found
+    render "errors/404", status: :not_found
   end
 end


### PR DESCRIPTION
The 404 page was previously converted from a static HTML file to a ERB template. However, the render statement wasn't updated to render the erb template so was returning the file un-rendered as plain/text.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
