### PR TITLE
Add survey banner

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,4 @@
 //= require govuk_publishing_components/all_components
 //= require_tree ./components
 //= require_tree ./core
+//= require_tree ./survey-banner

--- a/app/assets/javascripts/survey-banner/survey-banner.js
+++ b/app/assets/javascripts/survey-banner/survey-banner.js
@@ -1,0 +1,35 @@
+(function () {
+  var standardBanner = document.querySelector('.banner')
+  var surveyBanner = document.querySelector('.survey-banner')
+  var surveyBannerHidden = document.cookie
+    .split(';')
+    .some((item) => item.trim().startsWith('hideContentDataSurveyBanner='))
+
+  function hide (el) {
+    el.hidden = true
+    el.style.display = 'none'
+  }
+
+  function show (el) {
+    el.hidden = false
+    el.style.display = 'block'
+  }
+
+  if (surveyBannerHidden) {
+    hide(surveyBanner)
+  } else {
+    hide(standardBanner)
+    show(surveyBanner)
+  }
+
+  document.querySelectorAll('[data-hide-survey-banner]').forEach((btn) => {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault()
+      hide(surveyBanner)
+      show(standardBanner)
+      var expires = new Date()
+      expires.setFullYear(expires.getFullYear() + 1)
+      document.cookie = `hideContentDataSurveyBanner=; expires=${expires.toUTCString()}; SameSite=strict`
+    })
+  })
+})()

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,6 +44,109 @@ $govuk-global-styles: true;
   border-bottom: 1px solid $govuk-border-colour;
 }
 
+.survey-banner {
+  border-bottom: none;
+  background-color: $govuk-brand-colour;
+  padding-bottom: govuk-spacing(6);
+  padding-top: govuk-spacing(6);
+  padding-left: 40px;
+  padding-right: 40px;
+  @include govuk-typography-common;
+
+  @include govuk-media-query($from: desktop) {
+    padding-bottom: govuk-spacing(8);
+    padding-top: govuk-spacing(8);
+  }
+}
+
+.survey-banner__title {
+  @include govuk-typography-weight-bold;
+  color: govuk-colour("white");
+  font-size: 32px;
+  font-size: govuk-px-to-rem(32);
+  line-height: 1.2;
+  margin: 0;
+  padding-bottom: govuk-spacing(2);
+  padding-top: govuk-spacing(6);
+  border-top: 1px solid govuk-colour("light-blue");
+
+  @include govuk-media-query($from: desktop) {
+    font-size: 48px;
+    font-size: govuk-px-to-rem(48);
+  }
+}
+
+.survey-banner__intro {
+  color: govuk-colour("white");
+  font-size: 16px;
+  font-size: govuk-px-to-rem(16);
+  margin: 0;
+  padding: 0;
+  padding-bottom: govuk-spacing(5);
+
+  @include govuk-media-query($from: desktop) {
+    font-size: 19px;
+    font-size: govuk-px-to-rem(19);
+    width: 66.666%;
+  }
+}
+
+.survey-banner__buttons {
+  @include govuk-responsive-margin(6, "bottom", $adjustment: govuk-spacing(3) * -1);
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .govuk-link {
+    @include govuk-font($size: 19, $line-height: 19px);
+    display: inline-block;
+    max-width: 100%;
+    margin-top: govuk-spacing(1);
+    margin-bottom: govuk-spacing(4);
+    text-align: center;
+
+    color: govuk-colour("white");
+  }
+
+  .govuk-button {
+    margin-bottom: govuk-spacing(3) + $govuk-border-width-form-element;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    margin-right: (govuk-spacing(3) * -1);
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: baseline;
+
+    .govuk-button,
+    .govuk-link {
+      margin-right: govuk-spacing(3);
+    }
+
+    .govuk-link {
+      text-align: left;
+    }
+  }
+}
+
+.button--start_white:link,
+.button--start_white:visited {
+  background-color: govuk-colour("white");
+  color: $govuk-brand-colour;
+  box-shadow: 0 2px 0 #004172;
+}
+
+.button--start_white:hover {
+  color: govuk-colour("light-blue");
+}
+
+.survey-banner__button {
+  font-weight: 700;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 .gem-c-phase-banner {
   border: none;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,6 +53,20 @@
     <%= content_for :local_nav %>
   </div>
 
+  <div class="survey-banner" hidden="">
+    <h1 class="survey-banner__title">Help us improve Content Data App</h1>
+    <p class="survey-banner__intro">Hello, we want to understand how you use Content Data
+    app to make sure it works well for you and we'd love your feedback. You can
+    tell us about your experience of using the app by completing this short
+    questionnaire. It will take about 5 minutes and most questions are multiple
+    choice.
+    </p>
+    <div class="survey-banner__buttons govuk-button-group">
+      <a href="https://surveys.publishing.service.gov.uk/s/AYBBC5/" role="button" draggable="false" class="govuk-button button--start_white survey-banner__button" data-module="govuk-button">View Questionnaire</button>
+      <a href="" class="govuk-link govuk-!-font-size-16" data-hide-survey-banner="">Hide this</a>
+    </div>
+  </div>
+
   <% if flash[:notice] %>
     <p>
       <%= flash[:notice] %>


### PR DESCRIPTION
Add a call-to-action banner to complete a survey on users' experience of the Content Data tool.

The banner can be dismissed and this is recorded in a cookie.

![Content Data app banner](https://user-images.githubusercontent.com/35194/183091252-48d31acf-2f20-4fd3-b886-9deb461e44aa.png)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
