### PR TITLE
Don't return policy description if there's not note attr

### DIFF
--- a/app/presenters/siteimprove/policy_issues_presenter.rb
+++ b/app/presenters/siteimprove/policy_issues_presenter.rb
@@ -46,7 +46,7 @@ module Siteimprove
 
     def policy_description(issue)
       policy = Siteimprove::FetchPolicies.new.find(issue.id).first
-      return "No description for this policy" unless policy
+      return "No description for this policy" unless policy && policy.note
 
       note = policy.note
       note.gsub!(/https:\/\/(.+)/, "[https://\\1](https://\\1)")

--- a/spec/presenters/siteimprove/policy_issues_presenter_spec.rb
+++ b/spec/presenters/siteimprove/policy_issues_presenter_spec.rb
@@ -81,5 +81,15 @@ RSpec.describe Siteimprove::PolicyIssuesPresenter do
       presenter = described_class.new(policy_issues, summary_info)
       expect(presenter.policy_description(policy_issues.first)).to include("<p>")
     end
+
+    it "doesn't return the description if there's no note" do
+      policy = instance_double(SiteimproveAPIClient::ExecutedPolicy, name: "Copy of TestSI Start Now button (Before you start)", category: "content")
+      allow(policy).to receive(:note)
+      allow_any_instance_of(Siteimprove::FetchPolicies).to receive(:find).and_return([policy])
+
+      presenter = described_class.new(policy_issues, summary_info)
+
+      expect(presenter.policy_description(policy_issues.first)).to include("No description for this policy")
+    end
   end
 end


### PR DESCRIPTION
There's a few examples where the API response doesn't have `note` attribute causing: 
```
NoMethodError
undefined method `gsub!' for nil (NoMethodError)

      note.gsub!(/https:\/\/(.+)/, "[https://\\1](https://\\1)")
          ^^^^^^
```

https://govuk.sentry.io/issues/6330840181/events/6958f220ade349e3940088ce42af1e50/

Examples:
- check-the-patents-journal
- check-national-insurance-record
- get-access-evisa

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
