### PR TITLE
Finder note email stats

### DIFF
--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,5 +1,5 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
-<% if @performance_data.document_type == "finder" %>
+<% if @performance_data.document_type.to_s.downcase == "finder" %>
   <p><%= t("metrics.email_subscriptions.finder") %></p>
 <% elsif @email_subscriptions.present? %>
   <p><strong><%= t("metrics.email_subscriptions.active_title") %>:</strong> <%= @email_subscriptions.subscriber_list_count %></p>

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,5 +1,7 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
-<% if @email_subscriptions.present? %>
+<% if @performance_data.document_type == "finder" %>
+  <p><%= t("metrics.email_subscriptions.finder") %></p>
+<% elsif @email_subscriptions.present? %>
   <p><strong><%= t("metrics.email_subscriptions.active_title") %>:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
   <p><strong><%= t("metrics.email_subscriptions.total_notify_title") %>:</strong> <%=@email_subscriptions.all_notify_count %></p>
 <% else %>

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -17,6 +17,7 @@ en:
       total_notify_title: 'Number of subscribers notified by change'
       total_notify_description: 'Number of subscribers notified by change is the number of people who will receive emails if this page receives a major update. Note that this may be zero even if the page has active subscribers (if the page does not generate email alerts), or may be positive even if the page has no active subscribers (as there are lists that subscribe to all emails, or all emails on a certain topic)'
       no_information: 'No subscription information found'
+      finder: 'This page is a finder, which will not trigger alerts itself. There may be multiple subscriber lists to documents mentioned in the finder.'
     upviews:
       title: 'Unique page views'
       short_title: 'Unique page views'


### PR DESCRIPTION
It doesn't make sense to show the email statistics for finders because the way they handle email subscriptions is considerably more complex than normal pages, and there are very few of them. So to avoid misleading users, simply let them know the basics for finders (this is a finder, it won't trigger email alerts itself, there may be multiple subscriber lists to it).

https://trello.com/c/ZM53KHEM/2406-consider-how-email-alert-api-reports-mailing-list-sizes-for-finders

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
