### PR TITLE
Remove 'mail' as a direct dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ gem "govuk_app_config"
 gem "govuk_publishing_components", "~> 17" # Content Data uses the accessible autocomplete component which was removed in version 18
 gem "govuk_sidekiq"
 gem "kaminari"
-gem "mail"
 gem "mail-notify"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,6 @@ DEPENDENCIES
   govuk_sidekiq
   govuk_test
   kaminari
-  mail
   mail-notify
   pg
   plek


### PR DESCRIPTION
This is an indirect dependency, and was only included because we needed to pin the version for a while. The unpinning has happened, so we can now delete it as an explicit dependency.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
