### PR TITLE
Fix configuration of GOV.UK environment name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,15 +35,7 @@ module ContentDataAdmin
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    # The "acceptance environment" we're in - not the same as Rails env.
-    # Can be production, staging, integration, or development
-    govuk_environments = {
-      "production" => "production",
-      "staging" => "staging",
-      "integration-blue-aws" => "integration",
-    }
-
-    config.govuk_environment = govuk_environments.fetch(ENV["ERRBIT_ENVIRONMENT_NAME"], "development")
+    config.govuk_environment = ENV["GOVUK_ENVIRONMENT_NAME"] || "development"
 
     # Load all the locale files and raise execptions if locale missing.
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]


### PR DESCRIPTION
Use GOVUK_ENVIRONMENT_NAME for the environment name instead of ERRBIT, as we don't have that env var available in EKS. They should be the same anyway.
