### PR TITLE
Add distinct label to CSV export metrics

### DIFF
--- a/spec/features/index_page/export_csv_spec.rb
+++ b/spec/features/index_page/export_csv_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "Exporting CSV" do
 
     allow(Prometheus::Client::Push).to receive(:new).and_return(pushgateway)
     allow(prometheus_registry).to receive(:histogram)
-      .with(:content_data_admin_histogram, any_args)
+      .with(:content_data_admin_histogram_v1, any_args)
       .and_return(csv_export_histogram)
 
     visit "/content"

--- a/spec/workers/csv_export_worker_spec.rb
+++ b/spec/workers/csv_export_worker_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe CsvExportWorker do
 
     allow(Prometheus::Client::Push).to receive(:new).and_return(pushgateway)
     allow(prometheus_registry).to receive(:histogram)
-      .with(:content_data_admin_histogram, any_args)
+      .with(:content_data_admin_histogram_v1, any_args)
       .and_return(csv_export_histogram)
   end
 


### PR DESCRIPTION
Prometheus scrapes data from Pushgateway every 60 seconds which means it continues to record the same metric until another one is sent. Adding a distinct label will allow us to filter out duplicate values in Grafana.

As you can only register a histogram once, we have to create a new one which allows us to add a label as part of it's setup.

Related PR: https://github.com/alphagov/content-data-admin/pull/1426
Trello card: https://trello.com/c/SQro2G8f/3476-monitor-how-long-content-datas-csv-exports-take-5

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

