### PR TITLE
Removing link to ua

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -54,16 +54,6 @@ module ExternalLinksHelper
     end
   end
 
-  def google_analytics_url(from:, to:, base_path:)
-    from = from.to_fs(:number)
-    to = to.to_fs(:number)
-    base_path = base_path.downcase.gsub(%r{(/)(?!\z)}, "~2F")
-    "https://analytics.google.com/analytics/web/?hl=en&pli=1"\
-    "#/report/content-site-search-pages/a26179049w50705554p53872948/"\
-    "_u.date00=#{from}&_u.date01=#{to}&"\
-    "_r.drilldown=analytics.searchStartPage:#{base_path}"
-  end
-
   def external_url_for(service)
     Plek.external_url_for(service)
   end

--- a/app/presenters/single_content_item_presenter.rb
+++ b/app/presenters/single_content_item_presenter.rb
@@ -97,10 +97,6 @@ class SingleContentItemPresenter
     feedex_url(from: date_range.from, to: date_range.to, base_path:)
   end
 
-  def search_terms_href
-    google_analytics_url(from: date_range.from, to: date_range.to, base_path:)
-  end
-
   def period
     I18n.t("metrics.show.time_periods.#{@date_range.time_period}.reference")
   end

--- a/app/views/metrics/show.html.erb
+++ b/app/views/metrics/show.html.erb
@@ -117,7 +117,7 @@
         metric_name: 'searches',
         total: @performance_data.total_searches,
         short_context: nil,
-        external_link: @performance_data.search_terms_href,
+        external_link: nil,
         custom_month_selected: custom_month_selected(current_selection) %>
 
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">

--- a/config/locales/defaults/en.yml
+++ b/config/locales/defaults/en.yml
@@ -65,7 +65,7 @@ en:
       context: '%{percent_users_searched}% of users searched from the page'
       unit: 'search terms'
       data_source: google_analytics
-      external_link: 'See search terms in Google Analytics (opens in new tab)'
+      external_link: ''
       about_title: 'About searches from page'
       about: >
         This is the number of internal site searches that were started from the page. When people

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -223,9 +223,9 @@ RSpec.describe "/metrics/base/path", type: :feature do
         ])
       end
 
-      it "renders link to search terms" do
-        expect(page).to have_selector(".govuk-link", text: I18n.t("metrics.searches.external_link"))
-      end
+      # it "renders link to search terms" do
+      #   expect(page).to have_selector(".govuk-link", text: I18n.t("metrics.searches.external_link"))
+      # end
 
       it "renders the satisfaction score" do
         within ".section-performance" do

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -223,10 +223,6 @@ RSpec.describe "/metrics/base/path", type: :feature do
         ])
       end
 
-      # it "renders link to search terms" do
-      #   expect(page).to have_selector(".govuk-link", text: I18n.t("metrics.searches.external_link"))
-      # end
-
       it "renders the satisfaction score" do
         within ".section-performance" do
           expect(page).to have_selector(".metric-summary__satisfaction", text: "90% (700 responses) +50.00%")

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -203,16 +203,4 @@ RSpec.describe ExternalLinksHelper do
              )).to eq(expected_link)
     end
   end
-
-  describe "#google_analytics_url" do
-    it "generates URL to Google Analytics with given parameters" do
-      expected_link = "https://analytics.google.com/analytics/web/?hl=en&pli=1#/report/content-site-search-pages/a26179049w50705554p53872948/_u.date00=20181125&_u.date01=20181224&_r.drilldown=analytics.searchStartPage:~2Fthe~2Fbase~2Fpath"
-
-      expect(google_analytics_url(
-               from: Date.new(2018, 11, 25),
-               to: Date.new(2018, 12, 24),
-               base_path: "/the/base/path",
-             )).to eq(expected_link)
-    end
-  end
 end


### PR DESCRIPTION
Removed a link to UA because we are migrating to GA4. This link is now redundant.

Before: 
<img width="813" alt="BeforeLinkRemoval" src="https://github.com/alphagov/content-data-admin/assets/99875822/cafa86dc-874f-4b8f-87a9-1fbc80a1d56c">
After:
<img width="1003" alt="AfterLinkRemoval" src="https://github.com/alphagov/content-data-admin/assets/99875822/eb0f0169-674d-4518-a903-602859a09aef">




https://trello.com/c/QacJuXBT/3490-remove-a-link-to-universal-analytics-in-content-data-1
