### PR TITLE
Fix links in csv export email

### DIFF
--- a/app/views/content_csv_mailer/content_csv_email.text.erb
+++ b/app/views/content_csv_mailer/content_csv_email.text.erb
@@ -2,8 +2,9 @@ The data you exported from Content Data will be available from this link for 7 d
 
 <%= @file_url %>
 
-<%= I18n.t(:heading, scope: [:data_sources, :ga4_migration_warning])%> <%= I18n.t(:body, scope: [:data_sources, :ga4_migration_warning])%>
+We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024.
+For more information please contact govuk-ga4-support@digital.cabinet-office.gov.uk. Data is only collected for users that consent to analytics cookies.
 
-If you have feedback on the Content Data tool or problems downloading the CSV, raise a <%= link_to "support request (opens in new tab)", "https://support.publishing.service.gov.uk/", target: "_blank" %>.
+If you have feedback on the Content Data tool or problems downloading the CSV, raise a [support request (opens in a new tab)](https://support.publishing.service.gov.uk/).
 
 Do not reply to this message.


### PR DESCRIPTION
The links are not being rendered correctly and appear in the email as raw HTML.

## Before

![Screenshot 2024-03-04 at 11 39 39](https://github.com/alphagov/content-data-admin/assets/19667619/ac10fcc9-463b-4f09-b850-d018887ee5af)

## After

![Screenshot 2024-03-04 at 11 40 00](https://github.com/alphagov/content-data-admin/assets/19667619/18bd14e8-e18a-4c01-93f9-3f631d5eb664)

Trello card: https://trello.com/c/DboQcYLw/3431-2-point-content-data-users-needing-help-to-a-form-in-the-support-app

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

