### PR TITLE
Only include better_errors gem in development env

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,13 +18,16 @@ gem "sassc-rails"
 gem "sentry-sidekiq"
 gem "uglifier"
 
+group :development do
+  gem "better_errors"
+end
+
 group :test do
   gem "simplecov"
   gem "timecop"
 end
 
 group :development, :test do
-  gem "better_errors"
   gem "binding_of_caller"
   gem "byebug"
   gem "capybara"

--- a/spec/features/document_children_page/documents_children_page_spec.rb
+++ b/spec/features/document_children_page/documents_children_page_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe "/documents/:document_id/children" do
   let(:document_id) { "1234:en" }
 
   before do
+    stub_metrics_page(base_path: "parent", time_period: :past_30_days)
     stub_document_children_page(document_id:)
     GDS::SSO.test_user = build(:user, organisation_content_id: "users-org-id")
 


### PR DESCRIPTION
This gem swallows exceptions raised by our app, and replaces them with error pages. This makes it very difficult to debug failures in our feature specs, as we no longer see a stack trace.

Before this change, here's what the failures on [this Dependabot PR](https://github.com/alphagov/content-data-admin/pull/1230) look like:

```
Failures:

  1) /content Filter by title / url renders the filtered items
     Failure/Error: fill_in "Search for a title or URL", with: "title"

     Capybara::ElementNotFound:
       Unable to find field "Search for a title or URL" that is not disabled
     # ./spec/features/index_page/index_filter_by_title_spec.rb:23:in `block (3 levels) in <top (required)>'

  2) /content Filter by title / url populates the search field with the current filter
     Failure/Error: fill_in "Search for a title or URL", with: "title"

     Capybara::ElementNotFound:
       Unable to find field "Search for a title or URL" that is not disabled
     # ./spec/features/index_page/index_filter_by_title_spec.rb:23:in `block (3 levels) in <top (required)>'

  3) /content Filter by title / url launches help text in a modal
     Failure/Error: fill_in "Search for a title or URL", with: "title"

     Capybara::ElementNotFound:
       Unable to find field "Search for a title or URL" that is not disabled
     # ./spec/features/index_page/index_filter_by_title_spec.rb:23:in `block (3 levels) in <top (required)>'
```

After this change, here's what they look like:

```
  1) /content Filter by title / url renders the filtered items
     Failure/Error: @document_type = humanize(data[:document_type])
     
     NoMethodError:
       undefined method `end_with?' for nil:NilClass
     
             if !keep_id_suffix && lower_case_and_underscored_word.end_with?("_id")
                                                                  ^^^^^^^^^^
     # ./app/presenters/content_row_presenter.rb:19:in `initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `new'
     # ./app/presenters/content_items_presenter.rb:16:in `block in initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `map'
     # ./app/presenters/content_items_presenter.rb:16:in `initialize'
     # ./app/controllers/content_controller.rb:17:in `new'
     # ./app/controllers/content_controller.rb:17:in `index'
     # ./spec/features/index_page/index_filter_by_title_spec.rb:16:in `block (2 levels) in <top (required)>'

  2) /content Filter by title / url populates the search field with the current filter
     Failure/Error: @document_type = humanize(data[:document_type])
     
     NoMethodError:
       undefined method `end_with?' for nil:NilClass
     
             if !keep_id_suffix && lower_case_and_underscored_word.end_with?("_id")
                                                                  ^^^^^^^^^^
     # ./app/presenters/content_row_presenter.rb:19:in `initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `new'
     # ./app/presenters/content_items_presenter.rb:16:in `block in initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `map'
     # ./app/presenters/content_items_presenter.rb:16:in `initialize'
     # ./app/controllers/content_controller.rb:17:in `new'
     # ./app/controllers/content_controller.rb:17:in `index'
     # ./spec/features/index_page/index_filter_by_title_spec.rb:16:in `block (2 levels) in <top (required)>'

  3) /content Filter by title / url launches help text in a modal
     Failure/Error: @document_type = humanize(data[:document_type])
     
     NoMethodError:
       undefined method `end_with?' for nil:NilClass
     
             if !keep_id_suffix && lower_case_and_underscored_word.end_with?("_id")
                                                                  ^^^^^^^^^^
     # ./app/presenters/content_row_presenter.rb:19:in `initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `new'
     # ./app/presenters/content_items_presenter.rb:16:in `block in initialize'
     # ./app/presenters/content_items_presenter.rb:16:in `map'
     # ./app/presenters/content_items_presenter.rb:16:in `initialize'
     # ./app/controllers/content_controller.rb:17:in `new'
     # ./app/controllers/content_controller.rb:17:in `index'
     # ------------------
     # --- Caused by: ---
     # Capybara::ElementNotFound:
     #   Unable to find field "Search for a title or URL" that is not disabled
     #   ./spec/features/index_page/index_filter_by_title_spec.rb:23:in `block (3 levels) in <top (required)>'
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
