### PR TITLE
Fix development dependancy error

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -64,10 +64,6 @@ Rails.application.configure do
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Use an evented file watcher to asynchronously detect changes in source code,
-  # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
-
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 


### PR DESCRIPTION
This development config (file_watcher) was previously enabled in a Rails bump upgrade
[1], however as we don't bundle the listen Gem [2], this config just throws a requirement error.

[1]: https://github.com/alphagov/content-data-admin/commit/ea910176d1b22a0267344ed534185f62a8372e3b#diff-d3c4b3f41072daa416f1920511e9b2e26caea8c5cec0a14cb9508589a4dafa47R69
[2]: https://github.com/guard/listen

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
