### PR TITLE
Add sentry-sidekiq to track Sidekiq errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "mail-notify"
 gem "pg"
 gem "plek"
 gem "sassc-rails"
+gem "sentry-sidekiq"
 gem "uglifier"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,6 +394,9 @@ GEM
       sentry-ruby (~> 5.9.0)
     sentry-ruby (5.9.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.9.0)
+      sentry-ruby (~> 5.9.0)
+      sidekiq (>= 3.0)
     sidekiq (6.5.5)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -475,6 +478,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
+  sentry-sidekiq
   simplecov
   spring-commands-rspec
   timecop


### PR DESCRIPTION
The default configuration comes from GovukError in https://github.com/alphagov/govuk_app_config

Added in response to:

```
Warning: GovukError is not configured to track Sidekiq errors,
install the sentry-sidekiq gem to track them.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
