### PR TITLE
WIP: Re-enable Dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
     allow:
       # Security updates
       - dependency-name: brakeman
-        dependency-type: all
+        dependency-type: direct
       # Internal gems
       - dependency-name: "govuk*"
         dependency-type: direct

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+    open-pull-requests-limit: 0 # security updates only
+
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: daily
     allow:
       # Security updates
       - dependency-name: brakeman

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Security related PRs will ignore the following config.
+    # See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch
+    target-branch: latest-dependencies # Raise PRs for version updates against this branch
+    labels:
+      - "dependencies not-security" # Labels on PRs for version updates only
     allow:
       # Security updates
       - dependency-name: brakeman
@@ -37,6 +42,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    # Security related PRs will ignore the following config.
+    # See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch
+    target-branch: latest-dependencies # Raise PRs for version updates against this branch
+    labels:
+      - "dependencies not-security" # Labels on PRs for version updates only
     allow:
       # Internal packages
       - dependency-name: stylelint-config-gds

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,10 @@ updates:
     directory: /
     schedule:
       interval: daily
-    open-pull-requests-limit: 0 # security updates only
-
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
     allow:
       # Security updates
       - dependency-name: brakeman
-        dependency-type: direct
+        dependency-type: all
       # Internal gems
       - dependency-name: "govuk*"
         dependency-type: direct

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,17 +26,6 @@ updates:
         dependency-type: direct
       - dependency-name: plek
         dependency-type: direct
-      # Framework gems
-      - dependency-name: factory_bot_rails
-        dependency-type: direct
-      - dependency-name: pg
-        dependency-type: direct
-      - dependency-name: rails
-        dependency-type: direct
-      - dependency-name: rspec-rails
-        dependency-type: direct
-      - dependency-name: sassc-rails
-        dependency-type: direct
 
   - package-ecosystem: npm
     directory: /

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "7.0.3.1"
+gem "rails", "7.0.3"
 
 gem "bootsnap"
 gem "chartkick"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -484,7 +484,7 @@ DEPENDENCIES
   pg
   plek
   pry
-  rails (= 7.0.3.1)
+  rails (= 7.0.3)
   rspec-rails
   rubocop-govuk
   sassc-rails


### PR DESCRIPTION
GitHub automatically opts all qualifying repos in for security
updates, but this gets overwritten by the presence of a
`dependabot.yml` file, which we have in most repos. We’ll
therefore need to edit the Dependabot config to fix security
related PRs not being raised.

It’s not immediately clear from the docs exactly what’s needed
to opt in, but we believe our use of an allow-list may be the
issue.

We get some value from configuring Dependabot to raise fewer PRs
(i.e. only update the dependencies we care about), but we need
security updates for _all_ dependencies, so this PR is an
attempt to arrive at a configuration that allows security PRs but that
doesn't break our existing behaviour.

See https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file

Trello: https://trello.com/c/nqliwwxV/2952-investigate-how-to-fix-dependabot-not-raising-security-prs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
