### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem "aws-sdk-s3"
 gem "bootsnap", require: false
 gem "chartkick"
 gem "dartsass-rails"
-gem "gds-api-adapters", "~> 96.0.0"
+gem "gds-api-adapters"
 gem "gds-sso"
 gem "govspeak"
 gem "govuk_app_config"


### PR DESCRIPTION
Unpin gem so that govuk-dependabot-merger can do its thing.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
