### PR TITLE
Fix Javascript error when survey banner turned off

### DIFF
--- a/app/assets/javascripts/survey-banner/survey-banner.js
+++ b/app/assets/javascripts/survey-banner/survey-banner.js
@@ -15,11 +15,13 @@
     el.style.display = 'block'
   }
 
-  if (surveyBannerHidden) {
-    hide(surveyBanner)
-  } else {
-    hide(standardBanner)
-    show(surveyBanner)
+  if (surveyBanner) {
+    if (surveyBannerHidden) {
+      hide(surveyBanner)
+    } else {
+      hide(standardBanner)
+      show(surveyBanner)
+    }
   }
 
   function setHideBannerCookie () {


### PR DESCRIPTION
The script that handles showing and hiding the survey banner breaks on pages other than the index page, because it assumes the element is present.

This fix simply checks that the element is present before attempting to show or hide it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
