### PR TITLE
Add email subscription metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,8 @@ gem "rails", "7.1.2"
 gem "bootsnap", require: false
 gem "chartkick"
 gem "fog-aws"
-gem "gds-api-adapters"
+gem "gds-api-adapters", "~> 92.1.0"
+
 gem "gds-sso"
 gem "govspeak"
 gem "govuk_app_config"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
     debug_inspector (1.1.0)
     diff-lcs (1.5.0)
     docile (1.4.0)
-    domain_name (0.6.20231109)
+    domain_name (0.6.20240107)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -145,7 +145,7 @@ GEM
       fog-core
       nokogiri (>= 1.5.11, < 2.0.0)
     formatador (1.1.0)
-    gds-api-adapters (92.0.0)
+    gds-api-adapters (92.1.0)
       addressable
       link_header
       null_logger
@@ -716,7 +716,7 @@ DEPENDENCIES
   chartkick
   factory_bot_rails
   fog-aws
-  gds-api-adapters
+  gds-api-adapters (~> 92.1.0)
   gds-sso
   govspeak
   govuk_app_config

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -15,6 +15,7 @@ class MetricsController < ApplicationController
     )
 
     setup_siteimprove
+    setup_email_subscriptions
   end
 
   rescue_from GdsApi::HTTPNotFound do
@@ -23,9 +24,18 @@ class MetricsController < ApplicationController
 
 private
 
-
   def base_path
     params[:base_path]
+  end
+
+  def setup_email_subscriptions
+    return unless current_user.view_email_subs?
+
+    @show_email_subs_section = true
+    @email_subscriptions = {
+      subscriber_list_count: 12,
+      all_notify_count: 26,
+    }
   end
 
   def setup_siteimprove

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -32,10 +32,7 @@ private
     return unless current_user.view_email_subs?
 
     @show_email_subs_section = true
-    @email_subscriptions = {
-      subscriber_list_count: 12,
-      all_notify_count: 26,
-    }
+    @email_subscriptions = EmailApi::PageSubscriptionsClient.new.fetch(path: "/#{base_path}")
   end
 
   def setup_siteimprove

--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -1,7 +1,6 @@
 class MetricsController < ApplicationController
   def show
     time_period = params[:date_range] || "past-30-days"
-    base_path = params[:base_path]
 
     curr_period = DateRange.new(time_period)
     prev_period = curr_period.previous
@@ -15,24 +14,32 @@ class MetricsController < ApplicationController
       curr_period,
     )
 
-    if current_user.view_siteimprove?
-      begin
-        @summary_info = Siteimprove::FetchSummary.call(url: "https://www.gov.uk/#{params[:base_path]}")
-
-        raw_policy_issues = Siteimprove::FetchPolicyIssues.call(url: "https://www.gov.uk/#{params[:base_path]}")
-        @policy_issues = Siteimprove::PolicyIssuesPresenter.new(raw_policy_issues, @summary_info)
-        raw_quality_assurance_issues = Siteimprove::FetchQualityAssuranceIssues.call(url: "https://www.gov.uk/#{params[:base_path]}")
-        @quality_assurance_issues = Siteimprove::QualityAssuranceIssuesPresenter.new(raw_quality_assurance_issues, @summary_info)
-        @has_accessibility_info = @policy_issues.any? || @quality_assurance_issues.any?
-      rescue Siteimprove::BaseError
-        @has_accessibility_info = false
-      end
-    else
-      @has_accessibility_info = false
-    end
+    setup_siteimprove
   end
 
   rescue_from GdsApi::HTTPNotFound do
     render "errors/404", status: :not_found
+  end
+
+private
+
+
+  def base_path
+    params[:base_path]
+  end
+
+  def setup_siteimprove
+    return unless current_user.view_siteimprove?
+
+    begin
+      @summary_info = Siteimprove::FetchSummary.call(url: "https://www.gov.uk/#{base_path}")
+      raw_policy_issues = Siteimprove::FetchPolicyIssues.call(url: "https://www.gov.uk/#{base_path}")
+      @policy_issues = Siteimprove::PolicyIssuesPresenter.new(raw_policy_issues, @summary_info)
+      raw_quality_assurance_issues = Siteimprove::FetchQualityAssuranceIssues.call(url: "https://www.gov.uk/#{base_path}")
+      @quality_assurance_issues = Siteimprove::QualityAssuranceIssuesPresenter.new(raw_quality_assurance_issues, @summary_info)
+      @has_accessibility_info = @policy_issues.any? || @quality_assurance_issues.any?
+    rescue Siteimprove::BaseError
+      @has_accessibility_info = false
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,4 +4,8 @@ class User < ApplicationRecord
   def view_siteimprove?
     permissions.include?("view_siteimprove")
   end
+
+  def view_email_subs?
+    permissions.include?("view_email_subs")
+  end
 end

--- a/app/services/email_api/page_subscriptions_client.rb
+++ b/app/services/email_api/page_subscriptions_client.rb
@@ -1,0 +1,18 @@
+module EmailApi
+  class PageSubscriptionsClient
+    def initialize
+      @email_alert_api = GdsApi::EmailAlertApi.new(Plek.find("email-alert-api"))
+    end
+
+    def fetch(path:)
+      response = email_alert_api.get_subscriber_list_metrics(path:)
+      EmailApi::PageSubscriptionsResponse.new(**response.to_h.symbolize_keys)
+    rescue GdsApi::HTTPNotFound
+      nil
+    end
+
+  private
+
+    attr_reader :email_alert_api
+  end
+end

--- a/app/services/email_api/page_subscriptions_client.rb
+++ b/app/services/email_api/page_subscriptions_client.rb
@@ -1,7 +1,7 @@
 module EmailApi
   class PageSubscriptionsClient
     def initialize
-      @email_alert_api = GdsApi::EmailAlertApi.new(Plek.find("email-alert-api"))
+      @email_alert_api = GdsApi.email_alert_api
     end
 
     def fetch(path:)

--- a/app/services/email_api/page_subscriptions_response.rb
+++ b/app/services/email_api/page_subscriptions_response.rb
@@ -1,0 +1,10 @@
+module EmailApi
+  class PageSubscriptionsResponse
+    def initialize(all_notify_count:, subscriber_list_count:)
+      @all_notify_count = all_notify_count
+      @subscriber_list_count = subscriber_list_count
+    end
+
+    attr_reader :all_notify_count, :subscriber_list_count
+  end
+end

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,7 +1,19 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
 <% if @email_subscriptions.present? %>
-  <p><strong>Subscribers:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
-  <p><strong>All notification subscribers:</strong> <%=@email_subscriptions.all_notify_count %></p>
+  <p><strong><%= t("metrics.email_subscriptions.active_title") %>:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
+  <p><strong><%= t("metrics.email_subscriptions.total_notify_title") %>:</strong> <%=@email_subscriptions.all_notify_count %></p>
 <% else %>
-  <p>No subscription information found</p>
+  <p><%= t("metrics.email_subscriptions.no_information") %></p>
+<% end %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: t("metrics.email_subscriptions.about_title")
+} do %>
+
+  <h3 class="govuk-heading-m"><%= t("metrics.email_subscriptions.active_title") %></h3>
+  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.active_description") %></p>
+
+  <h3 class="govuk-heading-m"><%= t("metrics.email_subscriptions.total_notify_title") %></h3>
+  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.total_notify_description") %></p>
+
 <% end %>

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,1 +1,3 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
+<p><strong>Subscribers:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
+<p><strong>All notification subscribers:</strong> <%=@email_subscriptions.all_notify_count %></p>

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,0 +1,1 @@
+<h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,3 +1,7 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
-<p><strong>Subscribers:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
-<p><strong>All notification subscribers:</strong> <%=@email_subscriptions.all_notify_count %></p>
+<% if @email_subscriptions.present? %>
+  <p><strong>Subscribers:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
+  <p><strong>All notification subscribers:</strong> <%=@email_subscriptions.all_notify_count %></p>
+<% else %>
+  <p>No subscription information found</p>
+<% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -151,6 +151,10 @@
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <%= render "siteimprove_issues" %>
 <% end %>
+<% if @show_email_subs_section %>
+   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+   <%= render "email_subscriptions" %>
+<% end %>
 
 
 

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -9,6 +9,8 @@ en:
     feedback_explorer: 'Feedback Explorer'
     none: false
   metrics:
+    email_subscriptions:
+      title: 'Email subscriptions'
     upviews:
       title: 'Unique page views'
       short_title: 'Unique page views'

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -11,6 +11,12 @@ en:
   metrics:
     email_subscriptions:
       title: 'Email subscriptions'
+      about_title: 'About Email subscriptions'
+      active_title: 'Active subscribers'
+      active_description: 'Active subscribers is the number of people who have clicked the Get Emails button on this page and signed up to be subscribed to valid email alerts either to this page or to pages related to this one. Note that some pages can be subscribed to, but do not generate email alerts themselves (in these cases the subscriber list will be notified if pages related to this one are updated)'
+      total_notify_title: 'Number of subscribers notified by change'
+      total_notify_description: 'Number of subscribers notified by change is the number of people who will receive emails if this page receives a major update. Note that this may be zero even if the page has active subscribers (if the page does not generate email alerts), or may be positive even if the page has no active subscribers (as there are lists that subscribe to all emails, or all emails on a certain topic)'
+      no_information: 'No subscription information found'
     upviews:
       title: 'Unique page views'
       short_title: 'Unique page views'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,4 +14,8 @@ FactoryBot.define do
   factory :view_siteimprove_user, parent: :user do
     permissions { %i[view_siteimprove] }
   end
+
+  factory :view_email_subs_user, parent: :user do
+    permissions { %i[view_email_subs] }
+  end
 end

--- a/spec/features/single_content_item_email_subs_spec.rb
+++ b/spec/features/single_content_item_email_subs_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe "/metrics/base/path email subscription details", type: :feature do
+  include RequestStubs
+
+  context "logged in as another department" do
+    before do
+      GDS::SSO.test_user = build(:user)
+      stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+    end
+
+    it "does not show the Email Subscriptions title" do
+      visit "/metrics/base/path"
+      expect(page).not_to have_content("Email subscriptions")
+    end
+  end
+
+  context "logged in as GDS" do
+    before do
+      GDS::SSO.test_user = build(:view_email_subs_user)
+      stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+    end
+
+    it "shows the Email subscriptions section" do
+      visit "/metrics/base/path"
+      expect(page).to have_content("Email subscriptions")
+    end
+  end
+end

--- a/spec/features/single_content_item_email_subs_spec.rb
+++ b/spec/features/single_content_item_email_subs_spec.rb
@@ -20,16 +20,34 @@ RSpec.describe "/metrics/base/path email subscription details", type: :feature d
     before do
       GDS::SSO.test_user = build(:view_email_subs_user)
       stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
-      json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
-      stub_get_subscriber_list_metrics(path: "/base/path", response: json)
     end
 
     context "when there are subscriptions" do
+      before do
+        json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
+        stub_get_subscriber_list_metrics(path: "/base/path", response: json)
+      end
+
       it "shows the Email subscriptions section" do
         visit "/metrics/base/path"
         expect(page).to have_content("Email subscriptions")
         expect(page).to have_content("Subscribers: 3")
         expect(page).to have_content("All notification subscribers: 10")
+        expect(page).not_to have_content("No subscription information found")
+      end
+    end
+
+    context "when there is a 404 from email-alert-api" do
+      before do
+        stub_get_subscriber_list_metrics_not_found(path: "/base/path")
+      end
+
+      it "shows the no subscription info section" do
+        visit "/metrics/base/path"
+        expect(page).to have_content("Email subscriptions")
+        expect(page).to have_content("No subscription information found")
+        expect(page).not_to have_content("Subscribers:")
+        expect(page).not_to have_content("All notification subscribers:")
       end
     end
   end

--- a/spec/features/single_content_item_email_subs_spec.rb
+++ b/spec/features/single_content_item_email_subs_spec.rb
@@ -31,9 +31,19 @@ RSpec.describe "/metrics/base/path email subscription details", type: :feature d
       it "shows the Email subscriptions section" do
         visit "/metrics/base/path"
         expect(page).to have_content("Email subscriptions")
-        expect(page).to have_content("Subscribers: 3")
-        expect(page).to have_content("All notification subscribers: 10")
+        expect(page).to have_content("Active subscribers: 3")
+        expect(page).to have_content("Number of subscribers notified by change: 10")
         expect(page).not_to have_content("No subscription information found")
+      end
+
+      it "shows information on the email metrics" do
+        visit "/metrics/base/path"
+        [
+          "Active subscribers is the number of people",
+          "Number of subscribers notified by change is the number of people",
+        ].each do |txt|
+          expect(page).to have_content(txt)
+        end
       end
     end
 
@@ -46,8 +56,8 @@ RSpec.describe "/metrics/base/path email subscription details", type: :feature d
         visit "/metrics/base/path"
         expect(page).to have_content("Email subscriptions")
         expect(page).to have_content("No subscription information found")
-        expect(page).not_to have_content("Subscribers:")
-        expect(page).not_to have_content("All notification subscribers:")
+        expect(page).not_to have_content("Active subscribers:")
+        expect(page).not_to have_content("Number of subscribers notified by change:")
       end
     end
   end

--- a/spec/features/single_content_item_email_subs_spec.rb
+++ b/spec/features/single_content_item_email_subs_spec.rb
@@ -1,5 +1,8 @@
+require "gds_api/test_helpers/email_alert_api"
+
 RSpec.describe "/metrics/base/path email subscription details", type: :feature do
   include RequestStubs
+  include GdsApi::TestHelpers::EmailAlertApi
 
   context "logged in as another department" do
     before do
@@ -17,11 +20,17 @@ RSpec.describe "/metrics/base/path email subscription details", type: :feature d
     before do
       GDS::SSO.test_user = build(:view_email_subs_user)
       stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+      json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
+      stub_get_subscriber_list_metrics(path: "/base/path", response: json)
     end
 
-    it "shows the Email subscriptions section" do
-      visit "/metrics/base/path"
-      expect(page).to have_content("Email subscriptions")
+    context "when there are subscriptions" do
+      it "shows the Email subscriptions section" do
+        visit "/metrics/base/path"
+        expect(page).to have_content("Email subscriptions")
+        expect(page).to have_content("Subscribers: 3")
+        expect(page).to have_content("All notification subscribers: 10")
+      end
     end
   end
 end

--- a/spec/services/email_api/page_subscriptions_client_spec.rb
+++ b/spec/services/email_api/page_subscriptions_client_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "gds_api/test_helpers/email_alert_api"
+
+RSpec.describe EmailApi::PageSubscriptionsClient do
+  include GdsApi::TestHelpers::EmailAlertApi
+  subject { described_class.new }
+
+  context "when subscription metrics exist" do
+    before do
+      json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
+      stub_get_subscriber_list_metrics(path: "/some/path", response: json)
+    end
+
+    it "show details for the metrics" do
+      metrics = subject.fetch(path: "/some/path")
+      assert_equal 3, metrics.subscriber_list_count
+      assert_equal 10, metrics.all_notify_count
+    end
+  end
+
+  context "when subscription metrics 404" do
+    before do
+      stub_get_subscriber_list_metrics_not_found(path: "/some/path")
+    end
+
+    it "show details for the metrics" do
+      metrics = subject.fetch(path: "/some/path")
+      assert_nil metrics
+    end
+  end
+end


### PR DESCRIPTION
## GIFT Week

* Show a section with email subscription numbers from the `email-alert-api` on the `/metrics` page.