### PR TITLE
Ignore Ruby 2.7.6 EOL Brakeman warning

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,22 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 123,
+      "fingerprint": "425dcb3af9624f11f12d777d6f9fe05995719975a155c30012baa6b9dc3487df",
+      "check_name": "EOLRuby",
+      "message": "Support for Ruby 2.7.6 ends on 2023-03-31",
+      "file": "Gemfile.lock",
+      "line": 291,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "note": "work is ongoing to upgrade the Ruby version"
+    }
+  ],
+  "updated": "2023-02-03 11:01:25 +0000",
+  "brakeman_version": "5.2.1"
+}


### PR DESCRIPTION
It's not yet at EOL and work is currently on-going to upgrade the Ruby version.
