### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "govuk_app_config"
 gem "govuk_publishing_components", "~> 17" # Content Data uses the accessible autocomplete component which was removed in version 18
 gem "govuk_sidekiq"
 gem "kaminari"
+gem "mail", "~> 2.7.1"  # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "mail-notify"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -470,6 +470,7 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   kaminari
+  mail (~> 2.7.1)
   mail-notify
   pg
   plek


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
