### PR TITLE
Bump yarn resolutions js-yaml version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "accessible-autocomplete": "^3.0.1"
   },
   "resolutions": {
-    "js-yaml*3.13.1": "^3.14.2",
-    "js-yaml*4.1.0": "^4.1.1"
+    "js-yaml@^3.13.1": "^3.14.2",
+    "js-yaml@^4.1.0": "^4.2.0"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1847,7 +1847,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1":
+"js-yaml@npm:^3.14.2":
   version: 3.14.2
   resolution: "js-yaml@npm:3.14.2"
   dependencies:
@@ -1859,14 +1859,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.1.0":
-  version: 4.1.1
-  resolution: "js-yaml@npm:4.1.1"
+"js-yaml@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "js-yaml@npm:4.2.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: ea2339c6930fe048ec31b007b3c90be2714ab3e7defcc2c27ebf30c74fd940358f29070b4345af0019ef151875bf3bc3f8644bea1bab0372652b5044813ac02d
+  checksum: 86bd35548a0c19cd1f5861147c09aa1f52eb0fc9464f34023524d22bbe079c62c30fd00750e63f632e8d12c12ad36ea0dd1e6bec5171c492ecad433d8db295eb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This partially fixes a security issue with js-yaml: https://github.com/alphagov/content-data-admin/security/dependabot/186

Unfortunately we can’t force all packages to use v4.0.2, because standardx (which is no longer maintained) uses eslint v7, which uses js-yaml v3. GDS is for now committed to using standardx for linting JS: https://docs.publishing.service.gov.uk/manual/configure-linting.html#linting-javascript-and-scss. However the risk seems fairly low because the package is being used as a linting tool locally and in CI.