### PR TITLE
Update js-yaml v4 to at least 4.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "resolutions": {
     "js-yaml@^3.13.1": "^3.14.2",
-    "js-yaml@^4.1.0": "^4.2.0"
+    "js-yaml@^4.1.0": "^4.3.0"
   },
   "packageManager": "yarn@3.5.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,14 +1871,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: ^2.0.1
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 86bd35548a0c19cd1f5861147c09aa1f52eb0fc9464f34023524d22bbe079c62c30fd00750e63f632e8d12c12ad36ea0dd1e6bec5171c492ecad433d8db295eb
+  checksum: 1268fb22ae8504646cedc0823c18816d4af056029578e855b9a4d3e19bcafc3e9ba9e391f70dea4a29b023bb09f23639766071199cb89e853266b90a6ec25f9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Unfortunately we can’t force all packages to use v4.3.0, because standardx (which is no longer maintained) uses eslint v7, which uses js-yaml v3. GDS is for now committed to using standardx in linting JS: docs.publishing.service.gov.uk/manual/configure-linting.html#linting-javascript-and-scss. However the risk seems fairly low because the package is being used as a linting tool locally and in CI.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
