### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,9 @@ Rails.application.routes.draw do
             [200, {}, ["Sentry notified"]]
           }
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+
   if Rails.env.development? || Rails.application.config.govuk_environment == "integration"
     get "/dev" => "development#index"
   end


### PR DESCRIPTION
Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
