### PR TITLE
Remove 'acl' argument from S3 put signature

### DIFF
--- a/app/controllers/concerns/file_storage.rb
+++ b/app/controllers/concerns/file_storage.rb
@@ -7,7 +7,6 @@ module FileStorage
     key = "#{timestamp}/#{filename}"
 
     s3.put_object({
-      acl: "public-read",
       body:,
       bucket: ENV["AWS_CSV_EXPORT_BUCKET_NAME"],
       content_disposition: "attachment; filename=\"#{filename}\"",


### PR DESCRIPTION
## Fix upload of CSVs to S3 

Jira [CR-89](https://gov-uk.atlassian.net/browse/CR-89) Investigates reports of emails not being received after requesting CSV downloads. The issue was that the upload of the requested CSV to S3 was failing due to bucket ACLs being disabled

---

Our infrastructure no longer supports bucket ACLs. We're now using a bucket policy which replicates the rules that the old ACL gave.

In the case of this bucket "public-read" bucket new bucket policy has `GetObject` and `ListBucket` allowed via this terraform:

```
data "aws_iam_policy_document" "content_data_csvs_s3_bucket_public_read" {
  statement {
    sid = "AllowPublicObjectRead"

    actions = ["s3:GetObject"]

    resources = ["${local.content_data_csvs_s3_bucket_arn}/*"]

    principals {
      type        = "*"
      identifiers = ["*"]
    }
  }

  statement {
    sid = "AllowPublicListBucket"

    actions = ["s3:ListBucket"]

    resources = [local.content_data_csvs_s3_bucket_arn]

    principals {
      type        = "*"
      identifiers = ["*"]
    }
  }
}
```

We need to remove the now disabled `acl` argument as it's causing this error:

```
Aws::S3::Errors::AccessControlListNotSupported
The bucket does not allow ACLs (Aws::S3::Errors::AccessControlListNotSupported)
```




[CR-89]: https://gov-uk.atlassian.net/browse/CR-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ