### PR TITLE
Setup Google Tag Manager

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,8 +15,23 @@
       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
       gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
     } %>
-    <% end %>
   <% end %>
+
+  <% if ENV["GOOGLE_TAG_MANAGER_GA4_ID"] %>
+    <script>
+      dataLayer = [
+        { 'gtm.blacklist' : ['customPixels', 'customScripts', 'html', 'nonGoogleScripts'] },
+        { 'user-organisation': '<%= current_user.organisation_slug %>' },
+        { 'cd-uid': '<%= current_user.uid %>' }
+      ];
+    </script>
+    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+      gtm_id: ENV["GOOGLE_TAG_MANAGER_GA4_ID"],
+      gtm_auth: ENV["GOOGLE_TAG_MANAGER_GA4_AUTH"],
+      gtm_preview: ENV["GOOGLE_TAG_MANAGER_GA4_PREVIEW"]
+    } %>
+  <% end %>
+<% end %>
 
 <%= render 'govuk_publishing_components/components/layout_for_admin',
   environment: Rails.application.config.govuk_environment,


### PR DESCRIPTION
This allows us to implement basic GA4 tracking on all pages of the app. It is configured using the following environment variables:

GOOGLE_TAG_MANAGER_GA4_ID
GOOGLE_TAG_MANAGER_GA4_AUTH (integration only)
GOOGLE_TAG_MANAGER_GA4_PREVIEW (integration only)

If only the `GOOGLE_TAG_MANAGER_GA4_ID` is set then the default environment of the GTM container will be used.

If `GOOGLE_TAG_MANAGER_GA4_AUTH` and `GOOGLE_TAG_MANAGER_GA4_PREVIEW` are set then the specified GTM container environment will be used - specifically for testing the configuration in Integration before rolling out to Production.

This app already has UA enabled and we will need to do dual tracking until we're sure the GA4 implementation is working as expected and have the relevant reporting in place.

This has been successfully tested in Integration using [the test environment](https://tagmanager.google.com/?pli=1#/container/accounts/6005964263/containers/136976719/workspaces/7) in Google Tag Manager.

Related PR - https://github.com/alphagov/govuk-helm-charts/pull/1947

Trello card: https://trello.com/c/NxwdsJb2/3475-implement-tracking-in-ga4-for-content-data-admin-3


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
