### PR TITLE
Update asset-path helper

### DIFF
--- a/app/assets/stylesheets/components/_accessible-autocomplete.scss
+++ b/app/assets/stylesheets/components/_accessible-autocomplete.scss
@@ -1,4 +1,4 @@
-@import url(asset-path("accessible-autocomplete/dist/accessible-autocomplete.min.css")); /* stylelint-disable-line */
+@import "accessible-autocomplete/src/autocomplete";
 
 .app-c-accessible-autocomplete {
   .autocomplete__input {


### PR DESCRIPTION
These are not supported in Dart Sass.

This has been tested in Integration - see below.

### Before

![Screenshot 2024-03-01 at 10 31 04](https://github.com/alphagov/content-data-admin/assets/19667619/ee756770-424a-468c-a83d-9531c50ed3a7)

### After
![Screenshot 2024-03-01 at 10 33 10](https://github.com/alphagov/content-data-admin/assets/19667619/106bf961-cf96-445d-8dcc-84e9e5522957)

Related PR - https://github.com/alphagov/content-data-admin/pull/1373

Trello card: https://trello.com/c/kZ3qj2TI/3405-3-migrate-content-data-admin-to-dart-sass

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

