### PR TITLE
Update broken links table so left column is fixed

### DIFF
--- a/app/views/metrics/_siteimprove_issues.html.erb
+++ b/app/views/metrics/_siteimprove_issues.html.erb
@@ -32,7 +32,7 @@
 
     <p><%= t("metrics.siteimprove.quality_assurance.broken_links.description", quality_assurance_url: @quality_assurance_issues.link).html_safe %></p>
 
-    <table class="govuk-table content-metrics__url-table">
+    <table class="govuk-table govuk-table__fixed-left-column">
       <caption class="govuk-visually-hidden"><%= t("metrics.siteimprove.quality_assurance.broken_links.caption") %></caption>
       <thead class="govuk-table__head">
         <tr class="govuk-table__row">


### PR DESCRIPTION
 (matching other siteimprove tables)

## Before

<img width="1014" alt="Screenshot 2024-03-11 at 14 16 28" src="https://github.com/alphagov/content-data-admin/assets/4225737/382ae518-952b-4c14-9c73-408c3fa83b4e">

## After

<img width="1011" alt="Screenshot 2024-03-11 at 14 16 35" src="https://github.com/alphagov/content-data-admin/assets/4225737/00c6aa7a-8aba-4384-a82a-1242f0994a6b">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
