### PR TITLE
Remove legacy /healthcheck route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,13 +1,6 @@
 Rails.application.routes.draw do
   root to: redirect("/content")
 
-  get "/healthcheck", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck-f",
-      to: proc {
-            GovukError.notify("Sentry works")
-            [200, {}, ["Sentry notified"]]
-          }
-
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
   get "/healthcheck/ready", to: GovukHealthcheck.rack_response
 


### PR DESCRIPTION
govuk-puppet and govuk-aws have now been updated to only use the new
routes, so the old one is no longer needed.

See RFC 141 for more information.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)
