### PR TITLE
Update contact details for user downloads

### DIFF
--- a/app/views/content/export_csv.html.erb
+++ b/app/views/content/export_csv.html.erb
@@ -10,7 +10,6 @@
   <div class="govuk-grid-column-two-thirds">
     <h1 class="govuk-heading-l">Sending the CSV export</h1>
     <p>The data you exported is on its way. We'll send an email to <%= @recipient %> with a link to download the CSV.</p>
-    <p>Most emails arrive within 15 minutes. If you do not receive an email within 30 minutes, contact 
-    <a href="mailto:2nd-line-support@digital.cabinet-office.gov.uk">2nd-line-support@digital.cabinet-office.gov.uk</a>.</p>
+    <p>Most emails arrive within 15 minutes. If you do not receive an email within 30 minutes, raise a <a href="https://support.publishing.service.gov.uk/">support request</a>.</p>
   </div>
 </div>

--- a/app/views/content_csv_mailer/content_csv_email.text.erb
+++ b/app/views/content_csv_mailer/content_csv_email.text.erb
@@ -4,6 +4,6 @@ The data you exported from Content Data will be available from this link for 7 d
 
 <%= I18n.t(:heading, scope: [:data_sources, :ga4_migration_warning])%> <%= I18n.t(:body, scope: [:data_sources, :ga4_migration_warning])%>
 
-If you have feedback on the Content Data tool or problems downloading the CSV, email 2nd-line-support@digital.cabinet-office.gov.uk.
+If you have feedback on the Content Data tool or problems downloading the CSV, raise a <%= link_to "support request (opens in new tab)", "https://support.publishing.service.gov.uk/", target: "_blank" %>.
 
 Do not reply to this message.


### PR DESCRIPTION
Pointing users to the Support app form means requests can be triaged appropriately through Zendesk, and is also consistent with how we manage user requests for other apps.

Trello card: https://trello.com/c/DboQcYLw/3431-2-point-contact-data-users-needing-help-to-a-form-in-the-support-app

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
