### PR TITLE
Add Siteimprove Sitemap Generator

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,8 +16,3 @@ inherit_mode:
 #
 # See https://github.com/alphagov/rubocop-govuk/blob/main/CONTRIBUTING.md
 # **************************************************************
-
-Rails/SaveBang:
-  AllowedReceivers:
-    - connection.directories # false positive for Fog::Storage
-    - directory.files # false positive for Fog::Storage

--- a/Gemfile
+++ b/Gemfile
@@ -2,11 +2,10 @@ source "https://rubygems.org"
 
 gem "rails", "7.1.3.2"
 
+gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "chartkick"
-gem "fog-aws"
 gem "gds-api-adapters", "~> 93.0.0"
-
 gem "gds-sso"
 gem "govspeak"
 gem "govuk_app_config"
@@ -20,6 +19,7 @@ gem "plek"
 gem "sassc-rails"
 gem "sentry-sidekiq"
 gem "siteimprove_api_client"
+gem "sitemap_generator"
 gem "uglifier"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,22 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    aws-eventstream (1.3.0)
+    aws-partitions (1.894.0)
+    aws-sdk-core (3.191.3)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
+    aws-sdk-kms (1.77.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.143.0)
+      aws-sdk-core (~> 3, >= 3.191.0)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.8)
+    aws-sigv4 (1.8.0)
+      aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
@@ -118,7 +134,6 @@ GEM
     erubi (1.12.0)
     ethon (0.16.0)
       ffi (>= 1.15.0)
-    excon (0.104.0)
     execjs (2.8.1)
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
@@ -130,22 +145,6 @@ GEM
     faraday-net_http (3.1.0)
       net-http
     ffi (1.15.5)
-    fog-aws (3.21.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-core (2.3.0)
-      builder
-      excon (~> 0.71)
-      formatador (>= 0.2, < 2.0)
-      mime-types
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-xml (0.1.4)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (1.1.0)
     gds-api-adapters (93.0.0)
       addressable
       link_header
@@ -220,6 +219,7 @@ GEM
     irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
+    jmespath (1.6.2)
     json (2.7.1)
     jwt (2.7.1)
     kaminari (1.2.2)
@@ -266,7 +266,6 @@ GEM
     mini_portile2 (2.8.5)
     minitest (5.22.2)
     msgpack (1.7.2)
-    multi_json (1.15.0)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -664,6 +663,8 @@ GEM
     simplecov_json_formatter (0.1.4)
     siteimprove_api_client (1.0.0)
       typhoeus (~> 1.0, >= 1.0.1)
+    sitemap_generator (6.3.0)
+      builder (~> 3.0)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -713,6 +714,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   better_errors
   binding_of_caller
   bootsnap
@@ -720,7 +722,6 @@ DEPENDENCIES
   capybara
   chartkick
   factory_bot_rails
-  fog-aws
   gds-api-adapters (~> 93.0.0)
   gds-sso
   govspeak
@@ -741,6 +742,7 @@ DEPENDENCIES
   sentry-sidekiq
   simplecov
   siteimprove_api_client
+  sitemap_generator
   spring-commands-rspec
   timecop
   uglifier

--- a/app/controllers/concerns/file_storage.rb
+++ b/app/controllers/concerns/file_storage.rb
@@ -1,26 +1,20 @@
 module FileStorage
   def upload_csv_to_s3(basename, body)
-    connection = Fog::Storage.new(
-      provider: "AWS",
-      region: ENV["AWS_REGION"],
-      aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-      aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-    )
-
-    directory = connection.directories.get(ENV["AWS_CSV_EXPORT_BUCKET_NAME"])
+    s3 = Aws::S3::Client.new
 
     timestamp = Time.zone.now.utc.strftime("%Y-%m-%d-%H-%M-%S")
     filename = "#{basename}.csv"
     key = "#{timestamp}/#{filename}"
 
-    file = directory.files.create(
-      key:,
+    s3.put_object({
+      acl: "public-read",
       body:,
-      public: true,
+      bucket: ENV["AWS_CSV_EXPORT_BUCKET_NAME"],
       content_disposition: "attachment; filename=\"#{filename}\"",
       content_type: "text/csv",
-    )
+      key:,
+    })
 
-    file.public_url
+    "https://#{ENV['AWS_CSV_EXPORT_BUCKET_NAME']}.s3.amazonaws.com/#{key}"
   end
 end

--- a/app/workers/csv_export_worker.rb
+++ b/app/workers/csv_export_worker.rb
@@ -1,5 +1,3 @@
-require "fog/aws"
-
 class CsvExportWorker
   include FileStorage
   include Sidekiq::Worker

--- a/lib/partial_sitemap_generator.rb
+++ b/lib/partial_sitemap_generator.rb
@@ -1,0 +1,30 @@
+require "sitemap_generator"
+
+class PartialSitemapGenerator
+  def generate_for_organisations(organisations: [])
+    raise(StandardError, "No organisations specified") if organisations.empty?
+
+    pages = GdsApi.search.search_enum({
+      fields: "link",
+      filter_organisations: organisations,
+    })
+
+    raise(StandardError, "Sitemap empty (are the organisation slugs correct?)") if pages.none?
+
+    SitemapGenerator.verbose = false
+
+    SitemapGenerator::Sitemap.adapter = SitemapGenerator::AwsSdkAdapter.new(ENV["AWS_SITEIMPROVE_SITEMAPS_BUCKET_NAME"])
+
+    SitemapGenerator::Sitemap.default_host = "https://www.gov.uk"
+    SitemapGenerator::Sitemap.filename = "sitemap-#{organisations.join('-and-')}"
+    SitemapGenerator::Sitemap.public_path = ENV.fetch("TMPDIR", "/tmp")
+
+    # rubocop:disable Rails/SaveBang!
+    SitemapGenerator::Sitemap.create do
+      pages.each { |page| add page["link"], changefreq: "weekly" }
+    end
+    # rubocop:enable Rails/SaveBang!
+
+    "https://#{ENV['AWS_SITEIMPROVE_SITEMAPS_BUCKET_NAME']}.s3.amazonaws.com/#{SitemapGenerator::Sitemap.filename}.xml.gz"
+  end
+end

--- a/lib/tasks/sitemaps.rake
+++ b/lib/tasks/sitemaps.rake
@@ -1,0 +1,7 @@
+desc "Create partial sitemap suitable for Siteimprove ingestion"
+task create_partial_sitemap: :environment do |_t, args|
+  puts("Created sitemap at #{PartialSitemapGenerator.new.generate_for_organisations(organisations: args.extras.to_a)}")
+rescue StandardError => e
+  puts(e.message)
+  abort("Failed to create sitemap")
+end

--- a/spec/lib/partial_sitemap_generator_spec.rb
+++ b/spec/lib/partial_sitemap_generator_spec.rb
@@ -1,0 +1,47 @@
+require "gds_api/test_helpers/search"
+
+RSpec.describe "PartialSitemapGenerator" do
+  include GdsApi::TestHelpers::Search
+
+  subject { PartialSitemapGenerator.new }
+
+  describe "#generate_for_organisations" do
+    before do
+      ENV["AWS_SITEIMPROVE_SITEMAPS_BUCKET_NAME"] = "test-bucket"
+    end
+
+    context "with an empty organisation list" do
+      it "raises an error" do
+        expect { subject.generate_for_organisations }.to raise_error(StandardError, "No organisations specified")
+      end
+    end
+
+    context "with no pages for the sitemap" do
+      before do
+        stub_any_search_to_return_no_results
+      end
+
+      it "raises an error" do
+        expect { subject.generate_for_organisations(organisations: %w[bogus-organisation]) }.to raise_error(StandardError, "Sitemap empty (are the organisation slugs correct?)")
+      end
+    end
+
+    context "with organisations that have pages" do
+      before do
+        stub_any_search.to_return(body: { results: [{ "link" => "https://www.example.com/" }] }.to_json)
+      end
+
+      context "with a single org" do
+        it "returns the sitemap public URL" do
+          expect(subject.generate_for_organisations(organisations: %w[bogus-organisation])).to eq("https://test-bucket.s3.amazonaws.com/sitemap-bogus-organisation.xml.gz")
+        end
+      end
+
+      context "with multiple orgs" do
+        it "returns the sitemap public URL" do
+          expect(subject.generate_for_organisations(organisations: %w[bogus-organisation my-org])).to eq("https://test-bucket.s3.amazonaws.com/sitemap-bogus-organisation-and-my-org.xml.gz")
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,4 +20,8 @@ RSpec.configure do |config|
   config.expose_dsl_globally = false
   config.infer_spec_type_from_file_location!
   config.include FactoryBot::Syntax::Methods
+
+  # rubocop:disable Rails/SaveBang
+  Aws.config.update(stub_responses: true)
+  # rubocop:enable Rails/SaveBang
 end

--- a/spec/workers/concerns/file_storage_spec.rb
+++ b/spec/workers/concerns/file_storage_spec.rb
@@ -3,39 +3,17 @@ RSpec.describe "FileStorage" do
   describe "#upload_csv_to_s3" do
     before do
       Timecop.freeze(Time.new(2019, 5, 4, 3, 2, 1, "+00:00"))
-      Fog.mock!
-
-      ENV["AWS_REGION"] = "eu-west-1"
-      ENV["AWS_ACCESS_KEY_ID"] = "test"
-      ENV["AWS_SECRET_ACCESS_KEY"] = "test"
       ENV["AWS_CSV_EXPORT_BUCKET_NAME"] = "test-bucket"
-
-      # Create an S3 bucket so the code being tested can find it
-      connection = Fog::Storage.new(
-        provider: "AWS",
-        region: ENV["AWS_REGION"],
-        aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
-        aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
-      )
-      @directory = connection.directories.create(key: ENV["AWS_CSV_EXPORT_BUCKET_NAME"])
     end
 
     after do
-      Fog::Mock.reset
       Timecop.return
-    end
-
-    it "uploads a file to s3" do
-      upload_csv_to_s3("basename", "body")
-
-      expect(@directory.files.first.key).to eq("2019-05-04-03-02-01/basename.csv")
-      expect(@directory.files.first.body).to eq("body")
     end
 
     it "returns the public url" do
       url = upload_csv_to_s3("basename", "")
 
-      expect(url).to eq("https://test-bucket.s3.eu-west-1.amazonaws.com/2019-05-04-03-02-01/basename.csv")
+      expect(url).to eq("https://test-bucket.s3.amazonaws.com/2019-05-04-03-02-01/basename.csv")
     end
   end
 end


### PR DESCRIPTION
Converts Content Data Admin to use S3 rather than Fog, and adds a rake task to generate partial sitemaps to be ingested by Siteimprove.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
