### PR TITLE
Remove logic for Contacts Admin

### DIFF
--- a/app/helpers/external_links_helper.rb
+++ b/app/helpers/external_links_helper.rb
@@ -16,8 +16,6 @@ module ExternalLinksHelper
       end
     when "maslow", "need-api"
       "#{external_url_for('maslow')}/needs/#{content_id}"
-    when "contacts"
-      "#{external_url_for('contacts-admin')}/admin/contacts/#{slug_from_basepath(base_path)}/edit"
     when "specialist-publisher"
       "#{external_url_for('specialist-publisher')}/#{specialist_publisher_path(document_type, content_id)}"
     when "collections-publisher"

--- a/spec/features/single_content_item_spec.rb
+++ b/spec/features/single_content_item_spec.rb
@@ -292,13 +292,6 @@ RSpec.describe "/metrics/base/path", type: :feature do
         expect(page).to have_selector ".related-actions", text: "Whitehall"
       end
 
-      it "renders the contacts application" do
-        stub_metrics_page(base_path: "contacts/path", time_period: :past_30_days, publishing_app: "contacts")
-        visit "/metrics/contacts/path"
-        label = I18n.t("metrics.show.navigation.edit_link", publishing_app: "Contacts")
-        expect(page).to have_link(label, href: "http://contacts-admin.dev.gov.uk/admin/contacts/path/edit")
-      end
-
       it "renders the specialist publisher application" do
         stub_metrics_page(base_path: "specialist/path", time_period: :past_30_days, publishing_app: "specialist-publisher")
         visit "/metrics/specialist/path"

--- a/spec/helpers/external_links_helper_spec.rb
+++ b/spec/helpers/external_links_helper_spec.rb
@@ -36,21 +36,6 @@ RSpec.describe ExternalLinksHelper do
       end
     end
 
-    context "with contacts" do
-      it "generates a link to the contacts publisher app" do
-        expect(
-          edit_url_for(
-            content_id: "content_id",
-            publishing_app: "contacts",
-            base_path: "government/organisations/hm-revenue-customs/contact/tax-credits-agent-priority-line",
-            document_type: "news_story",
-          ),
-        ).to eq(
-          "#{external_url_for('contacts-admin')}/admin/contacts/tax-credits-agent-priority-line/edit",
-        )
-      end
-    end
-
     context "with specialist-publisher" do
       it "generates a link to the specialist publisher app with document_type" do
         expect(


### PR DESCRIPTION
The app is being retired.

Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
