### PR TITLE
Use GOVUK_ENVIRONMENT instead of GOVUK_ENVIRONMENT_NAME

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,7 +39,7 @@ module ContentDataAdmin
     # Don't generate system test files.
     config.generators.system_tests = nil
 
-    config.govuk_environment = ENV["GOVUK_ENVIRONMENT_NAME"] || "development"
+    config.govuk_environment = ENV["GOVUK_ENVIRONMENT"] || "development"
 
     # Load all the locale files and raise execptions if locale missing.
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.yml")]


### PR DESCRIPTION
Both environment variables are set to the same value. GOVUK_ENVIRONMENT is used more frequently, renaming for consistency.