### PR TITLE
Prevent crash if policy not found

### DIFF
--- a/app/presenters/siteimprove/policy_issues_presenter.rb
+++ b/app/presenters/siteimprove/policy_issues_presenter.rb
@@ -45,7 +45,10 @@ module Siteimprove
     end
 
     def policy_description(issue)
-      note = Siteimprove::FetchPolicies.new.find(issue.id).first.note
+      policy = Siteimprove::FetchPolicies.new.find(issue.id).first
+      return "No description for this policy" unless policy
+
+      note = policy.note
       note.gsub!(/https:\/\/(.+)/, "[https://\\1](https://\\1)")
       Govspeak::Document.new(note).to_html
     end


### PR DESCRIPTION
Reported crash on certain pages: https://govuk.sentry.io/issues/4893720921/?project=1259363&query=&referrer=project-issue-stream

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
