### PR TITLE
Set `require: false` for bootsnap.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "rails", "7.0.4"
 
-gem "bootsnap"
+gem "bootsnap", require: false
 gem "chartkick"
 gem "fog-aws"
 gem "gds-api-adapters"


### PR DESCRIPTION
This way the bootsnap caches are much more likely to be effective.

See https://github.com/Shopify/bootsnap#usage.