### PR TITLE
Use Postgres 13 in CI 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,10 @@
 
 library("govuk")
 
-node("postgresql-9.6") {
+node {
+
+  // Run against the Postgres 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/content-data-admin-test")
+
   govuk.buildProject()
 }


### PR DESCRIPTION
Points the app to run against Postgres version 13, instead of the
old version 9.6. Postgres 13 runs on the port 54313.

Trello:

* https://trello.com/c/QQf4LjT6/14-content-data-admin

* https://trello.com/c/yaBLaC1O/957-upgrade-content-data-admin-postgres-96-13


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
