### PR TITLE
Upgrade govuk_publishing_components and Plek to current versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ FROM $builder_image AS builder
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
+COPY package.json yarn.lock ./
+RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log

--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,12 @@ gem "fog-aws"
 gem "gds-api-adapters"
 gem "gds-sso"
 gem "govuk_app_config"
-gem "govuk_publishing_components", "~> 17" # Content Data uses the accessible autocomplete component which was removed in version 18
+gem "govuk_publishing_components"
 gem "govuk_sidekiq"
 gem "kaminari"
 gem "mail-notify"
 gem "pg"
-gem "plek", "~>4" # govuk_publishing_components 17 uses Plek.current, which was removed in Plek 5.
+gem "plek"
 gem "sassc-rails"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
-    excon (0.97.2)
+    excon (0.99.0)
     execjs (2.8.1)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -157,18 +157,17 @@ GEM
       sentry-ruby (~> 5.3)
       statsd-ruby (~> 1.5)
       unicorn (~> 6.1)
-    govuk_frontend_toolkit (9.0.1)
-      railties (>= 3.1.0)
-    govuk_publishing_components (17.21.0)
-      gds-api-adapters
+    govuk_personalisation (0.13.0)
+      plek (>= 1.9.0)
+      rails (>= 6, < 8)
+    govuk_publishing_components (34.7.1)
       govuk_app_config
-      govuk_frontend_toolkit
+      govuk_personalisation (>= 0.7.0)
       kramdown
       plek
-      rails (>= 5.0.0.1)
-      rake
+      rails (>= 6)
       rouge
-      sassc-rails (>= 2.0.1)
+      sprockets (>= 3)
     govuk_sidekiq (6.0.0)
       gds-api-adapters (>= 19.1.0)
       govuk_app_config (>= 1.1)
@@ -259,7 +258,7 @@ GEM
       rack (>= 1.2, < 4)
       snaky_hash (~> 2.0)
       version_gem (~> 1.1)
-    omniauth (2.1.0)
+    omniauth (2.1.1)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -270,7 +269,7 @@ GEM
     parser (3.2.0.0)
       ast (~> 2.4.1)
     pg (1.4.5)
-    plek (4.1.0)
+    plek (5.0.0)
     prometheus_exporter (2.0.8)
       webrick
     pry (0.14.2)
@@ -319,7 +318,7 @@ GEM
     redis (4.8.0)
     redis-namespace (1.10.0)
       redis (>= 4)
-    regexp_parser (2.6.1)
+    regexp_parser (2.6.2)
     request_store (1.5.1)
       rack (>= 1.4)
     rest-client (2.1.0)
@@ -346,32 +345,35 @@ GEM
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
     rspec-support (3.12.0)
-    rubocop (1.39.0)
+    rubocop (1.44.1)
       json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 3.1.2.1)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.23.0, < 2.0)
+      rubocop-ast (>= 1.24.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.23.0)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
-    rubocop-govuk (4.9.0)
-      rubocop (= 1.39.0)
-      rubocop-ast (= 1.23.0)
-      rubocop-rails (= 2.17.3)
+    rubocop-capybara (2.17.0)
+      rubocop (~> 1.41)
+    rubocop-govuk (4.10.0)
+      rubocop (= 1.44.1)
+      rubocop-ast (= 1.24.1)
+      rubocop-rails (= 2.17.4)
       rubocop-rake (= 0.6.0)
-      rubocop-rspec (= 2.15.0)
-    rubocop-rails (2.17.3)
+      rubocop-rspec (= 2.18.1)
+    rubocop-rails (2.17.4)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.15.0)
+    rubocop-rspec (2.18.1)
       rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -430,7 +432,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (2.3.0)
+    unicode-display_width (2.4.2)
     unicorn (6.1.0)
       kgio (~> 2.6)
       raindrops (~> 0.7)
@@ -467,13 +469,13 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govuk_app_config
-  govuk_publishing_components (~> 17)
+  govuk_publishing_components
   govuk_sidekiq
   govuk_test
   kaminari
   mail-notify
   pg
-  plek (~> 4)
+  plek
   pry
   rails (= 7.0.4.2)
   rspec-rails

--- a/app/assets/javascripts/components/accessible-autocomplete.js
+++ b/app/assets/javascripts/components/accessible-autocomplete.js
@@ -1,0 +1,79 @@
+/* eslint-env jquery */
+/* global accessibleAutocomplete */
+// = require accessible-autocomplete/dist/accessible-autocomplete.min.js
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  'use strict'
+
+  Modules.AccessibleAutocomplete = function () {
+    var $selectElem
+
+    this.start = function ($element) {
+      $selectElem = $element.find('select')
+
+      var configOptions = {
+        selectElement: document.getElementById($selectElem.attr('id')),
+        showAllValues: true,
+        confirmOnBlur: true,
+        preserveNullOptions: true, // https://github.com/alphagov/accessible-autocomplete#null-options
+        defaultValue: ''
+      }
+
+      configOptions.onConfirm = this.onConfirm
+
+      new accessibleAutocomplete.enhanceSelectElement(configOptions) // eslint-disable-line no-new, new-cap
+      // attach the onConfirm function to data attr, to call it in finder-frontend when clearing facet tags
+      $selectElem.data('onconfirm', this.onConfirm)
+    }
+
+    this.onConfirm = function (label, value, removeDropDown) {
+      function escapeHTML (str) {
+        return new window.Option(str).innerHTML
+      }
+
+      if ($selectElem.data('track-category') !== undefined && $selectElem.data('track-action') !== undefined) {
+        track($selectElem.data('track-category'), $selectElem.data('track-action'), label, $selectElem.data('track-options'))
+      }
+      // This is to compensate for the fact that the accessible-autocomplete library will not
+      // update the hidden select if the onConfirm function is supplied
+      // https://github.com/alphagov/accessible-autocomplete/issues/322
+      if (typeof label !== 'undefined') {
+        if (typeof value === 'undefined') {
+          value = $selectElem.children('option').filter(function () { return $(this).html() === escapeHTML(label) }).val()
+        }
+
+        if (typeof value !== 'undefined') {
+          var $option = $selectElem.find('option[value=\'' + value + '\']')
+          // if removeDropDown we are clearing the selection from outside the component
+          var selectState = typeof removeDropDown === 'undefined'
+          $option.prop('selected', selectState)
+          $selectElem.change()
+        }
+
+        // used to clear the autocomplete when clicking on a facet tag in finder-frontend
+        // very brittle but menu visibility is determined by autocomplete after this function is called
+        // setting autocomplete val to '' causes menu to appear, we don't want that, this solves it
+        // ideally will rewrite autocomplete to have better hooks in future
+        if (removeDropDown) {
+          $selectElem.closest('.gem-c-accessible-autocomplete').addClass('gem-c-accessible-autocomplete--hide-menu')
+          setTimeout(function () {
+            $('.autocomplete__menu').remove() // this element is recreated every time the user starts typing
+            $selectElem.closest('.gem-c-accessible-autocomplete').removeClass('gem-c-accessible-autocomplete--hide-menu')
+          }, 100)
+        }
+      }
+    }
+
+    function track (category, action, label, options) {
+      if (window.GOVUK.analytics && window.GOVUK.analytics.trackEvent) {
+        options = options || {}
+        options.label = label
+
+        window.GOVUK.analytics.trackEvent(category, action, options)
+      }
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,13 +6,10 @@ $sort-link-arrow-size-small: 8px;
 $sort-link-arrow-spacing: 4px;
 $sort-link-arrow-margin: -4px;
 $govuk-global-styles: true;
+$govuk-use-legacy-palette: false;
 
 // gem components
 @import "govuk_publishing_components/all_components";
-
-// TODO: remove the font-face include when govuk_publishing_components doesn't
-// rely on govuk_template and has $govuk-compatibility-govuktemplate set to false
-@include _govuk-font-face-nta;
 
 // local components
 @import "components/accessible-autocomplete";
@@ -165,7 +162,7 @@ $govuk-global-styles: true;
 .sortable-table {
   .table-caption {
     @include govuk-font(16);
-    @include media(mobile) {
+    @include govuk-media-query($from: mobile) {
       @include govuk-responsive-padding(3, "left");
     }
   }
@@ -187,7 +184,11 @@ $govuk-global-styles: true;
 
   .table__sort-link {
     @include govuk-link-style-no-visited-state;
-    @include govuk-focusable-fill;
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+
     position: relative;
     padding-right: $sort-link-arrow-size;
     color: $govuk-link-colour;
@@ -243,7 +244,7 @@ $govuk-global-styles: true;
   }
 
   .govuk-table {
-    background-color: $white;
+    background-color: govuk-colour("white");
     // re-align text content of left and right columns
     margin-top: -1px;
   }
@@ -260,7 +261,7 @@ $govuk-global-styles: true;
   }
 
   .govuk-table__cell--shaded {
-    background-color: govuk-colour("grey-4");
+    background-color: govuk-colour("light-grey");
   }
 
   .govuk-table__cell--numeric {
@@ -289,14 +290,14 @@ $govuk-global-styles: true;
     @include govuk-font(14);
     outline: 1px solid $govuk-border-colour;
 
-    background-color: govuk-colour("grey-3");
+    background-color: govuk-colour("light-grey");
     font-weight: normal;
 
     &.govuk-table__header--sorted {
       background-color: govuk-colour("blue");
 
       .table__sort-link { // stylelint-disable-line max-nesting-depth
-        color: $white;
+        color: govuk-colour("white");
       }
     }
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@ $govuk-global-styles: true;
 @include _govuk-font-face-nta;
 
 // local components
+@import "components/accessible-autocomplete";
 @import "components/chart";
 @import "components/ga_data_notice";
 @import "components/glance-metric";

--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -1,0 +1,41 @@
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+
+.gem-c-accessible-autocomplete {
+  .autocomplete__input {
+    z-index: 1;
+  }
+
+  .autocomplete__dropdown-arrow-down {
+    z-index: 0;
+  }
+
+  .autocomplete__option {
+    @include govuk-font(19);
+  }
+
+  // needed as frontend doesn't currently support select multiples
+  // hopefully will in future and this can be removed
+  .govuk-select[multiple] {
+    height: auto;
+  }
+
+  .js-enabled & .gem-c-autocomplete__multiselect-instructions {
+    display: none;
+  }
+
+  .autocomplete__list .autocomplete__option {
+    padding: 5px 6px;
+
+    &:before {
+      position: relative;
+      top: 3px;
+      padding-top: 2px;
+    }
+  }
+}
+
+.gem-c-accessible-autocomplete--hide-menu {
+  .autocomplete__menu {
+    display: none;
+  }
+}

--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -1,3 +1,4 @@
+// stylelint-disable-next-line function-url-quotes
 @import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
 
 .gem-c-accessible-autocomplete {

--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -1,5 +1,5 @@
 // stylelint-disable-next-line function-url-quotes
-@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css"));
+@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min"));
 
 .gem-c-accessible-autocomplete {
   .autocomplete__input {

--- a/app/assets/stylesheets/components/_chart.scss
+++ b/app/assets/stylesheets/components/_chart.scss
@@ -10,7 +10,7 @@
   max-height: 300px;
   margin-top: govuk-spacing(3);
 
-  @include media(mobile) {
+  @include govuk-media-query($from: mobile) {
     max-height: 250px;
   }
 
@@ -24,7 +24,7 @@
 
   .govuk-table .govuk-table__header {
     border: none;
-    background-color: $white;
+    background-color: govuk-colour("white");
     @include govuk-font($size: 14, $weight: bold);
     text-align: center;
     min-width: 4em;
@@ -32,7 +32,7 @@
 
   .govuk-table .govuk-table__body .govuk-table__cell {
     @include govuk-font(14);
-    border-top: 1px solid $black;
+    border-top: 1px solid govuk-colour("black");
   }
 
   .govuk-table .govuk-table__cell {
@@ -67,7 +67,7 @@
     height: 250px;
   }
 
-  @include media(mobile) {
+  @include govuk-media-query($from: mobile) {
     #chart-1,
     #chart-2,
     #chart-3,
@@ -83,11 +83,11 @@
 
 // stylelint-disable declaration-no-important
 .google-visualization-tooltip {
-  background-color: $black !important;
+  background-color: govuk-colour("black") !important;
   opacity: .95;
 
   span {
-    color: $white !important;
+    color: govuk-colour("white") !important;
     font-family: nta, Arial, sans-serif !important;
     font-size: 14px !important;
   }

--- a/app/assets/stylesheets/components/_glance-metric.scss
+++ b/app/assets/stylesheets/components/_glance-metric.scss
@@ -51,7 +51,7 @@
 }
 
 .app-c-glance-metric__trend-icon {
-  color: $grey-1;
+  color: govuk-colour("dark-grey");
 
   @include media-down(mobile) {
     @include govuk-font(19);

--- a/app/assets/stylesheets/components/_info-metric.scss
+++ b/app/assets/stylesheets/components/_info-metric.scss
@@ -16,7 +16,7 @@
 }
 
 .app-c-info-metric__trend-icon {
-  color: $grey-1;
+  color: govuk-colour("dark-grey");
 }
 
 .app-c-info-metric__period {

--- a/app/assets/stylesheets/components/_related-actions.scss
+++ b/app/assets/stylesheets/components/_related-actions.scss
@@ -19,6 +19,6 @@
 }
 
 .app-c-related-actions__links--local {
-  border-top: 1px solid $grey-2;
+  border-top: 1px solid govuk-colour("mid-grey");
   @include govuk-responsive-padding(3, "top");
 }

--- a/app/assets/stylesheets/content/_index.scss
+++ b/app/assets/stylesheets/content/_index.scss
@@ -5,14 +5,14 @@
 
   .gem-c-pagination {
 
-    @include media(mobile) {
+    @include govuk-media-query($from: mobile) {
       @include govuk-responsive-padding(3, "left");
     }
   }
 
   .table-wrapper {
     min-width: 900px;
-    background-color: $white;
+    background-color: govuk-colour("white");
     @include govuk-responsive-padding(6, "right");
   }
 

--- a/app/assets/stylesheets/metrics/_show.scss
+++ b/app/assets/stylesheets/metrics/_show.scss
@@ -105,7 +105,7 @@
     }
 
     .content-metrics__data {
-      border-top: 1px solid $grey-2;
+      border-top: 1px solid govuk-colour("mid-grey");
     }
 
     .content-metrics__data .govuk-summary-list__row:last-of-type {

--- a/app/views/components/_accessible_autocomplete.html.erb
+++ b/app/views/components/_accessible_autocomplete.html.erb
@@ -1,0 +1,35 @@
+<%
+  id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  label ||= nil
+  data_attributes ||= nil
+  options ||= []
+  selected_option ||= nil
+  multiple ||= false
+
+  classes = %w(gem-c-accessible-autocomplete govuk-form-group)
+%>
+<% if label && options.any? %>
+  <%= tag.div class: classes, data: { module: "accessible-autocomplete" } do %>
+    <%=
+      render "govuk_publishing_components/components/label", {
+        html_for: id
+      }.merge(label.symbolize_keys)
+    %>
+
+    <% if multiple %>
+      <span class="govuk-hint gem-c-autocomplete__multiselect-instructions">
+        <%= t('components.autocomplete.multiselect') %>
+      </span>
+    <% end %>
+
+    <%=
+      select_tag(
+        id,
+        options_for_select(options, selected_option),
+        multiple: multiple,
+        class: "govuk-select",
+        data: data_attributes
+      )
+    %>
+  <% end %>
+<% end %>

--- a/app/views/components/docs/accessible_autocomplete.yml
+++ b/app/views/components/docs/accessible_autocomplete.yml
@@ -1,0 +1,49 @@
+name: Accessible autocomplete
+description: An autocomplete component, built to be accessible.
+body: |
+  This component uses the [Accessible Autocomplete](https://github.com/alphagov/accessible-autocomplete) code to create an accessible autocomplete element. The autocomplete is created with the `showAllValues`
+  option set to `true` and the `confirmOnBlur` option set to `false` (see [Autocomplete examples](https://alphagov.github.io/accessible-autocomplete/examples) here). It also depends upon the
+  [label component](https://github.com/component-guide/label).
+
+  If Javascript is disabled, the component appears as a select box, so the user can still select an option.
+accessibility_criteria: |
+  [Accessibility acceptance criteria](https://github.com/alphagov/accessible-autocomplete/blob/master/accessibility-criteria.md)
+examples:
+  default:
+    data:
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]
+  with_unique_identifier:
+    data:
+      id: 'unique-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+  with_selected_option_chosen:
+    data:
+      id: 'selected-option-chosen-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      selected_option: ['United Kingdom', 'gb']
+  with_tracking_enabled:
+    description: |
+     This example shows tracking enabled on an autocomplete. Tracking will be enabled automatically when `track_category` and `track_action` are specified in `data_attributes`.
+    data:
+      id: 'tracking-enabled-autocomplete'
+      label:
+        text: 'Countries'
+      options: [['', ''], ['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us']]
+      data_attributes:
+        track_category: 'chosen_category'
+        track_action: 'chosen_action'
+        track_option:
+          custom_dimension: 'your_custom_dimension'
+  with_multiple_selections:
+    description: This parameter allows the user to choose more than one option from the autocomplete. The component generates a select multiple in place of a regular select, and the autocomplete Javascript detects this and provides the multiple selection functionality.
+    data:
+      multiple: true
+      label:
+        text: 'Countries'
+      options: [['France', 'fr'], ['Germany', 'de'], ['Sweden', 'se'], ['Switzerland', 'ch'], ['United Kingdom', 'gb'], ['United States', 'us'], ['The Separate Customs Territory of Taiwan, Penghu, Kinmen, and Matsu (Chinese Taipei)', 'tw']]

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -41,7 +41,7 @@
                 value: params[:search_term],
               } %>
 
-          <%= render "govuk_publishing_components/components/accessible_autocomplete",
+          <%= render "components/accessible_autocomplete",
               {
                 id: 'document_type',
                 label: {
@@ -51,7 +51,7 @@
                 selected_option: @filter.selected_document_type(params)
               }
           %>
-          <%= render "govuk_publishing_components/components/accessible_autocomplete",
+          <%= render "components/accessible_autocomplete",
               {
                 id: 'organisation_id',
                 label: {

--- a/app/views/development/index.html.erb
+++ b/app/views/development/index.html.erb
@@ -2,7 +2,7 @@
 <%= content_for :title, "Dev page" %>
 
 
-<%= render "govuk_publishing_components/components/accessible_autocomplete", {
+<%= render "components/accessible_autocomplete", {
   label: {
     text: "Countries"
   },

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,4 +11,6 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-# Rails.application.config.assets.precompile += %w( admin.js admin.css )
+Rails.application.config.assets.precompile += %w(
+  accessible-autocomplete/dist/accessible-autocomplete.min.css
+)

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,5 +12,6 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
 Rails.application.config.assets.precompile += %w[
+  accessible-autocomplete/dist/accessible-autocomplete.min.js
   accessible-autocomplete/dist/accessible-autocomplete.min.css
 ]

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -11,6 +11,6 @@ Rails.application.config.assets.paths << Rails.root.join("node_modules")
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w(
+Rails.application.config.assets.precompile += %w[
   accessible-autocomplete/dist/accessible-autocomplete.min.css
-)
+]

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,7 +1,6 @@
 # config/initializers/govuk_publishing_components.rb
 GovukPublishingComponents.configure do |c|
   c.component_guide_title = "Content Data"
-  c.application_print_stylesheet = nil
   c.application_stylesheet = "application"
   c.application_javascript = "application"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,6 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  components:
+    autocomplete:
+      multiselect: "To select multiple items in a list, hold down Ctrl (PC) or Cmd (Mac) key."

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "stylelint": {
     "extends": "stylelint-config-gds/scss"
   },
+  "dependencies": {
+    "accessible-autocomplete": "^2.0.4"
+  },
   "devDependencies": {
     "standardx": "^7.0.0",
     "stylelint": "^14.16.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "accessible-autocomplete": "^2.0.4"
   },
   "devDependencies": {
+    "postcss": "^8.4.21",
     "standardx": "^7.0.0",
     "stylelint": "^14.16.1",
     "stylelint-config-gds": "^0.2.0"

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+describe "AccessibleAutocomplete", type: :view do
+  def component_name
+    "accessible_autocomplete"
+  end
+
+  it 'renders select element' do
+    render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select[multiple]", false
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=gb]", text: 'United Kingdom'
+    assert_select "select#basic-autocomplete option[value=us]"
+    assert_select "select#basic-autocomplete option[value=us]", text: 'United States'
+  end
+
+  it 'renders select element with selected value' do
+    render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']],
+      selected_option: ['United States', 'us']
+    )
+
+    assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
+    assert_select "select#basic-autocomplete"
+    assert_select "select#basic-autocomplete option[value=gb]"
+    assert_select "select#basic-autocomplete option[value=us][selected]"
+  end
+
+  it 'does not render when no data is specified' do
+    assert_empty render_component({})
+  end
+
+  it 'does not render when no label is specified' do
+    assert_empty render_component(
+      id: 'basic-autocomplete',
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+  end
+
+  it 'does not render when no options are specified' do
+    assert_empty render_component(
+      id: 'basic-autocomplete',
+      label: { text: "Countries" }
+    )
+  end
+
+  it 'renders the multiple selection version correctly' do
+    render_component(
+      multiple: true,
+      label: { text: "Countries" },
+      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+    )
+
+    assert_select "select[multiple]"
+    assert_select ".gem-c-autocomplete__multiselect-instructions"
+  end
+end

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "AccessibleAutocomplete", type: :view do
+RSpec.describe "AccessibleAutocomplete", type: :view do
   def component_name
     "accessible_autocomplete"
   end

--- a/spec/components/accessible_autocomplete_spec.rb
+++ b/spec/components/accessible_autocomplete_spec.rb
@@ -1,32 +1,32 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe "AccessibleAutocomplete", type: :view do
   def component_name
     "accessible_autocomplete"
   end
 
-  it 'renders select element' do
+  it "renders select element" do
     render_component(
-      id: 'basic-autocomplete',
+      id: "basic-autocomplete",
       label: { text: "Countries" },
-      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
     )
 
     assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
     assert_select "select#basic-autocomplete"
     assert_select "select[multiple]", false
     assert_select "select#basic-autocomplete option[value=gb]"
-    assert_select "select#basic-autocomplete option[value=gb]", text: 'United Kingdom'
+    assert_select "select#basic-autocomplete option[value=gb]", text: "United Kingdom"
     assert_select "select#basic-autocomplete option[value=us]"
-    assert_select "select#basic-autocomplete option[value=us]", text: 'United States'
+    assert_select "select#basic-autocomplete option[value=us]", text: "United States"
   end
 
-  it 'renders select element with selected value' do
+  it "renders select element with selected value" do
     render_component(
-      id: 'basic-autocomplete',
+      id: "basic-autocomplete",
       label: { text: "Countries" },
-      options: [['United Kingdom', 'gb'], ['United States', 'us']],
-      selected_option: ['United States', 'us']
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
+      selected_option: ["United States", "us"],
     )
 
     assert_select ".govuk-label", text: "Countries", for: "basic-autocomplete"
@@ -35,29 +35,29 @@ describe "AccessibleAutocomplete", type: :view do
     assert_select "select#basic-autocomplete option[value=us][selected]"
   end
 
-  it 'does not render when no data is specified' do
+  it "does not render when no data is specified" do
     assert_empty render_component({})
   end
 
-  it 'does not render when no label is specified' do
+  it "does not render when no label is specified" do
     assert_empty render_component(
-      id: 'basic-autocomplete',
-      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+      id: "basic-autocomplete",
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
     )
   end
 
-  it 'does not render when no options are specified' do
+  it "does not render when no options are specified" do
     assert_empty render_component(
-      id: 'basic-autocomplete',
-      label: { text: "Countries" }
+      id: "basic-autocomplete",
+      label: { text: "Countries" },
     )
   end
 
-  it 'renders the multiple selection version correctly' do
+  it "renders the multiple selection version correctly" do
     render_component(
       multiple: true,
       label: { text: "Countries" },
-      options: [['United Kingdom', 'gb'], ['United States', 'us']]
+      options: [["United Kingdom", "gb"], ["United States", "us"]],
     )
 
     assert_select "select[multiple]"

--- a/spec/features/date_selection_spec.rb
+++ b/spec/features/date_selection_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "date selection", type: :feature do
       visit page_uri
 
       time_labels = find(".app-c-time-select", visible: false).all(".govuk-radios__item", visible: false).map do |el|
-        { el.find("label", visible: false).text(:all) => el.find("span", visible: false).text(:all) }
+        { el.find("label", visible: false).text(:all) => el.find(class: "govuk-radios__hint", visible: false).text(:all) }
       end
 
       expect(time_labels).to match([

--- a/spec/javascripts/components/accessible-autocomplete-spec.js
+++ b/spec/javascripts/components/accessible-autocomplete-spec.js
@@ -1,0 +1,175 @@
+/* eslint-env jasmine, jquery */
+/* global GOVUK */
+
+describe('An accessible autocomplete component', function () {
+  'use strict'
+
+  function loadAutocompleteComponent () {
+    window.setFixtures(html)
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete()
+    autocomplete.start($('.gem-c-accessible-autocomplete'))
+  }
+
+  function loadAutocompleteMultiple () {
+    window.setFixtures(html)
+    var autocomplete = new GOVUK.Modules.AccessibleAutocomplete()
+    $('.gem-c-accessible-autocomplete').find('select').attr('multiple', 'multiple').find('option:first-child').remove()
+    autocomplete.start($('.gem-c-accessible-autocomplete'))
+  }
+
+  var html =
+    '<div class="gem-c-accessible-autocomplete" data-module="accessible-autocomplete">' +
+      '<select id="test" class="govuk-select" data-track-category="category" data-track-action="action">' +
+        '<option value=""></option>' +
+        '<option value="mo">Moose</option>' +
+        '<option value="de">Deer</option>' +
+      '</select>' +
+    '</div>'
+
+  // the autocomplete onConfirm function fires after the tests run unless we put
+  // in a timeout like this - makes the tests a bit verbose unfortunately
+  function testAsyncWithDeferredReturnValue () {
+    var deferred = $.Deferred()
+
+    setTimeout(function () {
+      deferred.resolve()
+    }, 500)
+
+    return deferred.promise()
+  }
+
+  describe('updates the hidden select when', function () {
+    beforeEach(function (done) {
+      loadAutocompleteComponent()
+
+      // the autocomplete is complex enough that all of these
+      // events are necessary to simulate user input
+      $('.autocomplete__input').val('Moose').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('an option is selected', function () {
+      expect($('select').val()).toEqual('mo')
+    })
+  })
+
+  describe('updates the hidden select when', function () {
+    beforeEach(function (done) {
+      loadAutocompleteComponent()
+
+      $('select').val('de').change()
+      $('.autocomplete__input').val('Deer')
+
+      $('.autocomplete__input').val('').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('the input is cleared', function () {
+      expect($('select').val()).toEqual('')
+    })
+  })
+
+  describe('triggers a Google Analytics event', function () {
+    beforeEach(function (done) {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      loadAutocompleteComponent()
+
+      $('.autocomplete__input').val('Moose').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('when a valid option is chosen', function () {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: 'Moose' }))
+    })
+  })
+
+  describe('triggers a Google Analytics event', function () {
+    beforeEach(function (done) {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      }
+      spyOn(GOVUK.analytics, 'trackEvent')
+
+      loadAutocompleteComponent()
+
+      $('.autocomplete__input').val('Deer').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      $('.autocomplete__input').val('').click().focus().trigger(
+        $.Event('keypress', { which: 13, key: 13, keyCode: 13 })
+      ).blur()
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('when an input is cleared', function () {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', Object({ label: '' }))
+    })
+  })
+
+  describe('in multiple mode', function () {
+    beforeEach(function (done) {
+      loadAutocompleteMultiple()
+      // use the component api for this test
+      // as methods in previous tests don't seem to
+      // work in multiple mode
+      var onConfirm = $('select').data('onconfirm')
+
+      $('.autocomplete__input').val('Deer')
+      onConfirm('Deer', 'de')
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('selects one option in the select', function () {
+      expect($('select').val()).toEqual(['de'])
+    })
+  })
+
+  describe('in multiple mode', function () {
+    beforeEach(function (done) {
+      loadAutocompleteMultiple()
+      var onConfirm = $('select').data('onconfirm')
+
+      $('.autocomplete__input').val('Moose')
+      onConfirm('Moose', 'mo')
+
+      $('.autocomplete__input').val('Deer')
+      onConfirm('Deer', 'de')
+
+      testAsyncWithDeferredReturnValue().done(function () {
+        done()
+      })
+    })
+
+    it('selects multiple options in the select', function () {
+      expect($('select').val()).toEqual(['mo', 'de'])
+    })
+  })
+})

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,4 +20,5 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
+  config.include Helpers::Components, type: :view
 end

--- a/spec/support/components_helper.rb
+++ b/spec/support/components_helper.rb
@@ -1,0 +1,15 @@
+module Helpers
+  module Components
+    def component_name
+      raise NotImplementedError, "Override this method in your test class"
+    end
+
+    def render_component(locals, &block)
+      if block_given?
+        render("components/#{component_name}", locals, &block)
+      else
+        render "components/#{component_name}", locals
+      end
+    end
+  end
+end

--- a/yarn.lock
+++ b/yarn.lock
@@ -1616,6 +1616,15 @@ postcss@^8.4.19:
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
 
+postcss@^8.4.21:
+  version "8.4.21"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
+  integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
+  dependencies:
+    nanoid "^3.3.4"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
+
 preact@^8.3.1:
   version "8.5.3"
   resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,6 +85,13 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+accessible-autocomplete@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/accessible-autocomplete/-/accessible-autocomplete-2.0.4.tgz#e295256c8d268b97c5ab456a1cb084b553ed3eb0"
+  integrity sha512-2p0txrSpvs5wXFUeQJHMheDPTZVSEmiUHWlEPb7vJnv2Dd1xPfoLnBQQMfNbTSit2pL/9sSQYESuD2Yyohd4Yw==
+  dependencies:
+    preact "^8.3.1"
+
 acorn-jsx@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
@@ -1608,6 +1615,11 @@ postcss@^8.4.19:
     nanoid "^3.3.4"
     picocolors "^1.0.0"
     source-map-js "^1.0.2"
+
+preact@^8.3.1:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-8.5.3.tgz#78c2a5562fcecb1fed1d0055fa4ac1e27bde17c1"
+  integrity sha512-O3kKP+1YdgqHOFsZF2a9JVdtqD+RPzCQc3rP+Ualf7V6rmRDchZ9MJbiGTT7LuyqFKZqlHSOyO/oMFmI2lVTsw==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Add the accessible-autocomplete component directly, since it was removed from govuk_publishing_components in version 18. This is the upgrade path recommended in the [govuk_publishing_components changelog](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md#1800).

This unblocks upgrading from the now very outdated version 17 of govuk_publishing_components, which unblocks upgrading to the current version of [Plek].

Removed the no-longer-necessary version constraints and ran `bundle update` to update to govuk_publishing_components 34.7.1 and Plek 5.0.0 (plus minor updates to some other gems).

[Plek]: https://github.com/alphagov/plek