### PR TITLE
Upgrade to govuk-dependabot-merger v2

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -1,30 +1,4 @@
-api_version: 1
-auto_merge:
-  - dependency: gds-api-adapters
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: gds-sso
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govspeak
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_app_config
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_publishing_components
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: govuk_test
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+api_version: 2
+defaults:
+  auto_merge: true
+  update_external_dependencies: true


### PR DESCRIPTION
This PR:

- Upgrades to govuk-dependabot-merger V2
- Enables auto-merge of external dependencies

I've tried running the new govuk-dependabot-merger locally and can confirm it would attempt to auto-merge the two external dependency PRs (#1416, #1418) 🎉 

```
2 Dependabot PRs found for repo 'content-data-admin':
  - Inspecting content-data-admin#1416...
    ...eligible for auto-merge! This is a dry run, so skipping.
  - Inspecting content-data-admin#1418...
    ...eligible for auto-merge! This is a dry run, so skipping.
```

---

Trello: https://trello.com/c/iC9shJG4/3479-roll-out-govuk-dependabot-merger-v2-across-select-repositories

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
