### PR TITLE
Add GA4 migration notice

### DIFF
--- a/app/views/components/_ga4_notice.html.erb
+++ b/app/views/components/_ga4_notice.html.erb
@@ -1,0 +1,11 @@
+<% i18n_scope = [:data_sources, :ga4_migration_warning] %>
+
+<div class="govuk-inset-text ga-data-notice">
+  <p class="govuk-body govuk-!-font-weight-bold">
+    <%= I18n.t(:heading, scope: i18n_scope) %>
+  </p>
+
+  <p class="govuk-body">
+    <%= raw(I18n.t(:body, scope: i18n_scope)) %>
+  </p>
+</div>

--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -5,6 +5,7 @@
     <a href="/content" class="local-nav__search-link govuk-link govuk-link--no-visited-state" data-gtm-id="back-link">Search</a>
   </div>
 <% end %>
+<%= render(partial: 'components/ga4_notice') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sending the CSV export</h1>

--- a/app/views/content/index.html.erb
+++ b/app/views/content/index.html.erb
@@ -2,6 +2,12 @@
 <% content_for :page_class, "content-data__index" %>
 
 <div class="govuk-grid-row">
+  <div class="govuk-grid-column-full ga-data-notice-column">
+    <%= render(partial: 'components/ga4_notice') %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
     <div class="govuk-grid-column-one-quarter">
       <div class="filters-control__wrapper filter--hidden" data-module="filter-toggle">
         <span class="filters-control filters-control--hide filter--hidden">

--- a/app/views/content_csv_mailer/content_csv_email.text.erb
+++ b/app/views/content_csv_mailer/content_csv_email.text.erb
@@ -2,6 +2,8 @@ The data you exported from Content Data will be available from this link for 7 d
 
 <%= @file_url %>
 
+<%= I18n.t(:heading, scope: [:data_sources, :ga4_migration_warning])%> <%= I18n.t(:body, scope: [:data_sources, :ga4_migration_warning])%>
+
 If you have feedback on the Content Data tool or problems downloading the CSV, email 2nd-line-support@digital.cabinet-office.gov.uk.
 
 Do not reply to this message.

--- a/app/views/documents/children.html.erb
+++ b/app/views/documents/children.html.erb
@@ -8,6 +8,7 @@
 <% end %>
 
 <div class="content-wrapper">
+  <%= render(partial: 'components/ga4_notice') %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds headings">
       <span class="govuk-caption-xl" data-gtm-id="page-kicker"><%= @presenter.kicker %></span>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -7,6 +7,7 @@
 <% end %>
 <% current_selection = @performance_data.date_range.time_period || 'past-30-days' %>
 
+<%= render(partial: 'components/ga4_notice') %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <span class="govuk-caption-xl" data-gtm-id="page-kicker"><%= t ".page_kicker" %></span>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -2,6 +2,9 @@ en:
   no_matching_results: 'No matching results'
   data_sources:
     google_analytics: 'Google Analytics'
+    ga4_migration_warning:
+      heading: We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024.
+      body: For more information please contact <a href="mailto:govuk-ga4-support@digital.cabinet-office.gov.uk">govuk-ga4-support@digital.cabinet-office.gov.uk</a>. Data is only collected for users that consent to analytics cookies.
     calculated_google_analytics: 'calculated from Google Analytics'
     feedback_explorer: 'Feedback Explorer'
     none: false


### PR DESCRIPTION
The new Google GA4/BigQuery product we are migrating to are not direct mappings of the old (Universal Analytics) metrics and the numbers may vary.
Adding this notice should hopefully make it clear to the user of the changes in case they see a significant change in pattern in the GOV.UK pages they are monitoring.

This has been tested on Integration - see screenshots below.

Before:
<img width="1694" alt="Screenshot 2024-01-31 at 10 45 39" src="https://github.com/alphagov/content-data-admin/assets/19667619/60d0f45f-4aac-4d55-8fa5-d7cbc98602fe">

After:
<img width="1695" alt="Screenshot 2024-01-31 at 10 57 22" src="https://github.com/alphagov/content-data-admin/assets/19667619/2f6489b0-8459-41f3-b88b-881e2520c3ff">

Before:
<img width="1003" alt="Screenshot 2024-01-31 at 10 45 30" src="https://github.com/alphagov/content-data-admin/assets/19667619/6d074e82-bd4a-4ad5-b079-bd8d5123822d">

After:
<img width="1006" alt="Screenshot 2024-01-31 at 10 53 47" src="https://github.com/alphagov/content-data-admin/assets/19667619/0258e724-ebbd-40b4-9cc3-81df3044ed91">

Trello card: https://trello.com/c/7z6fJUBD/3381-1-update-content-data-admin-with-google-ga4-migration-notice

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
