### PR TITLE
Replace `Plek.current` with `Plek.new`

### DIFF
--- a/lib/gds_api/content_data_api.rb
+++ b/lib/gds_api/content_data_api.rb
@@ -3,7 +3,7 @@ require "gds_api/base"
 class GdsApi::ContentDataApi < GdsApi::Base
   def initialize
     super(
-"#{Plek.current.find('content-data-api')}/api/v1",
+"#{Plek.new.find('content-data-api')}/api/v1",
       disable_cache: true,
       timeout: 60,
       bearer_token: ENV["CONTENT_DATA_API_BEARER_TOKEN"] || "example")
@@ -45,7 +45,7 @@ class GdsApi::ContentDataApi < GdsApi::Base
 private
 
   def content_data_api_endpoint
-    Plek.current.find("content-data-api").to_s
+    Plek.new.find("content-data-api").to_s
   end
 
   def aggregated_metrics_url(base_path, from, to)

--- a/spec/support/content_data_api.rb
+++ b/spec/support/content_data_api.rb
@@ -6,7 +6,7 @@ module GdsApi
     module ContentDataApi
       include ResponseHelpers
 
-      CONTENT_DATA_API_ENDPOINT = Plek.current.find("content-data-api")
+      CONTENT_DATA_API_ENDPOINT = Plek.new.find("content-data-api")
 
       def content_data_api_has_orgs
         url = "#{CONTENT_DATA_API_ENDPOINT}/api/v1/organisations"


### PR DESCRIPTION
Usage of `Plek.current` was marked as deprecated in https://github.com/alphagov/plek/pull/94, therefore we should remove uses of the old syntax before upgrading Plek, else we'll log lots of deprecation warnings.

See also https://github.com/alphagov/publishing-api/pull/2158

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
