### PR TITLE
Only show the survey banner on the index page

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,6 +53,7 @@
     <%= content_for :local_nav %>
   </div>
 
+  <% if css_classes.include? "content-data__index" %>
   <div class="survey-banner" hidden="">
     <h2 class="survey-banner__title">Help us improve Content Data App</h2>
     <p class="survey-banner__intro">Hello, we want to understand how you use Content Data
@@ -66,6 +67,7 @@
       <a href="" class="govuk-link govuk-!-font-size-16" data-hide-survey-banner>Hide this</a>
     </div>
   </div>
+<% end %>
 
   <% if flash[:notice] %>
     <p>


### PR DESCRIPTION
The survey banner is currently shown at the top of every view of the Content Data Admin app - including the CSV Download page, the search results page and even the Help page. This is a bit intrusive, so this change makes the survey banner only display on the index page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
