### PR TITLE
Update the GA4 banner with details about inconsistencies

### DIFF
--- a/app/views/content_csv_mailer/content_csv_email.text.erb
+++ b/app/views/content_csv_mailer/content_csv_email.text.erb
@@ -2,7 +2,7 @@ The data you exported from Content Data will be available from this link for 7 d
 
 <%= @file_url %>
 
-We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024.
+We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024, including some unusually high spikes in page views. We're looking into the cause of these.
 For more information please contact govuk-ga4-support@digital.cabinet-office.gov.uk. Data is only collected for users that consent to analytics cookies.
 
 If you have feedback on the Content Data tool or problems downloading the CSV, raise a [support request (opens in a new tab)](https://support.publishing.service.gov.uk/).

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -3,7 +3,7 @@ en:
   data_sources:
     google_analytics: 'Google Analytics'
     ga4_migration_warning:
-      heading: We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024.
+      heading: We're currently upgrading our Google Analytics source to Google's new product, GA4. Users may see the numbers vary as of January 2024, including some unusually high spikes in page views. We're looking into the cause of these.
       body: For more information please contact <a href="mailto:govuk-ga4-support@digital.cabinet-office.gov.uk">govuk-ga4-support@digital.cabinet-office.gov.uk</a>. Data is only collected for users that consent to analytics cookies.
     calculated_google_analytics: 'calculated from Google Analytics'
     feedback_explorer: 'Feedback Explorer'


### PR DESCRIPTION
Some issues with the data were reported. We don't think we should email users via Notify, because we can't tell how many of the potential 4,599 users are actually actively using the app (access to the app is given by default). This message will only be seen by users who are actually using the tool.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
