### PR TITLE
Introduce 10 day cooldown period for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,16 @@
+---
 version: 2
 updates:
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: daily
-
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily
+- package-ecosystem: bundler
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: daily
+  cooldown:
+    default-days: 10
+...


### PR DESCRIPTION
## What

Adds 10 day dependency cooldowns for Dependabot and Renovate as appropriate
