### PR TITLE
Clean up Dockerfile.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,11 @@
 .github
 Dockerfile
 Jenkinsfile
+Procfile
 README.md
+coverage
 docs
+log
+node_modules
+spec
 tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,26 @@
-ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
-ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
- 
+ARG ruby_version=2.7.6
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
+
+
 FROM $builder_image AS builder
 
-WORKDIR /app
-
-COPY Gemfile* .ruby-version /app/
-
+WORKDIR $APP_HOME
+COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY . .
+RUN bootsnap precompile --gemfile .
+RUN rails assets:precompile && rm -fr log
 
-COPY . /app
-
-RUN bundle exec rails assets:precompile && \
-    rm -fr /app/log
 
 FROM $base_image
 
 ENV GOVUK_APP_NAME=content-data-admin
 
-WORKDIR /app
-
-COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
-COPY --from=builder /app /app/
+WORKDIR $APP_HOME
+COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
+COPY --from=builder $BOOTSNAP_CACHE_DIR $BOOTSNAP_CACHE_DIR
+COPY --from=builder $APP_HOME .
 
 USER app
-
-CMD bundle exec puma
+CMD ["puma"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,9 @@ module ContentDataAdmin
     # to use CSS that has same function names as SCSS such as max.
     # https://github.com/alphagov/govuk-frontend/issues/1350
     config.assets.css_compressor = nil
+
+    # Set asset path to be application specific so that we can put all GOV.UK
+    # assets into an S3 bucket and distinguish app by path.
+    config.assets.prefix = "/assets/content-data-admin"
   end
 end


### PR DESCRIPTION
- Parameterise the Ruby version.
- Precompute the [bootsnap](https://github.com/Shopify/bootsnap#bootsnap-) bytecode and path caches so that bootsnap is effective when running the app from the container image.
- Remove some hard-coded paths.
- Clean up `.dockerignore`.
- Make better use of `WORKDIR`.
- Remove the now-redundant `bundle exec` from the default command.

Tested: builds and comes up healthy on the integration Kubernetes cluster.