### PR TITLE
Remove Permission for Email stats

### DIFF
--- a/app/controllers/metrics_controller.rb
+++ b/app/controllers/metrics_controller.rb
@@ -29,9 +29,6 @@ private
   end
 
   def setup_email_subscriptions
-    return unless current_user.view_email_subs?
-
-    @show_email_subs_section = true
     @email_subscriptions = EmailApi::PageSubscriptionsClient.new.fetch(path: "/#{base_path}")
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,4 @@ class User < ApplicationRecord
   def view_siteimprove?
     permissions.include?("view_siteimprove")
   end
-
-  def view_email_subs?
-    permissions.include?("view_email_subs")
-  end
 end

--- a/app/views/metrics/_email_subscriptions.html.erb
+++ b/app/views/metrics/_email_subscriptions.html.erb
@@ -1,7 +1,5 @@
 <h2 class="section-content__header content-metrics__header"><%= t("metrics.email_subscriptions.title") %></h2>
-<% if @performance_data.document_type.to_s.downcase == "finder" %>
-  <p><%= t("metrics.email_subscriptions.finder") %></p>
-<% elsif @email_subscriptions.present? %>
+<% if @email_subscriptions.present? %>
   <p><strong><%= t("metrics.email_subscriptions.active_title") %>:</strong> <%= @email_subscriptions.subscriber_list_count %></p>
   <p><strong><%= t("metrics.email_subscriptions.total_notify_title") %>:</strong> <%=@email_subscriptions.all_notify_count %></p>
 <% else %>
@@ -13,9 +11,9 @@
 } do %>
 
   <h3 class="govuk-heading-m"><%= t("metrics.email_subscriptions.active_title") %></h3>
-  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.active_description") %></p>
+  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.active_description").html_safe %></p>
 
   <h3 class="govuk-heading-m"><%= t("metrics.email_subscriptions.total_notify_title") %></h3>
-  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.total_notify_description") %></p>
+  <p class="govuk-body govuk-body-s"><%= t("metrics.email_subscriptions.total_notify_description").html_safe %></p>
 
 <% end %>

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -151,10 +151,9 @@
   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
   <%= render "siteimprove_issues" %>
 <% end %>
-<% if @show_email_subs_section %>
-   <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
-   <%= render "email_subscriptions" %>
-<% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+<%= render "email_subscriptions" %>
 
 
 

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -12,10 +12,10 @@ en:
     email_subscriptions:
       title: 'Email subscriptions'
       about_title: 'About Email subscriptions'
-      active_title: 'Active subscribers'
-      active_description: 'Active subscribers is the number of people who have clicked the Get Emails button on this page and signed up to be subscribed to valid email alerts either to this page or to pages related to this one. Note that some pages can be subscribed to, but do not generate email alerts themselves (in these cases the subscriber list will be notified if pages related to this one are updated)'
-      total_notify_title: 'Number of subscribers notified by change'
-      total_notify_description: 'Number of subscribers notified by change is the number of people who will receive emails if this page receives a major update. Note that this may be zero even if the page has active subscribers (if the page does not generate email alerts), or may be positive even if the page has no active subscribers (as there are lists that subscribe to all emails, or all emails on a certain topic)'
+      active_title: 'Users signed up to get email updates about this page'
+      active_description: 'This is the number of users who have signed up to get email updates about changes to this page. Users get an email when there is a ‘major change’ to the page or, if it’s a document collection, pages that are part of the document collection.<br /><br />A major change is when the publisher has decided users need to know the content has changed. A change note will be published on the page and users will get an email.<br /><br />Topic taxonomy pages, organisation pages or finders (like guidance and regulation) don’t have major changes. On these pages the number refers to people who have signed up to receive emails about that topic, organisation or finder. '
+      total_notify_title: 'Users who will get email updates about changes to this page'
+      total_notify_description: 'The number of users that get emails about changes to this page might be different from the number signed up to get email updates on the page.<br /><br />This happens when the page is part of a document collection, topic taxonomy page, organisation or finder. Users who have signed up to get email updates on those pages will also get an email notification when there is a major change to this page.'
       no_information: 'No subscription information found'
       finder: 'This page is a finder, which will not trigger alerts itself. There may be multiple subscriber lists to documents mentioned in the finder.'
     upviews:

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,8 +14,4 @@ FactoryBot.define do
   factory :view_siteimprove_user, parent: :user do
     permissions { %i[view_siteimprove] }
   end
-
-  factory :view_email_subs_user, parent: :user do
-    permissions { %i[view_email_subs] }
-  end
 end

--- a/spec/features/single_content_item_email_subs_spec.rb
+++ b/spec/features/single_content_item_email_subs_spec.rb
@@ -4,61 +4,42 @@ RSpec.describe "/metrics/base/path email subscription details", type: :feature d
   include RequestStubs
   include GdsApi::TestHelpers::EmailAlertApi
 
-  context "logged in as another department" do
-    before do
-      GDS::SSO.test_user = build(:user)
-      stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+  before do
+    GDS::SSO.test_user = build(:user)
+    stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+  end
+
+  context "when there are subscriptions" do
+    it "shows the Email subscriptions section" do
+      visit "/metrics/base/path"
+      expect(page).to have_content("Email subscriptions")
+      expect(page).to have_content("Users signed up to get email updates about this page: 3")
+      expect(page).to have_content("Users who will get email updates about changes to this page: 10")
+      expect(page).not_to have_content("No subscription information found")
     end
 
-    it "does not show the Email Subscriptions title" do
+    it "shows information on the email metrics" do
       visit "/metrics/base/path"
-      expect(page).not_to have_content("Email subscriptions")
+      [
+        "This is the number of users who have signed up",
+        "The number of users that get emails about changes to this page",
+      ].each do |txt|
+        expect(page).to have_content(txt)
+      end
     end
   end
 
-  context "logged in as GDS" do
+  context "when there is a 404 from email-alert-api" do
     before do
-      GDS::SSO.test_user = build(:view_email_subs_user)
-      stub_metrics_page(base_path: "base/path", time_period: :past_30_days)
+      stub_get_subscriber_list_metrics_not_found(path: "/base/path")
     end
 
-    context "when there are subscriptions" do
-      before do
-        json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
-        stub_get_subscriber_list_metrics(path: "/base/path", response: json)
-      end
-
-      it "shows the Email subscriptions section" do
-        visit "/metrics/base/path"
-        expect(page).to have_content("Email subscriptions")
-        expect(page).to have_content("Active subscribers: 3")
-        expect(page).to have_content("Number of subscribers notified by change: 10")
-        expect(page).not_to have_content("No subscription information found")
-      end
-
-      it "shows information on the email metrics" do
-        visit "/metrics/base/path"
-        [
-          "Active subscribers is the number of people",
-          "Number of subscribers notified by change is the number of people",
-        ].each do |txt|
-          expect(page).to have_content(txt)
-        end
-      end
-    end
-
-    context "when there is a 404 from email-alert-api" do
-      before do
-        stub_get_subscriber_list_metrics_not_found(path: "/base/path")
-      end
-
-      it "shows the no subscription info section" do
-        visit "/metrics/base/path"
-        expect(page).to have_content("Email subscriptions")
-        expect(page).to have_content("No subscription information found")
-        expect(page).not_to have_content("Active subscribers:")
-        expect(page).not_to have_content("Number of subscribers notified by change:")
-      end
+    it "shows the no subscription info section" do
+      visit "/metrics/base/path"
+      expect(page).to have_content("Email subscriptions")
+      expect(page).to have_content("No subscription information found")
+      expect(page).not_to have_content("Users signed up to get email updates about this page:")
+      expect(page).not_to have_content("Users who will get email updates about changes to this page:")
     end
   end
 end

--- a/spec/support/request_stubs.rb
+++ b/spec/support/request_stubs.rb
@@ -1,8 +1,10 @@
+require "gds_api/test_helpers/email_alert_api"
 require "support/content_data_api"
 require "support/response_helpers"
 
 module RequestStubs
   include GdsApi::TestHelpers::ContentDataApi
+  include GdsApi::TestHelpers::EmailAlertApi
   include GdsApi::TestHelpers::ResponseHelpers
 
   def stub_metrics_page(base_path:, time_period:, publishing_app: "whitehall", content_item_missing: false, current_data_missing: false, comparison_data_missing: false, edition_metrics_missing: false, related_content: 0, parent_document_id: nil)
@@ -54,6 +56,9 @@ module RequestStubs
         payload: previous_period_data,
       )
     end
+
+    json = { subscriber_list_count: 3, all_notify_count: 10 }.to_json
+    stub_get_subscriber_list_metrics(path: "/#{base_path}", response: json)
   end
 
   def stub_document_children_page(document_id:, time_period: "past-30-days", sort: "sibling_order:asc", response: nil)


### PR DESCRIPTION
Since it was added, the email stats section of content data admin pages has always been gated behind a specific permission. This was added during development to test the feature without exposing it to departments. This PR removes the need for that permission, and updates the copy displayed in the feature.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

